### PR TITLE
Run weekly updates on dependabot.

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,6 +1,7 @@
 version: 1
 update_configs:
   - package_manager: "javascript"
+    update_schedule: "weekly"
     directory: "/"
     update_schedule: "live"
     default_reviewers:


### PR DESCRIPTION
Dependabot is spamming PRs every time any of selected packages is updated.

I added weekly restriction to it so we wont be reviewing dependabot PRs all the time.