### PR TITLE
Orders async filtering

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -466,3 +466,7 @@ a.breadcrumb-active {
   grid-gap: 16px !important;
   gap: 16px;
 }
+
+.bottom-pagination-container {
+  width: 100%
+}

--- a/src/helpers/order/order-helper.js
+++ b/src/helpers/order/order-helper.js
@@ -46,8 +46,8 @@ const getOrderItems = orderIds =>
 const getOrderPortfolioItems = itemIds =>
   axiosInstance.get(`${CATALOG_API_BASE}/portfolio_items?${itemIds.map(itemId => `filter[id][]=${itemId}`).join('&')}`);
 
-export const getOrders = (filter, pagination = defaultSettings) =>
-  axiosInstance.get(`${CATALOG_API_BASE}/orders?filter[id][contains]=${filter}&limit=${pagination.limit}&offset=${pagination.offset}`) // eslint-disable-line max-len
+export const getOrders = (filterType, filter, pagination = defaultSettings) =>
+  axiosInstance.get(`${CATALOG_API_BASE}/orders?filter[${filterType}][contains_i]=${filter}&limit=${pagination.limit}&offset=${pagination.offset}`) // eslint-disable-line max-len
   .then(orders =>
     getOrderItems(orders.data.map(({ id }) => id))
     .then(orderItems =>

--- a/src/helpers/order/order-helper.js
+++ b/src/helpers/order/order-helper.js
@@ -46,8 +46,8 @@ const getOrderItems = orderIds =>
 const getOrderPortfolioItems = itemIds =>
   axiosInstance.get(`${CATALOG_API_BASE}/portfolio_items?${itemIds.map(itemId => `filter[id][]=${itemId}`).join('&')}`);
 
-export const getOrders = (pagination = defaultSettings) =>
-  axiosInstance.get(`${CATALOG_API_BASE}/orders?limit=${pagination.limit}&offset=${pagination.offset}`) // eslint-disable-line max-len
+export const getOrders = (filter, pagination = defaultSettings) =>
+  axiosInstance.get(`${CATALOG_API_BASE}/orders?filter[id][contains]=${filter}&limit=${pagination.limit}&offset=${pagination.offset}`) // eslint-disable-line max-len
   .then(orders =>
     getOrderItems(orders.data.map(({ id }) => id))
     .then(orderItems =>

--- a/src/smart-components/common/async-pagination.js
+++ b/src/smart-components/common/async-pagination.js
@@ -6,7 +6,7 @@ import { Pagination } from '@patternfly/react-core';
 
 import { getCurrentPage, getNewPage } from '../../helpers/shared/pagination';
 
-const AsyncPagination = ({ meta: { limit, count, offset }, apiProps, apiRequest, ...props }) => {
+const AsyncPagination = ({ meta: { limit, count, offset }, apiProps, apiRequest, className, ...props }) => {
   const handleOnPerPageSelect = (_event, limit) => apiRequest(apiProps, {
     offset,
     limit
@@ -27,7 +27,7 @@ const AsyncPagination = ({ meta: { limit, count, offset }, apiProps, apiRequest,
   };
 
   return (
-    <div className="pf-u-mt-md">
+    <div className={ className }>
       <Pagination
         perPage={ limit || 50 }
         itemCount={ count || 0 }
@@ -48,7 +48,8 @@ AsyncPagination.propTypes = {
     offset: PropTypes.number.isRequired
   }),
   apiRequest: PropTypes.func.isRequired,
-  apiProps: PropTypes.any
+  apiProps: PropTypes.any,
+  className: PropTypes.string
 };
 
 AsyncPagination.defaultProps = {
@@ -56,7 +57,8 @@ AsyncPagination.defaultProps = {
     count: 0,
     limit: 50,
     offset: 0
-  }
+  },
+  className: 'pf-u-mt-md'
 };
 
 export default AsyncPagination;

--- a/src/smart-components/order/orders-list.js
+++ b/src/smart-components/order/orders-list.js
@@ -1,27 +1,35 @@
 import React, { useEffect, useReducer } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { DataList, Level, LevelItem, Grid, GridItem } from '@patternfly/react-core';
-import { Section } from '@redhat-cloud-services/frontend-components';
+import { DataList, Grid, GridItem,
+  Title,
+  Bullseye,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
+  Flex
+} from '@patternfly/react-core';
+import { Section, PrimaryToolbar, EmptyTable, TableToolbar  } from '@redhat-cloud-services/frontend-components';
+import { SearchIcon } from '@patternfly/react-icons';
 
 import { fetchOrders } from '../../redux/actions/order-actions';
 import { fetchPlatforms } from '../../redux/actions/platform-actions';
 import { ListLoader } from '../../presentational-components/shared/loader-placeholders';
 import OrderItem from './order-item';
-import FilterToolbarItem from '../../presentational-components/shared/filter-toolbar-item';
 import AsyncPagination from '../common/async-pagination';
 import asyncFormValidator from '../../utilities/async-form-validator';
 import { defaultSettings } from '../../helpers/shared/pagination';
 
-const debouncedFilter = asyncFormValidator((value, dispatch, filteringCallback) => {
+const debouncedFilter = asyncFormValidator((filterType, value, meta = defaultSettings, dispatch, filteringCallback) => {
   filteringCallback(true);
-  dispatch(fetchOrders(value, defaultSettings)).then(() => filteringCallback(false));
+  dispatch(fetchOrders(filterType, value, meta)).then(() => filteringCallback(false));
 }, 1000);
 
 const initialState = {
   filterValue: '',
   isOpen: false,
   isFetching: true,
-  isFiltering: false
+  isFiltering: false,
+  filterType: 'state'
 };
 
 const ordersListState = (state, action) => {
@@ -32,64 +40,110 @@ const ordersListState = (state, action) => {
       return { ...state, filterValue: action.payload };
     case 'setFilteringFlag':
       return { ...state, isFiltering: action.payload };
+    case 'setFilterType':
+      return { ...state, filterType: action.payload };
   }
 
   return state;
 };
 
 const OrdersList = () => {
-  const [{ isFetching, filterValue, isFiltering }, stateDispatch ] = useReducer(ordersListState, initialState);
+  const [{ isFetching, filterValue, isFiltering, filterType }, stateDispatch ] = useReducer(ordersListState, initialState);
   const { data, meta } = useSelector(({ orderReducer }) => orderReducer.orders);
   const dispatch = useDispatch();
   useEffect(() => {
     stateDispatch({ type: 'setFetching', payload: true });
-    Promise.all([ dispatch(fetchOrders(filterValue, meta)), dispatch(fetchPlatforms()) ])
+    Promise.all([ dispatch(fetchOrders(filterType, filterValue, meta)), dispatch(fetchPlatforms()) ])
     .then(() => stateDispatch({ type: 'setFetching', payload: false }));
   }, []);
 
   const handlePagination = (_apiProps, pagination) => {
     stateDispatch({ type: 'setFetching', payload: true });
-    dispatch(fetchOrders(filterValue, pagination))
+    dispatch(fetchOrders(filterType, filterValue, pagination))
     .then(() => stateDispatch({ type: 'setFetching', payload: false }))
     .catch(() => stateDispatch({ type: 'setFetching', payload: false }));
   };
 
   const handleFilterItems = value => {
     stateDispatch({ type: 'setFilterValue', payload: value });
-    debouncedFilter(value, dispatch, isFiltering => stateDispatch({ type: 'setFilteringFlag', payload: isFiltering }));
+    debouncedFilter(filterType, value, meta, dispatch, isFiltering => stateDispatch({ type: 'setFilteringFlag', payload: isFiltering }));
   };
-
-  console.log('data: ', data)
 
   return (
     <Grid gutter="md">
       <GridItem>
         <Section type="content">
-          <div className="pf-u-pb-md pf-u-pl-xl pf-u-pr-xl orders-list">
-            <Level>
-              <LevelItem className="pf-u-mt-md">
-                <FilterToolbarItem
-                  searchValue={ filterValue }
-                  onFilterChange={ value => handleFilterItems(value) }
-                  placeholder="Filter by name..."
-                />
-              </LevelItem>
-              <LevelItem>
-                <AsyncPagination isDisabled={ isFetching || isFiltering } apiRequest={ handlePagination } meta={ meta } />
-              </LevelItem>
-            </Level>
-          </div>
+          <PrimaryToolbar
+            { ...filterValue && {
+              activeFiltersConfig: {
+                filters: [{
+                  name: filterValue
+                }],
+                onDelete: () => {
+                  stateDispatch({ type: 'setFilterValue', payload: '' });
+                  handleFilterItems('');
+                }
+              }
+            } }
+            filterConfig={ {
+              onChange: (_e, value) => {
+                stateDispatch({ type: 'setFilterType', payload: value });
+                if (filterValue.length > 0) {
+                  handlePagination(undefined, { ...defaultSettings, limit: meta.limit });
+                }
+              },
+              value: filterType,
+              items: [{
+                filterValues: {
+                  value: filterValue,
+                  onChange: (_e, value) => handleFilterItems(value)
+                },
+                label: 'State',
+                value: 'state'
+              }, {
+                filterValues: {
+                  value: filterValue,
+                  onChange: (_e, value) => handleFilterItems(value)
+                },
+                label: 'Owner',
+                value: 'owner'
+              }]
+            } }
+            pagination={ <AsyncPagination isDisabled={ isFetching || isFiltering } apiRequest={ handlePagination } meta={ meta } /> } />
           <DataList aria-label="order-list">
             { isFiltering || isFetching
               ? <ListLoader />
-              : data.map((item, index) => (
+              : data.length > 0 ? data.map((item, index) => (
                 <OrderItem
                   key={ item.id }
                   index={ index }
                   item={ item }
                 />
-              )) }
+              )) : (
+                <EmptyTable>
+                  <Bullseye>
+                    <EmptyState>
+                      <Bullseye>
+                        <EmptyStateIcon icon={ SearchIcon } />
+                      </Bullseye>
+                      <Title size="lg">
+                        No results found
+                      </Title>
+                      <EmptyStateBody>
+                        No results match the filter criteria. Remove all filters or clear all filters to show results.
+                      </EmptyStateBody>
+                    </EmptyState>
+                  </Bullseye>
+                </EmptyTable>
+              ) }
           </DataList>
+          <TableToolbar>
+            <div className="bottom-pagination-container">
+              <Flex className="example-border" breakpointMods={ [{ modifier: 'justify-content-flex-end' }] }>
+                <AsyncPagination className="pf-u-mt-0" isDisabled={ isFetching || isFiltering } apiRequest={ handlePagination } meta={ meta } />
+              </Flex>
+            </div>
+          </TableToolbar>
         </Section>
       </GridItem>
     </Grid>

--- a/src/smart-components/order/orders-list.js
+++ b/src/smart-components/order/orders-list.js
@@ -41,7 +41,7 @@ const ordersListState = (state, action) => {
     case 'setFilteringFlag':
       return { ...state, isFiltering: action.payload };
     case 'setFilterType':
-      return { ...state, filterType: action.payload };
+      return { ...state, filterType: action.payload, filterValue: '' };
   }
 
   return state;
@@ -89,7 +89,7 @@ const OrdersList = () => {
               onChange: (_e, value) => {
                 stateDispatch({ type: 'setFilterType', payload: value });
                 if (filterValue.length > 0) {
-                  handlePagination(undefined, { ...defaultSettings, limit: meta.limit });
+                  handleFilterItems('');
                 }
               },
               value: filterType,

--- a/src/test/smart-components/order/orders.test.js
+++ b/src/test/smart-components/order/orders.test.js
@@ -93,7 +93,7 @@ describe('<Orders />', () => {
   it('should mount and render orders list component', async done => {
     const store = mockStore({ ...initialState, orderReducer: { ...orderInitialState, ...orderReducer }});
 
-    apiClientMock.get(`${CATALOG_API_BASE}/orders?limit=50&offset=0`, mockOnce({ body: { data: []}}));
+    apiClientMock.get(`${CATALOG_API_BASE}/orders?filter%5Bstate%5D%5Bcontains_i%5D=&limit=50&offset=0`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolio_items`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/order_items`, mockOnce({ body: { data: []}}));
     apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({ body: { data: []}}));
@@ -129,7 +129,7 @@ describe('<Orders />', () => {
     };
     const store = mockStore({ ...initialState, orderReducer: { ...orderInitialState, ...orderItemsPagination }});
 
-    apiClientMock.get(`${CATALOG_API_BASE}/orders?limit=50&offset=0`, mockOnce({ body: { data: []}}));
+    apiClientMock.get(`${CATALOG_API_BASE}/orders?filter%5Bstate%5D%5Bcontains_i%5D=&limit=50&offset=0`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolio_items`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/order_items`, mockOnce({ body: { data: []}}));
     apiClientMock.post(`${SOURCES_API_BASE}/graphql`, mockOnce({
@@ -144,7 +144,7 @@ describe('<Orders />', () => {
     /**
      * Pagination requests
      */
-    apiClientMock.get(`${CATALOG_API_BASE}/orders?limit=50&offset=100`, mockOnce({ body: { data: []}}));
+    apiClientMock.get(`${CATALOG_API_BASE}/orders?filter%5Bstate%5D%5Bcontains_i%5D=&limit=50&offset=100`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/portfolio_items`, mockOnce({ body: { data: []}}));
     apiClientMock.get(`${CATALOG_API_BASE}/order_items`, mockOnce({ body: { data: []}}));
     let wrapper;
@@ -160,7 +160,7 @@ describe('<Orders />', () => {
 
     store.clearActions();
     await act(async () => {
-      wrapper.find('button[data-action="last"]').simulate('click');
+      wrapper.find('button[data-action="last"]').first().simulate('click');
     });
     wrapper.update();
     expect(store.getActions()).toEqual([


### PR DESCRIPTION
### Changes
- added async filtering to orders view

As you can see the poor performance really starts to show. User is just mostly looking at loading screen. I think that we should bring back the discussions about better way to get the data from server. A basically have to create 3 sequential requests because each sub collection depends on the previous one

![orders-async-filtering](https://user-images.githubusercontent.com/22619452/69319447-75f9ce80-0c3f-11ea-9508-47ece13ba9b6.gif)
