### PR TITLE
Updated permission verbs to the new version

### DIFF
--- a/src/smart-components/portfolio/share-portfolio-modal.js
+++ b/src/smart-components/portfolio/share-portfolio-modal.js
@@ -86,7 +86,7 @@ const SharePortfolioModal = ({
             sharePromises.push(
               unsharePortfolio({
                 id: portfolioId,
-                permissions: ['catalog:portfolios:update'],
+                permissions: ['update'],
                 group_uuid: share.group_uuid
               })
             );

--- a/src/test/smart-components/portfolio/share-portfolio-modal.test.js
+++ b/src/test/smart-components/portfolio/share-portfolio-modal.test.js
@@ -124,7 +124,7 @@ describe('<SharePortfolioModal', () => {
       .onPost(`${CATALOG_API_BASE}/portfolios/123/unshare`)
       .replyOnce((req) => {
         expect(JSON.parse(req.data)).toEqual({
-          permissions: ['catalog:portfolios:update'],
+          permissions: ['update'],
           group_uuids: [null]
         });
         return [200, {}];

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -5,20 +5,15 @@ export const TOPOLOGICAL_INVENTORY_API_BASE = `${process.env.BASE_PATH}/topologi
 export const RBAC_API_BASE = `${process.env.BASE_PATH}/rbac/v1`;
 export const APP_NAME = 'catalog';
 
-export const permissionValues = [
-  'catalog:portfolios:order',
-  'catalog:portfolios:read',
-  'catalog:portfolios:update'
-];
+export const permissionValues = ['order', 'read', 'update'];
 
 export const permissionOptions = [
   {
-    value:
-      'catalog:portfolios:order,catalog:portfolios:read,catalog:portfolios:update',
+    value: 'order,read,update',
     label: 'Can order/edit'
   },
   {
-    value: 'catalog:portfolios:order,catalog:portfolios:read',
+    value: 'order,read',
     label: 'Can order/view'
   }
 ];


### PR DESCRIPTION
Updated permission verbs to the new version that removes the app name and resource type.

Should be merged after https://github.com/RedHatInsights/catalog-api/pull/500.

/cc @mkanoor 
