### PR TITLE
Use portfolio/resource name in modal titles

### DIFF
--- a/src/smart-components/common/edit-approval-workflow.js
+++ b/src/smart-components/common/edit-approval-workflow.js
@@ -27,7 +27,12 @@ const approvalState = (state, action) => {
   }
 };
 
-const EditApprovalWorkflow = ({ closeUrl, objectType, objectId }) => {
+const EditApprovalWorkflow = ({
+  closeUrl,
+  objectType,
+  objectId,
+  objectName = () => objectType
+}) => {
   const [{ isFetching }, stateDispatch] = useReducer(
     approvalState,
     initialState
@@ -80,7 +85,7 @@ const EditApprovalWorkflow = ({ closeUrl, objectType, objectId }) => {
 
   return (
     <Modal
-      title={'Set approval workflow'}
+      title={`Set approval workflow for ${objectName(id)}`}
       isOpen
       onClose={() => history.push(pushParam)}
       isSmall
@@ -104,6 +109,7 @@ const EditApprovalWorkflow = ({ closeUrl, objectType, objectId }) => {
 EditApprovalWorkflow.propTypes = {
   closeUrl: PropTypes.string.isRequired,
   objectType: PropTypes.string.isRequired,
+  objectName: PropTypes.func,
   objectId: PropTypes.string
 };
 

--- a/src/smart-components/platform/platform-inventories.js
+++ b/src/smart-components/platform/platform-inventories.js
@@ -117,6 +117,15 @@ const PlatformInventories = () => {
     ];
   };
 
+  const objectName = (id) => {
+    if (data) {
+      console.log('DEBUG: id, data', id, data);
+      return data.find((obj) => obj.id === id).name;
+    }
+
+    return `Inventory ${id}`;
+  };
+
   const renderItems = () => {
     const inventoryRows = data ? createRows(data, filterValue) : [];
     const title = platform ? platform.name : '';
@@ -142,6 +151,7 @@ const PlatformInventories = () => {
           <EditApprovalWorkflow
             closeUrl={`/platforms/detail/${id}/platform-inventories`}
             objectType={INVENTORY_RESOURCE_TYPE}
+            objectName={objectName}
           />
         </Route>
         <Section type="content">

--- a/src/smart-components/platform/platform-inventories.js
+++ b/src/smart-components/platform/platform-inventories.js
@@ -119,11 +119,9 @@ const PlatformInventories = () => {
 
   const objectName = (id) => {
     if (data) {
-      console.log('DEBUG: id, data', id, data);
       return data.find((obj) => obj.id === id).name;
     }
-
-    return `Inventory ${id}`;
+    return 'inventory';
   };
 
   const renderItems = () => {

--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
@@ -65,6 +65,7 @@ const ItemDetailDescription = ({ product, url }) => (
         closeUrl={url}
         objectType={PORTFOLIO_ITEM_RESOURCE_TYPE}
         objectId={product.id}
+        objectName={() => product.name}
       />
     </Route>
   </Switch>
@@ -72,7 +73,7 @@ const ItemDetailDescription = ({ product, url }) => (
 
 ItemDetailDescription.propTypes = {
   product: PropTypes.shape({
-    dscription: PropTypes.string,
+    name: PropTypes.string,
     long_description: PropTypes.string,
     support_url: PropTypes.string,
     documentation_url: PropTypes.string,

--- a/src/smart-components/portfolio/portfolio-items.js
+++ b/src/smart-components/portfolio/portfolio-items.js
@@ -59,6 +59,16 @@ const PortfolioItems = ({
       removeInProgress={removeInProgress}
     />
   ));
+
+  const itemName = (id) => {
+    if (data) {
+      console.log('DEBUG: id, data', id, data);
+      return data.find((item) => item.id === id).name;
+    }
+
+    return `Inventory ${id}`;
+  };
+
   return (
     <Fragment>
       <ToolbarRenderer
@@ -105,6 +115,7 @@ const PortfolioItems = ({
           <EditApprovalWorkflow
             closeUrl={routes.portfolioRoute}
             objectType={PORTFOLIO_RESOURCE_TYPE}
+            objectName={itemName}
             {...args}
           />
         )}

--- a/src/smart-components/portfolio/portfolio-items.js
+++ b/src/smart-components/portfolio/portfolio-items.js
@@ -60,14 +60,7 @@ const PortfolioItems = ({
     />
   ));
 
-  const itemName = (id) => {
-    if (data) {
-      console.log('DEBUG: id, data', id, data);
-      return data.find((item) => item.id === id).name;
-    }
-
-    return `Inventory ${id}`;
-  };
+  const itemName = () => name || 'portfolio';
 
   return (
     <Fragment>

--- a/src/smart-components/portfolio/portfolios.js
+++ b/src/smart-components/portfolio/portfolios.js
@@ -74,6 +74,15 @@ const Portfolios = () => {
     insights.chrome.appNavClick({ id: 'portfolios', secondaryNav: true });
   }, []);
 
+  const itemName = (id) => {
+    if (data) {
+      console.log('DEBUG: id, data', id, data);
+      return data.find((item) => item.id === id).name;
+    }
+
+    return `Inventory ${id}`;
+  };
+
   const handleFilterItems = (value) => {
     stateDispatch({ type: 'setFilterValue', payload: value });
     debouncedFilter(
@@ -130,6 +139,7 @@ const Portfolios = () => {
             <EditApprovalWorkflow
               closeUrl={match.url}
               objectType={PORTFOLIO_RESOURCE_TYPE}
+              objectName={itemName}
             />
           )}
         />

--- a/src/smart-components/portfolio/portfolios.js
+++ b/src/smart-components/portfolio/portfolios.js
@@ -76,11 +76,9 @@ const Portfolios = () => {
 
   const itemName = (id) => {
     if (data) {
-      console.log('DEBUG: id, data', id, data);
       return data.find((item) => item.id === id).name;
     }
-
-    return `Inventory ${id}`;
+    return `portfolio`;
   };
 
   const handleFilterItems = (value) => {

--- a/src/test/smart-components/common/__snapshots__/edit-approval-workflow.test.js.snap
+++ b/src/test/smart-components/common/__snapshots__/edit-approval-workflow.test.js.snap
@@ -35,6 +35,7 @@ exports[`<EditApprovalWorkflow /> should create the edit workflow modal 1`] = `
   <MemoryRouter>
     <EditApprovalWorkflow
       closeUrl="foo"
+      objectName={[Function]}
       objectType="Portfolio"
       portfolioId="123"
     />

--- a/src/test/smart-components/common/edit-approval-workflow.test.js
+++ b/src/test/smart-components/common/edit-approval-workflow.test.js
@@ -31,7 +31,8 @@ describe('<EditApprovalWorkflow />', () => {
     initialProps = {
       closeUrl: 'foo',
       portfolioId: '123',
-      objectType: 'Portfolio'
+      objectType: 'Portfolio',
+      objectName: () => 'Test Resource Name'
     };
     initialState = {
       portfolioReducer: {
@@ -122,7 +123,9 @@ describe('<EditApprovalWorkflow />', () => {
     wrapper.update();
     const modal = wrapper.find(Modal);
     const form = wrapper.find(FormRenderer);
-    expect(modal.props().title).toEqual('Set approval workflow');
+    expect(modal.props().title).toEqual(
+      'Set approval workflow for Test Resource Name'
+    );
     expect(form.props().schema).toEqual(expectedSchema);
     done();
   });


### PR DESCRIPTION
Use portfolio/resource name in modal titles for set approval workflow and the portfolio name in the share/edit portfolio modal titles.

https://projects.engineering.redhat.com/browse/SSP-1103

![Screenshot from 2020-01-09 13-27-48](https://user-images.githubusercontent.com/12769982/72094290-1e451e80-32e4-11ea-9e63-f84aa70d766e.png)

![Screenshot from 2020-01-09 13-28-14](https://user-images.githubusercontent.com/12769982/72094298-21d8a580-32e4-11ea-95a1-c052b6087cf2.png)

![Screenshot from 2020-01-09 13-28-30](https://user-images.githubusercontent.com/12769982/72094303-24d39600-32e4-11ea-8e42-14b7e8d69ee1.png)
