### PR TITLE
Empty states when server has no data

### DIFF
--- a/src/helpers/shared/pagination.js
+++ b/src/helpers/shared/pagination.js
@@ -1,7 +1,8 @@
 export const defaultSettings = {
   limit: 50,
   offset: 0,
-  count: 0
+  count: 0,
+  filter: ''
 };
 
 export const getCurrentPage = (limit = 1, offset = 0) =>

--- a/src/presentational-components/shared/content-gallery-empty-state.js
+++ b/src/presentational-components/shared/content-gallery-empty-state.js
@@ -52,7 +52,7 @@ export default ContentGalleryEmptyState;
 
 export const EmptyStatePrimaryAction = ({ url, label }) => (
   <Link to={url}>
-    <Button variant="primary">{label}</Button>
+    <Button variant="secondary">{label}</Button>
   </Link>
 );
 

--- a/src/presentational-components/shared/top-toolbar.js
+++ b/src/presentational-components/shared/top-toolbar.js
@@ -7,6 +7,7 @@ import {
   TextContent,
   TextVariants
 } from '@patternfly/react-core';
+import clsx from 'clsx';
 import { ToolbarTitlePlaceholder } from './loader-placeholders';
 import CatalogBreadcrumbs from './breadcrubms';
 import './top-toolbar.scss';
@@ -39,9 +40,15 @@ TopToolbar.defaultProps = {
 
 export default TopToolbar;
 
-export const TopToolbarTitle = ({ title, description, children, ...rest }) => (
+export const TopToolbarTitle = ({
+  title,
+  description,
+  children,
+  noData,
+  ...rest
+}) => (
   <Fragment>
-    <Level className="pf-u-mb-lg" {...rest}>
+    <Level className={clsx({ 'pf-u-mb-lg': !noData })} {...rest}>
       <LevelItem>
         <TextContent className="top-toolbar-title">
           <Text component={TextVariants.h2} className="pf-u-m-0 pf-u-mr-md">
@@ -63,7 +70,8 @@ TopToolbarTitle.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)
-  ])
+  ]),
+  noData: PropTypes.bool
 };
 
 TopToolbarTitle.defaultProps = {

--- a/src/redux/actions/order-actions.js
+++ b/src/redux/actions/order-actions.js
@@ -74,9 +74,9 @@ export const cancelOrder = (orderId) => (dispatch, getState) => {
     });
 };
 
-export const fetchOrders = (...args) => (dispatch) => {
+export const fetchOrders = (filterType, filter, pagination) => (dispatch) => {
   dispatch({ type: `${ActionTypes.FETCH_ORDERS}_PENDING` });
-  return OrderHelper.getOrders(...args)
+  return OrderHelper.getOrders(filterType, filter, pagination)
     .then(({ portfolioItems, ...orders }) => {
       dispatch({
         type: ActionTypes.SET_PORTFOLIO_ITEMS,
@@ -84,6 +84,7 @@ export const fetchOrders = (...args) => (dispatch) => {
       });
       return dispatch({
         type: `${ActionTypes.FETCH_ORDERS}_FULFILLED`,
+        meta: { filter },
         payload: orders
       });
     })

--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -9,17 +9,25 @@ import * as ActionTypes from '../action-types';
 import * as PortfolioHelper from '../../helpers/portfolio/portfolio-helper';
 import { defaultSettings } from '../../helpers/shared/pagination';
 
-export const doFetchPortfolios = (...args) => ({
+export const doFetchPortfolios = ({
+  filter,
+  ...options
+} = defaultSettings) => ({
   type: ActionTypes.FETCH_PORTFOLIOS,
-  payload: PortfolioHelper.listPortfolios(...args)
+  meta: { filter },
+  payload: PortfolioHelper.listPortfolios(filter, options)
 });
 
 export const fetchPortfolios = (...args) => (dispatch) => {
   return dispatch(doFetchPortfolios(...args));
 };
 
-export const fetchPortfolioItems = (filter, options = defaultSettings) => ({
+export const fetchPortfolioItems = (
+  filter = '',
+  options = defaultSettings
+) => ({
   type: ActionTypes.FETCH_PORTFOLIO_ITEMS,
+  meta: { filter },
   payload: PortfolioHelper.listPortfolioItems(
     options.limit,
     options.offset,
@@ -32,9 +40,13 @@ export const fetchPortfolioItem = (portfolioItemId) => ({
   payload: PortfolioHelper.getPortfolioItem(portfolioItemId)
 });
 
-export const fetchPortfolioItemsWithPortfolio = (...args) => ({
+export const fetchPortfolioItemsWithPortfolio = (
+  portfolioId,
+  options = defaultSettings
+) => ({
   type: ActionTypes.FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO,
-  payload: PortfolioHelper.getPortfolioItemsWithPortfolio(...args)
+  meta: { filter: options.filter },
+  payload: PortfolioHelper.getPortfolioItemsWithPortfolio(portfolioId, options)
 });
 
 export const fetchSelectedPortfolio = (id) => ({

--- a/src/redux/reducers/portfolio-reducer.js
+++ b/src/redux/reducers/portfolio-reducer.js
@@ -25,7 +25,8 @@ export const portfoliosInitialState = {
     data: [],
     meta: {
       limit: 50,
-      offset: 0
+      offset: 0,
+      filter: ''
     }
   },
   portfolioItem: {},

--- a/src/smart-components/order/orders-list.js
+++ b/src/smart-components/order/orders-list.js
@@ -160,16 +160,16 @@ const OrdersList = () => {
                       <EmptyStateIcon icon={SearchIcon} />
                     </Bullseye>
                     <Title size="lg">
-                      {filterValue === '' ? 'No orders' : 'No results found'}
+                      {meta.noData ? 'No orders' : 'No results found'}
                     </Title>
                     <EmptyStateBody>
-                      {filterValue === ''
+                      {meta.noData
                         ? 'No orders have been created'
                         : 'No results match the filter criteria. Remove all filters or clear all filters to show results.'}
                     </EmptyStateBody>
 
                     <EmptyStateSecondaryActions>
-                      {filterValue && (
+                      {!meta.noData && (
                         <Button
                           variant="link"
                           onClick={() => {

--- a/src/smart-components/order/orders-list.js
+++ b/src/smart-components/order/orders-list.js
@@ -95,56 +95,58 @@ const OrdersList = () => {
     <Grid gutter="md">
       <GridItem>
         <Section type="content">
-          <PrimaryToolbar
-            {...(filterValue && {
-              activeFiltersConfig: {
-                filters: [
-                  {
-                    name: filterValue
+          {!meta.noData && (
+            <PrimaryToolbar
+              {...(filterValue && {
+                activeFiltersConfig: {
+                  filters: [
+                    {
+                      name: filterValue
+                    }
+                  ],
+                  onDelete: () => {
+                    stateDispatch({ type: 'setFilterValue', payload: '' });
+                    handleFilterItems('');
                   }
-                ],
-                onDelete: () => {
-                  stateDispatch({ type: 'setFilterValue', payload: '' });
-                  handleFilterItems('');
                 }
-              }
-            })}
-            filterConfig={{
-              onChange: (_e, value) => {
-                stateDispatch({ type: 'setFilterType', payload: value });
-                if (filterValue.length > 0) {
-                  handleFilterItems('');
-                }
-              },
-              value: filterType,
-              items: [
-                {
-                  filterValues: {
-                    value: filterValue,
-                    onChange: (_e, value) => handleFilterItems(value)
-                  },
-                  label: 'State',
-                  value: 'state'
+              })}
+              filterConfig={{
+                onChange: (_e, value) => {
+                  stateDispatch({ type: 'setFilterType', payload: value });
+                  if (filterValue.length > 0) {
+                    handleFilterItems('');
+                  }
                 },
-                {
-                  filterValues: {
-                    value: filterValue,
-                    onChange: (_e, value) => handleFilterItems(value)
+                value: filterType,
+                items: [
+                  {
+                    filterValues: {
+                      value: filterValue,
+                      onChange: (_e, value) => handleFilterItems(value)
+                    },
+                    label: 'State',
+                    value: 'state'
                   },
-                  label: 'Owner',
-                  value: 'owner'
-                }
-              ]
-            }}
-            pagination={
-              <AsyncPagination
-                isDisabled={isFetching || isFiltering}
-                apiRequest={handlePagination}
-                meta={meta}
-                isCompact
-              />
-            }
-          />
+                  {
+                    filterValues: {
+                      value: filterValue,
+                      onChange: (_e, value) => handleFilterItems(value)
+                    },
+                    label: 'Owner',
+                    value: 'owner'
+                  }
+                ]
+              }}
+              pagination={
+                <AsyncPagination
+                  isDisabled={isFetching || isFiltering}
+                  apiRequest={handlePagination}
+                  meta={meta}
+                  isCompact
+                />
+              }
+            />
+          )}
           <DataList aria-label="order-list">
             {isFiltering || isFetching ? (
               <ListLoader />

--- a/src/smart-components/portfolio/portfolio-empty-state.js
+++ b/src/smart-components/portfolio/portfolio-empty-state.js
@@ -9,7 +9,7 @@ import { Button } from '@patternfly/react-core';
 
 const PortfolioEmptyState = ({ url, handleFilterChange, meta }) => {
   const NoDataAction = () => (
-    <EmptyStatePrimaryAction url={`${url}/add-products`} label="Add products" />
+    <EmptyStatePrimaryAction url={url} label="Add products" />
   );
 
   const FilterAction = () => (

--- a/src/smart-components/portfolio/portfolio-empty-state.js
+++ b/src/smart-components/portfolio/portfolio-empty-state.js
@@ -1,27 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { SearchIcon } from '@patternfly/react-icons';
+import { SearchIcon, WrenchIcon } from '@patternfly/react-icons';
 
 import ContentGalleryEmptyState, {
   EmptyStatePrimaryAction
 } from '../../presentational-components/shared/content-gallery-empty-state';
+import { Button } from '@patternfly/react-core';
 
-const PortfolioEmptyState = ({ url }) => (
-  <ContentGalleryEmptyState
-    Icon={SearchIcon}
-    title="No products yet"
-    description="You haven’t added any products to the portfolio"
-    PrimaryAction={() => (
-      <EmptyStatePrimaryAction
-        url={`${url}/add-products`}
-        label="Add products"
-      />
-    )}
-  />
-);
+const PortfolioEmptyState = ({ url, handleFilterChange, meta }) => {
+  const NoDataAction = () => (
+    <EmptyStatePrimaryAction url={`${url}/add-products`} label="Add products" />
+  );
+
+  const FilterAction = () => (
+    <Button variant="link" onClick={() => handleFilterChange('')}>
+      Clear all filters
+    </Button>
+  );
+
+  const emptyStateProps = {
+    PrimaryAction: meta.noData ? NoDataAction : FilterAction,
+    title: meta.noData ? 'No products yet' : 'No results found',
+    description: meta.noData
+      ? 'No products in your portfolio'
+      : 'No results match the filter criteria. Remove all filters or clear all filters to show results.',
+    Icon: meta.noData ? WrenchIcon : SearchIcon
+  };
+  return <ContentGalleryEmptyState {...emptyStateProps} />;
+};
 
 PortfolioEmptyState.propTypes = {
-  url: PropTypes.string.isRequired
+  url: PropTypes.string.isRequired,
+  handleFilterChange: PropTypes.func.isRequired,
+  meta: PropTypes.shape({
+    noData: PropTypes.bool
+  }).isRequired
 };
 
 export default PortfolioEmptyState;

--- a/src/smart-components/portfolio/portfolio-items.js
+++ b/src/smart-components/portfolio/portfolio-items.js
@@ -125,7 +125,11 @@ const PortfolioItems = ({
         items={items}
         isLoading={isFetching || isFiltering}
         renderEmptyState={() => (
-          <PortfolioEmptyState url={routes.addProductsRoute} />
+          <PortfolioEmptyState
+            handleFilterChange={handleFilterChange}
+            meta={meta}
+            url={routes.addProductsRoute}
+          />
         )}
       />
       {meta.count > 0 && (

--- a/src/smart-components/portfolio/portfolios.js
+++ b/src/smart-components/portfolio/portfolios.js
@@ -1,7 +1,7 @@
 import React, { Fragment, useEffect, useReducer } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch, useRouteMatch } from 'react-router-dom';
-import { SearchIcon } from '@patternfly/react-icons';
+import { SearchIcon, WrenchIcon } from '@patternfly/react-icons';
 
 import Portfolio from './portfolio';
 import AddPortfolio from './add-portfolio-modal';
@@ -22,11 +22,14 @@ import asyncFormValidator from '../../utilities/async-form-validator';
 import { PORTFOLIO_RESOURCE_TYPE } from '../../utilities/constants';
 import AsyncPagination from '../common/async-pagination';
 import BottomPaginationContainer from '../../presentational-components/shared/bottom-pagination-container';
+import { Button } from '@patternfly/react-core';
 
 const debouncedFilter = asyncFormValidator(
-  (value, dispatch, filteringCallback, meta = defaultSettings) => {
+  (filter, dispatch, filteringCallback, meta = defaultSettings) => {
     filteringCallback(true);
-    dispatch(fetchPortfolios(value, meta)).then(() => filteringCallback(false));
+    dispatch(fetchPortfolios({ ...meta, filter })).then(() =>
+      filteringCallback(false)
+    );
   },
   1000
 );
@@ -68,9 +71,9 @@ const Portfolios = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(fetchPortfolios(filterValue, defaultSettings)).then(() =>
-      stateDispatch({ type: 'setFetching', payload: false })
-    );
+    dispatch(
+      fetchPortfolios({ ...defaultSettings, filter: filterValue })
+    ).then(() => stateDispatch({ type: 'setFetching', payload: false }));
     scrollToTop();
     insights.chrome.appNavClick({ id: 'portfolios', secondaryNav: true });
   }, []);
@@ -98,6 +101,28 @@ const Portfolios = () => {
   };
 
   const renderItems = () => {
+    const NoDataAction = () => (
+      <EmptyStatePrimaryAction
+        url="/portfolios/add-portfolio"
+        label="Create portfolio"
+      />
+    );
+
+    const FilterAction = () => (
+      <Button variant="link" onClick={() => handleFilterItems('')}>
+        Clear all filters
+      </Button>
+    );
+
+    const emptyStateProps = {
+      PrimaryAction: meta.noData ? NoDataAction : FilterAction,
+      title: meta.noData ? 'No portfolios' : 'No results found',
+      description: meta.noData
+        ? 'No portfolios match your filter criteria.'
+        : 'No results match the filter criteria. Remove all filters or clear all filters to show results.',
+      Icon: meta.noData ? WrenchIcon : SearchIcon
+    };
+
     const galleryItems = data.map((item) => (
       <PortfolioCard key={item.id} {...item} />
     ));
@@ -147,21 +172,7 @@ const Portfolios = () => {
           items={galleryItems}
           isLoading={isFetching || isFiltering}
           renderEmptyState={() => (
-            <ContentGalleryEmptyState
-              title="No portfolios"
-              Icon={SearchIcon}
-              description={
-                filterValue === ''
-                  ? 'You haven’t created a portfolio yet.'
-                  : 'No portfolios match your filter criteria.'
-              }
-              PrimaryAction={() => (
-                <EmptyStatePrimaryAction
-                  url="/portfolios/add-portfolio"
-                  label="Create portfolio"
-                />
-              )}
-            />
+            <ContentGalleryEmptyState {...emptyStateProps} />
           )}
         />
         {meta.count > 0 && (

--- a/src/smart-components/products/products.js
+++ b/src/smart-components/products/products.js
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useReducer } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { WrenchIcon } from '@patternfly/react-icons';
+import { WrenchIcon, SearchIcon } from '@patternfly/react-icons';
 
 import { fetchPortfolioItems } from '../../redux/actions/portfolio-actions';
 import { scrollToTop } from '../../helpers/shared/helpers';
@@ -85,6 +85,27 @@ const Products = () => {
     <PortfolioItem key={item.id} to={buildItemUrl(item)} {...item} />
   ));
 
+  const SourcesAction = () => (
+    <a href={`${release}settings/sources/new`}>
+      <Button variant="secondary">Add source</Button>
+    </a>
+  );
+
+  const FilterAction = () => (
+    <Button variant="link" onClick={() => handleFilterItems('')}>
+      Clear all filters
+    </Button>
+  );
+
+  const emptyStateProps = {
+    PrimaryAction: meta.noData ? SourcesAction : FilterAction,
+    title: meta.noData ? 'No products yet' : 'No results found',
+    description: meta.noData
+      ? 'Configure a source to add products into portfolios.'
+      : 'No results match the filter criteria. Remove all filters or clear all filters to show results.',
+    Icon: meta.noData ? WrenchIcon : SearchIcon
+  };
+
   return (
     <div>
       <ToolbarRenderer
@@ -104,16 +125,7 @@ const Products = () => {
         isLoading={isFiltering || isFetching}
         items={galleryItems}
         renderEmptyState={() => (
-          <ContentGalleryEmptyState
-            PrimaryAction={() => (
-              <a href={`${release}settings/sources/new`}>
-                <Button variant="secondary">Add source</Button>
-              </a>
-            )}
-            title="No products yet"
-            description="Configure a source to add products into portfolios."
-            Icon={WrenchIcon}
-          />
+          <ContentGalleryEmptyState {...emptyStateProps} />
         )}
       />
       {meta.count > 0 && (

--- a/src/test/redux/actions/portfolio-actions.test.js
+++ b/src/test/redux/actions/portfolio-actions.test.js
@@ -63,10 +63,12 @@ describe('Portfolio actions', () => {
 
     const expectedActions = [
       {
-        type: `${FETCH_PORTFOLIOS}_PENDING`
+        type: `${FETCH_PORTFOLIOS}_PENDING`,
+        meta: { filter: '' }
       },
       {
         type: `${FETCH_PORTFOLIOS}_FULFILLED`,
+        meta: { filter: '' },
         payload: { data: [expectedPortfolio], meta: {} }
       }
     ];
@@ -85,7 +87,8 @@ describe('Portfolio actions', () => {
 
     const expectedActions = expect.arrayContaining([
       {
-        type: `${FETCH_PORTFOLIOS}_PENDING`
+        type: `${FETCH_PORTFOLIOS}_PENDING`,
+        meta: { filter: '' }
       },
       expect.objectContaining({
         type: ADD_NOTIFICATION,
@@ -120,15 +123,17 @@ describe('Portfolio actions', () => {
 
     const expectedActions = [
       {
-        type: `${FETCH_PORTFOLIO_ITEMS}_PENDING`
+        type: `${FETCH_PORTFOLIO_ITEMS}_PENDING`,
+        meta: { filter: '123' }
       },
       {
         type: `${FETCH_PORTFOLIO_ITEMS}_FULFILLED`,
+        meta: { filter: '123' },
         payload: { data: [], meta: {} }
       }
     ];
 
-    return store.dispatch(fetchPortfolioItems(123)).then(() => {
+    return store.dispatch(fetchPortfolioItems('123')).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
@@ -144,10 +149,12 @@ describe('Portfolio actions', () => {
 
     const expectedActions = [
       {
-        type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`
+        type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`,
+        meta: { filter: '' }
       },
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_FULFILLED`,
+        meta: { filter: '' },
         payload: { data: ['foo'] }
       }
     ];
@@ -335,10 +342,12 @@ describe('Portfolio actions', () => {
         type: `${REMOVE_PORTFOLIO_ITEMS}_PENDING`
       },
       {
-        type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`
+        type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`,
+        meta: {}
       },
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_FULFILLED`,
+        meta: {},
         payload: []
       },
       expect.objectContaining({ type: ADD_NOTIFICATION }),
@@ -404,10 +413,12 @@ describe('Portfolio actions', () => {
       },
       expect.objectContaining({ type: CLEAR_NOTIFICATIONS }),
       {
-        type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`
+        type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`,
+        meta: { filter: '' }
       },
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_FULFILLED`,
+        meta: { filter: '' },
         payload: { data: [] }
       },
       expect.objectContaining({ type: ADD_NOTIFICATION })

--- a/src/test/redux/reducers/portfolio-reducer.test.js
+++ b/src/test/redux/reducers/portfolio-reducer.test.js
@@ -110,7 +110,7 @@ describe('Portfolio reducer', () => {
     // reset selected portfolio and portfolio items
     const resetState = {
       selectedPortfolio: {},
-      portfolioItems: { data: [], meta: { offset: 0, limit: 50 } }
+      portfolioItems: { data: [], meta: { offset: 0, limit: 50, filter: '' } }
     };
     expect(
       reducer(initialState, { type: RESET_SELECTED_PORTFOLIO, payload })

--- a/src/test/smart-components/order/orders.test.js
+++ b/src/test/smart-components/order/orders.test.js
@@ -216,7 +216,11 @@ describe('<Orders />', () => {
     expect(store.getActions()).toEqual([
       { type: `${FETCH_ORDERS}_PENDING` },
       { type: SET_PORTFOLIO_ITEMS, payload: { data: [] } },
-      { type: `${FETCH_ORDERS}_FULFILLED`, payload: { data: [] } }
+      {
+        type: `${FETCH_ORDERS}_FULFILLED`,
+        meta: { filter: '' },
+        payload: { data: [] }
+      }
     ]);
     done();
   });

--- a/src/test/smart-components/portfolio/portfolio.test.js
+++ b/src/test/smart-components/portfolio/portfolio.test.js
@@ -99,7 +99,8 @@ describe('<Portfolio />', () => {
         type: `${FETCH_PORTFOLIO}_PENDING`
       },
       {
-        type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`
+        type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`,
+        meta: { filter: '' }
       },
       expect.objectContaining({
         type: `${FETCH_PORTFOLIO}_FULFILLED`

--- a/src/test/smart-components/portfolio/portfolios.test.js
+++ b/src/test/smart-components/portfolio/portfolios.test.js
@@ -75,7 +75,8 @@ describe('<Portfolios />', () => {
       .replyOnce(200, { data: [{ name: 'Foo', id: '11' }] });
     const expectedActions = [
       {
-        type: `${FETCH_PORTFOLIOS}_PENDING`
+        type: `${FETCH_PORTFOLIOS}_PENDING`,
+        meta: { filter: '' }
       },
       expect.objectContaining({
         type: `${FETCH_PORTFOLIOS}_FULFILLED`

--- a/src/toolbar/schemas/portfolio-toolbar.schema.js
+++ b/src/toolbar/schemas/portfolio-toolbar.schema.js
@@ -151,6 +151,7 @@ const createPortfolioToolbarSchema = ({
         {
           component: toolbarComponentTypes.TOP_TOOLBAR_TITLE,
           key: 'portfolio-toolbar-title',
+          noData: meta.noData,
           title,
           fields: [
             {
@@ -181,60 +182,62 @@ const createPortfolioToolbarSchema = ({
         {
           component: toolbarComponentTypes.LEVEL,
           key: 'portfolio-items-actions',
-          fields: [
-            {
-              component: toolbarComponentTypes.TOOLBAR,
-              key: 'portfolio-items-actions',
-              fields: [
-                createSingleItemGroup({
-                  groupName: 'filter-portfolio-items',
-                  component: toolbarComponentTypes.FILTER_TOOLBAR_ITEM,
-                  isClearable: true,
-                  key: 'portfolio-items-filter',
-                  searchValue,
-                  onFilterChange,
-                  placeholder
-                }),
-                createSingleItemGroup({
-                  hidden: meta.count === 0,
-                  groupName: 'add-portfolio-items',
-                  key: 'portfolio-items-add-group',
-                  ...createLinkButton({
-                    to: addProductsRoute,
-                    isDisabled: isLoading || copyInProgress,
-                    variant: 'primary',
-                    title: 'Add products',
-                    key: 'add-products-button'
-                  })
-                }),
+          fields: meta.noData
+            ? []
+            : [
                 {
-                  hidden: meta.count === 0,
-                  component: PortfolioItemsActionsDropdown,
-                  isDisabled: copyInProgress,
-                  key: 'remove-products-actions-dropdown',
-                  removeProducts,
-                  itemsSelected
+                  component: toolbarComponentTypes.TOOLBAR,
+                  key: 'portfolio-items-actions',
+                  fields: [
+                    createSingleItemGroup({
+                      groupName: 'filter-portfolio-items',
+                      component: toolbarComponentTypes.FILTER_TOOLBAR_ITEM,
+                      isClearable: true,
+                      key: 'portfolio-items-filter',
+                      searchValue,
+                      onFilterChange,
+                      placeholder
+                    }),
+                    createSingleItemGroup({
+                      hidden: meta.count === 0,
+                      groupName: 'add-portfolio-items',
+                      key: 'portfolio-items-add-group',
+                      ...createLinkButton({
+                        to: addProductsRoute,
+                        isDisabled: isLoading || copyInProgress,
+                        variant: 'primary',
+                        title: 'Add products',
+                        key: 'add-products-button'
+                      })
+                    }),
+                    {
+                      hidden: meta.count === 0,
+                      component: PortfolioItemsActionsDropdown,
+                      isDisabled: copyInProgress,
+                      key: 'remove-products-actions-dropdown',
+                      removeProducts,
+                      itemsSelected
+                    }
+                  ]
+                },
+                {
+                  component: toolbarComponentTypes.LEVEL_ITEM,
+                  key: 'pagination-item',
+                  fields:
+                    meta.count > 0
+                      ? [
+                          {
+                            component: AsyncPagination,
+                            key: 'portfolio-items-pagination',
+                            meta,
+                            apiRequest: fetchPortfolioItemsWithPortfolio,
+                            apiProps: portfolioId,
+                            isCompact: true
+                          }
+                        ]
+                      : []
                 }
               ]
-            },
-            {
-              component: toolbarComponentTypes.LEVEL_ITEM,
-              key: 'pagination-item',
-              fields:
-                meta.count > 0
-                  ? [
-                      {
-                        component: AsyncPagination,
-                        key: 'portfolio-items-pagination',
-                        meta,
-                        apiRequest: fetchPortfolioItemsWithPortfolio,
-                        apiProps: portfolioId,
-                        isCompact: true
-                      }
-                    ]
-                  : []
-            }
-          ]
         }
       ]
     }

--- a/src/toolbar/schemas/portfolios-toolbar.schema.js
+++ b/src/toolbar/schemas/portfolios-toolbar.schema.js
@@ -16,56 +16,59 @@ const createPortfolioToolbarSchema = ({
         {
           component: toolbarComponentTypes.TOP_TOOLBAR_TITLE,
           key: 'portfolios-toolbar-title',
-          title: 'Portfolios'
+          title: 'Portfolios',
+          noData: meta.noData
         },
         {
           component: toolbarComponentTypes.LEVEL,
           key: 'portfolios-actions',
-          fields: [
-            {
-              component: toolbarComponentTypes.TOOLBAR,
-              key: 'main-portfolio-toolbar',
-              fields: [
-                createSingleItemGroup({
-                  groupName: 'filter-group',
-                  component: toolbarComponentTypes.FILTER_TOOLBAR_ITEM,
-                  key: 'filter-input',
-                  searchValue,
-                  onFilterChange,
-                  placeholder,
-                  isClearable: true
-                }),
-                createSingleItemGroup({
-                  hidden: meta.count === 0,
-                  groupName: 'portfolio-button-group',
-                  key: 'create-portfolio',
-                  ...createLinkButton({
-                    to: '/portfolios/add-portfolio',
-                    variant: 'primary',
-                    key: 'create-portfolio-button',
-                    'aria-label': 'Create portfolio',
-                    title: 'Create'
-                  })
-                })
+          fields: meta.noData
+            ? []
+            : [
+                {
+                  component: toolbarComponentTypes.TOOLBAR,
+                  key: 'main-portfolio-toolbar',
+                  fields: [
+                    createSingleItemGroup({
+                      groupName: 'filter-group',
+                      component: toolbarComponentTypes.FILTER_TOOLBAR_ITEM,
+                      key: 'filter-input',
+                      searchValue,
+                      onFilterChange,
+                      placeholder,
+                      isClearable: true
+                    }),
+                    createSingleItemGroup({
+                      hidden: meta.count === 0,
+                      groupName: 'portfolio-button-group',
+                      key: 'create-portfolio',
+                      ...createLinkButton({
+                        to: '/portfolios/add-portfolio',
+                        variant: 'primary',
+                        key: 'create-portfolio-button',
+                        'aria-label': 'Create portfolio',
+                        title: 'Create'
+                      })
+                    })
+                  ]
+                },
+                {
+                  component: toolbarComponentTypes.LEVEL_ITEM,
+                  key: 'pagination-item',
+                  fields:
+                    meta.count > 0
+                      ? [
+                          {
+                            component: AsyncPagination,
+                            isCompact: true,
+                            key: 'portfolios-pagination',
+                            meta,
+                            apiRequest: fetchPortfolios
+                          }
+                        ]
+                      : []
+                }
               ]
-            },
-            {
-              component: toolbarComponentTypes.LEVEL_ITEM,
-              key: 'pagination-item',
-              fields:
-                meta.count > 0
-                  ? [
-                      {
-                        component: AsyncPagination,
-                        isCompact: true,
-                        key: 'portfolios-pagination',
-                        meta,
-                        apiRequest: fetchPortfolios
-                      }
-                    ]
-                  : []
-            }
-          ]
         }
       ]
     }

--- a/src/toolbar/schemas/products-toolbar.schema.js
+++ b/src/toolbar/schemas/products-toolbar.schema.js
@@ -18,46 +18,49 @@ const createPortfolioToolbarSchema = ({
           component: toolbarComponentTypes.TOP_TOOLBAR_TITLE,
           key: 'products-toolbar-title',
           title: 'Products',
-          description: 'All products collected from your portfolios'
+          description: 'All products collected from your portfolios',
+          noData: meta.noData
         },
         {
           component: toolbarComponentTypes.LEVEL,
           key: 'Products-actions',
-          fields: [
-            {
-              component: toolbarComponentTypes.TOOLBAR,
-              key: 'main-portfolio-toolbar',
-              fields: [
-                createSingleItemGroup({
-                  groupName: 'filter-group',
-                  component: toolbarComponentTypes.FILTER_TOOLBAR_ITEM,
-                  key: 'filter-input',
-                  searchValue,
-                  onFilterChange,
-                  placeholder,
-                  isClearable: true
-                })
+          fields: meta.noData
+            ? []
+            : [
+                {
+                  component: toolbarComponentTypes.TOOLBAR,
+                  key: 'main-portfolio-toolbar',
+                  fields: [
+                    createSingleItemGroup({
+                      groupName: 'filter-group',
+                      component: toolbarComponentTypes.FILTER_TOOLBAR_ITEM,
+                      key: 'filter-input',
+                      searchValue,
+                      onFilterChange,
+                      placeholder,
+                      isClearable: true
+                    })
+                  ]
+                },
+                {
+                  component: toolbarComponentTypes.LEVEL_ITEM,
+                  key: 'pagination-item',
+                  fields:
+                    meta.count > 0
+                      ? [
+                          {
+                            component: AsyncPagination,
+                            key: 'products-pagination',
+                            meta,
+                            apiProps: searchValue,
+                            apiRequest: fetchProducts,
+                            isDisabled: isLoading,
+                            isCompact: true
+                          }
+                        ]
+                      : []
+                }
               ]
-            },
-            {
-              component: toolbarComponentTypes.LEVEL_ITEM,
-              key: 'pagination-item',
-              fields:
-                meta.count > 0
-                  ? [
-                      {
-                        component: AsyncPagination,
-                        key: 'products-pagination',
-                        meta,
-                        apiProps: searchValue,
-                        apiRequest: fetchProducts,
-                        isDisabled: isLoading,
-                        isCompact: true
-                      }
-                    ]
-                  : []
-            }
-          ]
         }
       ]
     }

--- a/src/utilities/empty-data-middleware.js
+++ b/src/utilities/empty-data-middleware.js
@@ -1,0 +1,19 @@
+const emptyDataMiddleware = () => (dispatch) => (action) => {
+  const nextAction = { ...action };
+  if (
+    action.type.match(/_FULFILLED$/) &&
+    action.payload &&
+    action.meta &&
+    action.payload.data &&
+    action.payload.meta
+  ) {
+    nextAction.payload.meta.noData =
+      nextAction.payload.meta.count === 0 &&
+      nextAction.meta.filter.length === 0;
+    return dispatch(nextAction);
+  }
+
+  return dispatch(nextAction);
+};
+
+export default emptyDataMiddleware;

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -29,6 +29,7 @@ import openApiReducer, {
   openApiInitialState
 } from '../redux/reducers/open-api-reducer';
 import loadingStateMiddleware from './loading-state-middleware';
+import emptyDataMiddleware from './empty-data-middleware';
 
 const registry = new ReducerRegistry({}, [
   thunk,
@@ -47,6 +48,7 @@ const registry = new ReducerRegistry({}, [
     ]
   }),
   loadingStateMiddleware,
+  emptyDataMiddleware,
   reduxLogger
 ]);
 registry.register({


### PR DESCRIPTION
### Changes
- added redux middleware which adds `noData` flag
  - the flag is set to true when API response count is 0 and no filter was applied
- added empty states variants for `noData` scenario
- completely removed toolbar actions when `noData` is set. User will use primary actions from empty states

The same pattern is applied to all entities with exception of platforms (There are some missing API features to enable pagination/filter)

### Portfolio with items
![screenshot-ci foo redhat com_1337-2020 01 13-13_43_33](https://user-images.githubusercontent.com/22619452/72256929-b4da4e00-360a-11ea-81a0-5316128824ca.png)


### Portfolio with no items
![screenshot-ci foo redhat com_1337-2020 01 13-13_42_49](https://user-images.githubusercontent.com/22619452/72256899-a4c26e80-360a-11ea-9792-6dc68b06dc2f.png)
