### PR TITLE
Remove extra `update_schedule` setting from dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,7 +3,6 @@ update_configs:
   - package_manager: "javascript"
     update_schedule: "weekly"
     directory: "/"
-    update_schedule: "live"
     default_reviewers:
       - "Hyperkid123"
     allowed_updates:


### PR DESCRIPTION
The preferred schedule is weekly.  The additional "live" setting is not needed.