### PR TITLE
Added missing filter attribute to remove portfolio item.

### DIFF
--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -212,7 +212,8 @@ export const removeProductsFromPortfolio = (portfolioItems, portfolioName) => (
       dispatch(
         fetchPortfolioItemsWithPortfolio(portfolioId, {
           offset: 0,
-          limit: meta.limit
+          limit: meta.limit,
+          filter: ''
         })
       ).then(() => data)
     )

--- a/src/test/redux/actions/portfolio-actions.test.js
+++ b/src/test/redux/actions/portfolio-actions.test.js
@@ -343,11 +343,15 @@ describe('Portfolio actions', () => {
       },
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`,
-        meta: {}
+        meta: {
+          filter: ''
+        }
       },
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_FULFILLED`,
-        meta: {},
+        meta: {
+          filter: ''
+        },
         payload: []
       },
       expect.objectContaining({ type: ADD_NOTIFICATION }),


### PR DESCRIPTION
- when removing portfolio items from a portfolio, the filter attribute was missing and the empty data middleware crashed in runtime.