### PR TITLE
Fixed missing dispatch bind on unshare portfolio action.

### DIFF
--- a/src/smart-components/portfolio/share-portfolio-modal.js
+++ b/src/smart-components/portfolio/share-portfolio-modal.js
@@ -23,6 +23,7 @@ const SharePortfolioModal = ({
   initialValues,
   fetchShareInfo,
   sharePortfolio,
+  unsharePortfolio,
   fetchRbacGroups,
   shareInfo,
   portfolioId,


### PR DESCRIPTION
### Changes
- added `unsharePortfolio` to `bindActionsCreators`

unshare actions were not dispatched as redux actions, therefore the redux notification middleware did no catch the fulfilled message.