### PR TITLE
Fixed missing icons for service offerings.

### DIFF
--- a/src/presentational-components/platform/platform-item.js
+++ b/src/presentational-components/platform/platform-item.js
@@ -14,7 +14,7 @@ const PlatformItem = (props) => (
       <CardIcon
         src={`${TOPOLOGICAL_INVENTORY_API_BASE}/service_offering_icons/${props.service_offering_icon_id}/icon_data`}
         style={{ height: 40 }}
-        platformId={props.source_id}
+        sourceId={props.source_id}
       />
       {props.editMode && (
         <CardCheckbox

--- a/src/presentational-components/shared/service-offering-body.js
+++ b/src/presentational-components/shared/service-offering-body.js
@@ -43,7 +43,13 @@ ServiceOfferingCardBody.propTypes = {
   distributor: PropTypes.string,
   long_description: PropTypes.string,
   description: PropTypes.string,
-  url: PropTypes.string,
+  url: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      pathname: PropTypes.string,
+      search: PropTypes.string
+    })
+  ]),
   to: PropTypes.shape({
     pathname: PropTypes.string,
     search: PropTypes.string


### PR DESCRIPTION
### Changes
- apply fallback icon for service offerings cards

### Before
![screenshot-ci cloud redhat com-2020 01 22-15_07_10](https://user-images.githubusercontent.com/22619452/72900844-e947bb80-3d28-11ea-9485-a7740c8df05e.png)

### After
![screenshot-ci foo redhat com_1337-2020 01 22-15_07_17](https://user-images.githubusercontent.com/22619452/72900872-f4025080-3d28-11ea-9ab7-6c00cb7b22f6.png)
