### PR TITLE
Remove unnecessary clients.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3303,54 +3303,6 @@
         }
       }
     },
-    "@redhat-cloud-services/sources-client": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/sources-client/-/sources-client-1.0.11.tgz",
-      "integrity": "sha512-TyGjAGGLxUKF1fCpf+FJqfyUrMsWNomvdnE+eX8+amrokK327qleIUYt3TQnZX5mIB8VpnTJyVz/kHwqoBGs8A==",
-      "requires": {
-        "axios": "^0.18.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.18.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-          "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-          "requires": {
-            "follow-redirects": "1.5.10",
-            "is-buffer": "^2.0.2"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-        }
-      }
-    },
-    "@redhat-cloud-services/topological-inventory-client": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/topological-inventory-client/-/topological-inventory-client-1.0.37.tgz",
-      "integrity": "sha512-HFhg22YhSc6mFKB62bhG2N12RTNLdrg+vdODBSVuPSJXY0veWAuZ0+sl8chRPiS3zZiujsTFhIrgAjHwqrkruQ==",
-      "requires": {
-        "axios": "^0.19.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-          "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
-          "requires": {
-            "follow-redirects": "1.5.10",
-            "is-buffer": "^2.0.2"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-        }
-      }
-    },
     "@sentry/browser": {
       "version": "5.10.2",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.10.2.tgz",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "@redhat-cloud-services/frontend-components-notifications": "0.0.7",
     "@redhat-cloud-services/frontend-components-utilities": "0.0.15",
     "@redhat-cloud-services/rbac-client": "^1.0.12",
-    "@redhat-cloud-services/sources-client": "^1.0.11",
-    "@redhat-cloud-services/topological-inventory-client": "^1.0.37",
     "awesome-debounce-promise": "^2.1.0",
     "axios": "^0.19.0",
     "classnames": "^2.2.6",

--- a/src/helpers/platform/platform-helper.js
+++ b/src/helpers/platform/platform-helper.js
@@ -1,17 +1,9 @@
-import {
-  getAxiosInstance,
-  getSourcesApi,
-  getTopologocalInventoryApi,
-  getGraphqlInstance
-} from '../shared/user-login';
+import { getAxiosInstance, getGraphqlInstance } from '../shared/user-login';
 import {
   TOPOLOGICAL_INVENTORY_API_BASE,
   SOURCES_API_BASE
 } from '../../utilities/constants';
 import { defaultSettings } from '../shared/pagination';
-
-const sourcesApi = getSourcesApi();
-const topologicalApi = getTopologocalInventoryApi();
 const axiosInstance = getAxiosInstance();
 const graphqlInstance = getGraphqlInstance();
 
@@ -36,7 +28,7 @@ export const getPlatforms = () => {
 };
 
 export const getPlatform = (platformId) => {
-  return sourcesApi.showSource(platformId);
+  return axiosInstance.get(`${SOURCES_API_BASE}/sources/${platformId}`);
 };
 
 export const getPlatformItems = (platformId, filter, options) => {
@@ -48,7 +40,9 @@ export const getPlatformItems = (platformId, filter, options) => {
       }`
     );
   } else {
-    return topologicalApi.listServiceOfferings();
+    return axiosInstance.get(
+      `${TOPOLOGICAL_INVENTORY_API_BASE}/service_offerings`
+    );
   }
 };
 
@@ -64,7 +58,9 @@ export const getPlatformInventories = (
       }`
     );
   } else {
-    return topologicalApi.listServiceInventories(options);
+    return axiosInstance.get(
+      `${TOPOLOGICAL_INVENTORY_API_BASE}/service_inventories?limit=${options.limit}&offset=${options.offset}`
+    );
   }
 };
 

--- a/src/helpers/shared/user-login.js
+++ b/src/helpers/shared/user-login.js
@@ -3,8 +3,6 @@ import {
   RequestApi,
   WorkflowApi
 } from '@redhat-cloud-services/approval-client';
-import { DefaultApi as SourcesDefaultApi } from '@redhat-cloud-services/sources-client';
-import { DefaultApi as TopologicalDefaultApi } from '@redhat-cloud-services/topological-inventory-client';
 import {
   PortfolioApi,
   PortfolioItemApi,
@@ -15,17 +13,11 @@ import {
 } from '@redhat-cloud-services/catalog-client';
 
 import {
-  SOURCES_API_BASE,
-  TOPOLOGICAL_INVENTORY_API_BASE,
   CATALOG_API_BASE,
   APPROVAL_API_BASE,
   RBAC_API_BASE
 } from '../../utilities/constants';
-import {
-  AccessApi,
-  PrincipalApi,
-  GroupApi
-} from '@redhat-cloud-services/rbac-client';
+import { GroupApi } from '@redhat-cloud-services/rbac-client';
 import { stringify } from 'qs';
 
 const axiosInstance = axios.create({
@@ -67,30 +59,12 @@ const workflowApi = new WorkflowApi(
   APPROVAL_API_BASE,
   axiosInstance
 );
-const sourcesApi = new SourcesDefaultApi(
-  undefined,
-  SOURCES_API_BASE,
-  axiosInstance
-);
-const topologicalInventoryApi = new TopologicalDefaultApi(
-  undefined,
-  TOPOLOGICAL_INVENTORY_API_BASE,
-  axiosInstance
-);
 const iconApi = new IconApi(undefined, CATALOG_API_BASE, axiosInstance);
 const servicePlansApi = new ServicePlansApi(
   undefined,
   CATALOG_API_BASE,
   axiosInstance
 );
-
-export function getSourcesApi() {
-  return sourcesApi;
-}
-
-export function getTopologocalInventoryApi() {
-  return topologicalInventoryApi;
-}
 
 export function getPortfolioApi() {
   return portfolioApi;
@@ -112,21 +86,7 @@ export function getRequestsApi() {
   return requestsApi;
 }
 
-let rbacAccessApi = new AccessApi(undefined, RBAC_API_BASE, axiosInstance);
-let rbacPrincipalApi = new PrincipalApi(
-  undefined,
-  RBAC_API_BASE,
-  axiosInstance
-);
-let rbacGroupApi = new GroupApi(undefined, RBAC_API_BASE, axiosInstance);
-
-export function getRbacAccessApi() {
-  return rbacAccessApi;
-}
-
-export function getRbacPrincipalApi() {
-  return rbacPrincipalApi;
-}
+const rbacGroupApi = new GroupApi(undefined, RBAC_API_BASE, axiosInstance);
 
 export function getRbacGroupApi() {
   return rbacGroupApi;

--- a/src/test/helpers/shared/user-login.test.js
+++ b/src/test/helpers/shared/user-login.test.js
@@ -1,18 +1,7 @@
-import {
-  getSourcesApi,
-  getPortfolioApi
-} from '../../../helpers/shared/user-login';
-import {
-  SOURCES_API_BASE,
-  CATALOG_API_BASE
-} from '../../../utilities/constants';
+import { getPortfolioApi } from '../../../helpers/shared/user-login';
+import { CATALOG_API_BASE } from '../../../utilities/constants';
 
 describe('user login', () => {
-  it('should set correct basePath for sources api instance', () => {
-    const sources = getSourcesApi();
-    expect(sources.basePath).toEqual(SOURCES_API_BASE);
-  });
-
   it('should set correct basePath for ssp api instance', () => {
     const sspApi = getPortfolioApi();
     expect(sspApi.basePath).toEqual(CATALOG_API_BASE);


### PR DESCRIPTION
This is a first of series of PR which focuses on bundle size optimizations. The bigger effect will come after https://github.com/RedHatInsights/frontend-components/pull/340 is merged.

### Changes
- remove topological inventory client
- remove sources client

The catalog used one or two methods for API calls from each of these libraries. Because they are generated as a class, un-used methods cannot be ever tree shook.

Why is this necessary? By removing the topological inventory client itself, bundle size is reduced by 1 MB. See the relative size bellow. It has roughly the same size as the whole react-core library. The sources client is slightly smaller, but we were using only one method. The rest is handled by graphql calls.

![screenshot-127 0 0 1_8888-2020 02 03-16_47_22](https://user-images.githubusercontent.com/22619452/73667642-dcba5000-46a4-11ea-80a3-50b691cddbaa.png)
