### PR TITLE
Use approval_request_ref instead of id.

### DIFF
--- a/src/smart-components/order/order-detail/approval-request.js
+++ b/src/smart-components/order/order-detail/approval-request.js
@@ -25,7 +25,13 @@ const ApprovalRequests = () => {
             Request ID
           </TextListItem>
           <TextListItem component={TextListItemVariants.dd}>
-            {request.id}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={`${document.baseURI}ansible/catalog/approval/requests/detail/${request.approval_request_ref}`}
+            >
+              {request.approval_request_ref}
+            </a>
           </TextListItem>
           <TextListItem component={TextListItemVariants.dt}>
             Request created


### PR DESCRIPTION
### Changes
- use approval_request_ref instead of id in order detail screen
- the number is now a link that takes the user to approval detail

![approval link](https://user-images.githubusercontent.com/22619452/74137287-cc97f880-4bef-11ea-9177-90c645c5fba2.gif)
