### PR TITLE
Fixed overflow in share portfolio modal.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -325,26 +325,6 @@ a.pf-c-breadcrumb__item {
   height: 16px;
 }
 
-.share-group-modal{
-  .height-normalize {
-    height: 38px;
-  }
-  .share-column {
-    flex-grow: 1;
-    &:not(:first-child) {
-      max-width: 200px;
-      margin-left: 8px;
-    }
-    h4 {
-      margin: 0
-    }
-  }
-  &.group {
-    border-top: 1px solid #d2d2d2;
-    padding-top: 24px;
-  }
-}
-
 .app-tabs {
   border-bottom: 1px solid lightgrey;
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -230,6 +230,12 @@
   background-color: var(--pf-global--BackgroundColor--100)
 }
 
+.share-column {
+  .ddorg__pf4-component-mapper__select__single-value {
+    max-width: calc(100% - 70px);
+  }
+}
+
 /**
 * Update DDF select styles for select component
 */

--- a/src/forms/form-fields/shage-group-edit.js
+++ b/src/forms/form-fields/shage-group-edit.js
@@ -13,7 +13,7 @@ const ShareGroupEdit = ({ FieldProvider, label, ...props }) => {
   return (
     <div className="share-group-modal group">
       <Level>
-        <LevelItem className="share-column">
+        <LevelItem>
           <TextContent>
             <Text component={TextVariants.h4}>{label}</Text>
           </TextContent>

--- a/src/forms/form-fields/shage-group-edit.js
+++ b/src/forms/form-fields/shage-group-edit.js
@@ -2,31 +2,31 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { rawComponents } from '@data-driven-forms/pf4-component-mapper';
 import {
-  Level,
-  LevelItem,
   Text,
   TextContent,
-  TextVariants
+  TextVariants,
+  GridItem,
+  Grid
 } from '@patternfly/react-core';
 
 const ShareGroupEdit = ({ FieldProvider, label, ...props }) => {
   return (
-    <div className="share-group-modal group">
-      <Level>
-        <LevelItem>
-          <TextContent>
-            <Text component={TextVariants.h4}>{label}</Text>
-          </TextContent>
-        </LevelItem>
-        <LevelItem className="share-column">
-          <FieldProvider {...props}>
-            {({ input, ...props }) => (
-              <rawComponents.Select {...input} {...props} />
-            )}
-          </FieldProvider>
-        </LevelItem>
-      </Level>
-    </div>
+    <Grid gutter="md" className="share-column">
+      <GridItem span={7}>
+        <TextContent>
+          <Text component={TextVariants.h4}>{label}</Text>
+        </TextContent>
+      </GridItem>
+      <GridItem span={5}>
+        <FieldProvider
+          {...props}
+          menuIsPortal
+          render={({ input, ...props }) => (
+            <rawComponents.Select {...input} {...props} />
+          )}
+        />
+      </GridItem>
+    </Grid>
   );
 };
 

--- a/src/forms/form-fields/share-group-select.js
+++ b/src/forms/form-fields/share-group-select.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { rawComponents } from '@data-driven-forms/pf4-component-mapper';
-import { Level, LevelItem } from '@patternfly/react-core';
+import { Grid, GridItem } from '@patternfly/react-core';
 import asyncFormValidator from '../../utilities/async-form-validator';
 
 export const ShareGroupSelect = ({
@@ -12,38 +12,39 @@ export const ShareGroupSelect = ({
   permissions
 }) => {
   return (
-    <div className="share-group-modal">
-      <Level>
-        <LevelItem className="share-column">
-          <FieldProvider
-            name={inputName}
-            loadOptions={asyncFormValidator(loadOptions)}
-          >
-            {({ input, ...props }) => (
-              <rawComponents.Select
-                isSearchable
-                isClearable
-                loadOptions={asyncFormValidator(loadOptions)}
-                placeholder="Select group"
-                {...input}
-                {...props}
-              />
-            )}
-          </FieldProvider>
-        </LevelItem>
-        <LevelItem className="share-column">
-          <FieldProvider name={selectName} options={permissions}>
-            {({ input, ...props }) => (
-              <rawComponents.Select
-                placeholder="Select permission"
-                {...input}
-                {...props}
-              />
-            )}
-          </FieldProvider>
-        </LevelItem>
-      </Level>
-    </div>
+    <Grid gutter="md" className="share-column">
+      <GridItem span={7}>
+        <FieldProvider
+          name={inputName}
+          loadOptions={asyncFormValidator(loadOptions)}
+          render={({ input, ...props }) => (
+            <rawComponents.Select
+              isSearchable
+              isClearable
+              menuIsPortal
+              loadOptions={asyncFormValidator(loadOptions)}
+              placeholder="Select group"
+              {...input}
+              {...props}
+            />
+          )}
+        />
+      </GridItem>
+      <GridItem span={5}>
+        <FieldProvider
+          name={selectName}
+          options={permissions}
+          menuIsPortal
+          render={({ input, ...props }) => (
+            <rawComponents.Select
+              placeholder="Select permission"
+              {...input}
+              {...props}
+            />
+          )}
+        />
+      </GridItem>
+    </Grid>
   );
 };
 


### PR DESCRIPTION
### Changes
- ~~added max with to the select value container~~
- use grid layout to enforce correct width
- enabled portals for select menus to enable menu overflow over the modal container
- use render function instead of children in FieldProvider to prevent re-initialization after select change

### Before
![share modal select sizing](https://user-images.githubusercontent.com/22619452/74351565-8ee5cc00-4db7-11ea-9b65-957ca99f5248.png)

### After
![screenshot-ci foo redhat com_1337-2020 02 12-16_46_14](https://user-images.githubusercontent.com/22619452/74351540-84c3cd80-4db7-11ea-834a-5c064cd0391d.png)
