### PR TITLE
Add the 'delete' permission verb to the order/update sharing option

### DIFF
--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -3,11 +3,11 @@ export const SOURCES_API_BASE = `${process.env.BASE_PATH}/sources/v1.0`;
 export const APPROVAL_API_BASE = `${process.env.BASE_PATH}/approval/v1.0`;
 export const TOPOLOGICAL_INVENTORY_API_BASE = `${process.env.BASE_PATH}/topological-inventory/v1.0`;
 export const RBAC_API_BASE = `${process.env.BASE_PATH}/rbac/v1`;
-export const permissionValues = ['order', 'read', 'update'];
+export const permissionValues = ['delete', 'order', 'read', 'update'];
 
 export const permissionOptions = [
   {
-    value: 'order,read,update',
+    value: 'delete,order,read,update',
     label: 'Can order/edit'
   },
   {


### PR DESCRIPTION
Add the 'delete' verb to the order/update sharing option.
No UI change for the user - but selecting the 'order/update' option for sharing will now include the 'delete' verb: "delete,order,read,update'