### PR TITLE
Remove order button when source is unavailable.

### DIFF
--- a/src/presentational-components/styled-components/level.js
+++ b/src/presentational-components/styled-components/level.js
@@ -2,5 +2,5 @@ import styled from 'styled-components';
 import { LevelItem } from '@patternfly/react-core';
 
 export const StyledLevelItem = styled(LevelItem)`
-  align-items: ${({ alingEnd }) => (alingEnd ? 'end !important' : 'inherit')};
+  align-items: ${({ alignEnd }) => (alignEnd ? 'end !important' : 'inherit')};
 `;

--- a/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import {
+  Alert,
   Dropdown,
   DropdownItem,
   DropdownPosition,
@@ -18,19 +19,30 @@ const DetailToolbarActions = ({
   editSurveyUrl,
   isOpen,
   setOpen,
-  isFetching
+  isFetching,
+  availability
 }) => (
   <Fragment>
     <LevelItem>
-      <CatalogLink disabled={isFetching} pathname={orderUrl} preserveSearch>
-        <ButtonWithSpinner
-          isDisabled={isFetching}
-          showSpinner={isFetching}
-          variant="primary"
-        >
-          Order
-        </ButtonWithSpinner>
-      </CatalogLink>
+      {availability === 'available' ? (
+        <CatalogLink disabled={isFetching} pathname={orderUrl} preserveSearch>
+          <ButtonWithSpinner
+            isDisabled={isFetching}
+            showSpinner={isFetching}
+            variant="primary"
+            id="order-portfolio-item"
+          >
+            Order
+          </ButtonWithSpinner>
+        </CatalogLink>
+      ) : (
+        <Alert
+          id="unavailable-alert-info"
+          variant="info"
+          isInline
+          title="Source for this product is no longer available"
+        />
+      )}
     </LevelItem>
     {
       <LevelItem style={{ marginLeft: 16 }}>
@@ -97,7 +109,8 @@ DetailToolbarActions.propTypes = {
   workflowUrl: PropTypes.string.isRequired,
   isOpen: PropTypes.bool,
   setOpen: PropTypes.func.isRequired,
-  isFetching: PropTypes.bool
+  isFetching: PropTypes.bool,
+  availability: PropTypes.oneOf(['available', 'unavailable']).isRequired
 };
 
 DetailToolbarActions.defaultProps = {

--- a/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import {
-  Alert,
   Dropdown,
   DropdownItem,
   DropdownPosition,
@@ -24,25 +23,20 @@ const DetailToolbarActions = ({
 }) => (
   <Fragment>
     <LevelItem>
-      {availability === 'available' ? (
-        <CatalogLink disabled={isFetching} pathname={orderUrl} preserveSearch>
-          <ButtonWithSpinner
-            isDisabled={isFetching}
-            showSpinner={isFetching}
-            variant="primary"
-            id="order-portfolio-item"
-          >
-            Order
-          </ButtonWithSpinner>
-        </CatalogLink>
-      ) : (
-        <Alert
-          id="unavailable-alert-info"
-          variant="info"
-          isInline
-          title="Source for this product is no longer available"
-        />
-      )}
+      <CatalogLink
+        isDisabled={isFetching || availability === 'unavailable'}
+        pathname={orderUrl}
+        preserveSearch
+      >
+        <ButtonWithSpinner
+          isDisabled={isFetching || availability === 'unavailable'}
+          showSpinner={isFetching}
+          variant="primary"
+          id="order-portfolio-item"
+        >
+          Order
+        </ButtonWithSpinner>
+      </CatalogLink>
     </LevelItem>
     {
       <LevelItem style={{ marginLeft: 16 }}>

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
@@ -41,7 +41,8 @@ export const PortfolioItemDetailToolbar = ({
   product,
   setOpen,
   isFetching,
-  uploadIcon
+  uploadIcon,
+  availability
 }) => (
   <TopToolbar breadcrumbsSpacing={false}>
     <Level>
@@ -70,6 +71,7 @@ export const PortfolioItemDetailToolbar = ({
                 editSurveyUrl={`${url}/edit-survey`}
                 workflowUrl={`${url}/edit-workflow`}
                 isFetching={isFetching}
+                availability={availability}
                 {...args}
               />
             )}
@@ -98,7 +100,8 @@ PortfolioItemDetailToolbar.propTypes = {
   }).isRequired,
   setOpen: PropTypes.func.isRequired,
   isFetching: PropTypes.bool,
-  uploadIcon: PropTypes.func.isRequired
+  uploadIcon: PropTypes.func.isRequired,
+  availability: PropTypes.oneOf(['available', 'unavailable']).isRequired
 };
 
 PortfolioItemDetailToolbar.defaultProps = {

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, Fragment } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch, useRouteMatch } from 'react-router-dom';
-import { Grid, GridItem } from '@patternfly/react-core';
+import { Grid, GridItem, Alert } from '@patternfly/react-core';
 import { Section } from '@redhat-cloud-services/frontend-components/components/Section';
 
 import OrderModal from '../../common/order-modal';
@@ -76,6 +76,15 @@ const PortfolioItemDetail = () => {
               isFetching={isFetching}
               availability={source.availability_status}
             />
+            {source.availability_status === 'unavailable' && (
+              <Alert
+                className="pf-u-ml-lg pf-u-mr-lg"
+                id="unavailable-alert-info"
+                variant="info"
+                isInline
+                title="Platform for this product is unavailable"
+              />
+            )}
             <Grid className="pf-u-p-lg">
               <GridItem md={2}>
                 <ItemDetailInfoBar

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -74,6 +74,7 @@ const PortfolioItemDetail = () => {
               product={portfolioItem}
               setOpen={setOpen}
               isFetching={isFetching}
+              availability={source.availability_status}
             />
             <Grid className="pf-u-p-lg">
               <GridItem md={2}>

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
@@ -2,12 +2,16 @@
 
 exports[`<DetailToolbarActions /> should render correctly 1`] = `
 <DetailToolbarActions
+  availability="available"
   copyUrl="foo/copy"
+  editSurveyUrl="foo/edit-survey"
   editUrl="foo/baz"
   isFetching={false}
   isOpen={false}
   orderUrl="foo/bar"
+  pathname="foo/bar"
   setOpen={[MockFunction]}
+  workflowUrl="foo/workflow"
 >
   <LevelItem>
     <div>
@@ -50,16 +54,19 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                 onClick={[Function]}
               >
                 <ButtonWithSpinner
+                  id="order-portfolio-item"
                   isDisabled={false}
                   showSpinner={false}
                   variant="primary"
                 >
                   <Styled(Component)
+                    id="order-portfolio-item"
                     isDisabled={false}
                     variant="primary"
                   >
                     <Component
                       className="sc-AxjAm iMxqKn"
+                      id="order-portfolio-item"
                       isDisabled={false}
                       variant="primary"
                     >
@@ -74,6 +81,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                               false,
                             ],
                             "className": "sc-AxjAm iMxqKn",
+                            "id": "order-portfolio-item",
                             "isDisabled": false,
                             "variant": "primary",
                           }
@@ -82,6 +90,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                       >
                         <Button
                           className="sc-AxjAm iMxqKn"
+                          id="order-portfolio-item"
                           isDisabled={false}
                           ouiaContext={
                             Object {
@@ -96,6 +105,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                             aria-label={null}
                             className="pf-c-button pf-m-primary sc-AxjAm iMxqKn"
                             disabled={false}
+                            id="order-portfolio-item"
                             tabIndex={null}
                             type="button"
                           >
@@ -165,6 +175,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
               component={
                 <CatalogLink
                   nav={false}
+                  pathname="foo/workflow"
                   preserveSearch={true}
                   searchParams={Object {}}
                 >
@@ -178,6 +189,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
               component={
                 <CatalogLink
                   nav={false}
+                  pathname="foo/edit-survey"
                   preserveSearch={true}
                   searchParams={Object {}}
                 >
@@ -235,6 +247,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                 component={
                   <CatalogLink
                     nav={false}
+                    pathname="foo/workflow"
                     preserveSearch={true}
                     searchParams={Object {}}
                   >
@@ -248,6 +261,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                 component={
                   <CatalogLink
                     nav={false}
+                    pathname="foo/edit-survey"
                     preserveSearch={true}
                     searchParams={Object {}}
                   >
@@ -306,6 +320,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                     component={
                       <CatalogLink
                         nav={false}
+                        pathname="foo/workflow"
                         preserveSearch={true}
                         searchParams={Object {}}
                       >
@@ -319,6 +334,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                     component={
                       <CatalogLink
                         nav={false}
+                        pathname="foo/edit-survey"
                         preserveSearch={true}
                         searchParams={Object {}}
                       >
@@ -378,6 +394,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                     component={
                       <CatalogLink
                         nav={false}
+                        pathname="foo/workflow"
                         preserveSearch={true}
                         searchParams={Object {}}
                       >
@@ -391,6 +408,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                     component={
                       <CatalogLink
                         nav={false}
+                        pathname="foo/edit-survey"
                         preserveSearch={true}
                         searchParams={Object {}}
                       >

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
@@ -16,14 +16,14 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
   <LevelItem>
     <div>
       <CatalogLink
-        disabled={false}
+        isDisabled={false}
         nav={false}
         pathname="foo/bar"
         preserveSearch={true}
         searchParams={Object {}}
       >
         <Styled(Link)
-          disabled={false}
+          isDisabled={false}
           to={
             Object {
               "pathname": "foo/bar",
@@ -33,7 +33,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
         >
           <Link
             className="sc-AxiKw drCTeX"
-            disabled={false}
+            isDisabled={false}
             to={
               Object {
                 "pathname": "foo/bar",
@@ -43,14 +43,14 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
           >
             <LinkAnchor
               className="sc-AxiKw drCTeX"
-              disabled={false}
               href="foo/bar"
+              isDisabled={false}
               navigate={[Function]}
             >
               <a
                 className="sc-AxiKw drCTeX"
-                disabled={false}
                 href="foo/bar"
+                isDisabled={false}
                 onClick={[Function]}
               >
                 <ButtonWithSpinner

--- a/src/test/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.test.js
@@ -30,28 +30,4 @@ describe('<DetailToolbarActions />', () => {
     );
     expect(toJson(wrapper.find(DetailToolbarActions))).toMatchSnapshot();
   });
-
-  it('should render order button when source is available', () => {
-    const wrapper = mount(
-      <MemoryRouter>
-        <DetailToolbarActions {...initialProps} />
-      </MemoryRouter>
-    );
-    expect(wrapper.find('button#order-portfolio-item')).toHaveLength(1);
-    expect(
-      wrapper.find('#unavailable-alert-info.pf-c-alert.pf-m-inline')
-    ).toHaveLength(0);
-  });
-
-  it('should render alert when source is unavailable', () => {
-    const wrapper = mount(
-      <MemoryRouter>
-        <DetailToolbarActions {...initialProps} availability="unavailable" />
-      </MemoryRouter>
-    );
-    expect(
-      wrapper.find('#unavailable-alert-info.pf-c-alert.pf-m-inline')
-    ).toHaveLength(1);
-    expect(wrapper.find('button#order-portfolio-item')).toHaveLength(0);
-  });
 });

--- a/src/test/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.test.js
@@ -14,7 +14,11 @@ describe('<DetailToolbarActions />', () => {
       editUrl: 'foo/baz',
       isOpen: false,
       setOpen: jest.fn(),
-      copyUrl: 'foo/copy'
+      copyUrl: 'foo/copy',
+      availability: 'available',
+      editSurveyUrl: 'foo/edit-survey',
+      workflowUrl: 'foo/workflow',
+      pathname: 'foo/bar'
     };
   });
 
@@ -25,5 +29,29 @@ describe('<DetailToolbarActions />', () => {
       </MemoryRouter>
     );
     expect(toJson(wrapper.find(DetailToolbarActions))).toMatchSnapshot();
+  });
+
+  it('should render order button when source is available', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <DetailToolbarActions {...initialProps} />
+      </MemoryRouter>
+    );
+    expect(wrapper.find('button#order-portfolio-item')).toHaveLength(1);
+    expect(
+      wrapper.find('#unavailable-alert-info.pf-c-alert.pf-m-inline')
+    ).toHaveLength(0);
+  });
+
+  it('should render alert when source is unavailable', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <DetailToolbarActions {...initialProps} availability="unavailable" />
+      </MemoryRouter>
+    );
+    expect(
+      wrapper.find('#unavailable-alert-info.pf-c-alert.pf-m-inline')
+    ).toHaveLength(1);
+    expect(wrapper.find('button#order-portfolio-item')).toHaveLength(0);
   });
 });


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1283

I went with alert instead of disabling the button. The user must know why the button is available and popovers are totally buggy in PF. But of course, it can be changed if you decide the disabled button is preferable.

Also, I fixed a typo that was forcing the portfolio item name to be aligned to the bottom.

### Available source:
![screenshot-ci foo redhat com_1337-2020 02 27-09_48_34](https://user-images.githubusercontent.com/22619452/75427285-85776a80-5946-11ea-90ae-1ee84f37badc.png)

### Unavailable source:
![screenshot-ci foo redhat com_1337-2020 02 27-09_40_24](https://user-images.githubusercontent.com/22619452/75427312-90ca9600-5946-11ea-8fff-2a2ccd7ff23e.png)


Screenshot from testing:
![Screenshot from 2020-02-28 12-25-46](https://user-images.githubusercontent.com/12769982/75570711-b67a9c80-5a25-11ea-8cc8-8fdc50c09392.png)

