### PR TITLE
Fixed missing section.ins-l-content class.

### DIFF
--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -226,6 +226,52 @@ a.breadcrumb-active {
 .pf-l-flex.align-items-center {
   align-items: center;
 }
+
+/**
+ * frontend components override
+ */
+:root {
+  --ins-color--orange: #ec7a08;
+}
+
+button:focus {
+  outline: none;
+}
+
+section.ins-l-content {
+  padding: var(--pf-global--spacer--lg); 
+}
+
+section.ins-l-button-group {
+  margin: 24px 0px;
+  margin: 1.5rem 0rem; 
+}
+
+section.ins-l-button-group > * {
+  display: inline; 
+}
+
+section.ins-l-button-group * + * {
+  margin-left: 5px;
+  margin-left: 0.3125rem; 
+}
+
+section.ins-l-icon-group * + * {
+  margin-left: 10px; 
+}
+
+section.ins-l-icon-group__with-major * + * {
+  margin-left: 7.5px; 
+}
+
+section.ins-l-icon-group__with-major .ins-battery:last-of-type {
+  padding-left: 15px;
+  border-left: 2px solid #eaeaea; 
+}
+section.ins-l-icon-group__with-major .ins-battery:last-of-type span.label {
+  font-weight: 500;
+  margin: 0 10px; 
+}
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
### Changes
- added frontend component class override

For some reason, the CSS rules for `section.ins-l-content` are not making it into a production build bundle. It is probably caused by frontend components, but the cause is unknown so far. This was causing missing spacing in the main layouts:

![screenshot-ci cloud redhat com-2020 03 03-13_21_12](https://user-images.githubusercontent.com/22619452/75775253-dd044480-5d51-11ea-9134-ca173455c2b4.png)

`section.ins-l-content` was missing in the build bundle but this override inserts it correctly.
