### PR TITLE
Exclude css files from tree shaking.

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -28,8 +28,9 @@ const commonConfig = {
         use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
       },
       {
-        test: /\.s?[ac]ss$/,
-        use: ['style-loader', 'css-loader', 'sass-loader']
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+        sideEffects: true
       },
       {
         test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,

--- a/package.json
+++ b/package.json
@@ -122,8 +122,5 @@
   },
   "insights": {
     "appname": "catalog"
-  },
-  "sideEffects": [
-    "*.scss"
-  ]
+  }
 }


### PR DESCRIPTION
fixes: https://projects.engineering.redhat.com/browse/SSP-1316

In production mode, webpack was marking all external CSS files as side effects (never used) so it got rid of them before the style-loader could inject them into the bundle and they never made it to the production build.

That is why we have been missing some CSS in production, but they were in the dev build.