### PR TITLE
Fixed opened cancel modal after cancel was pressed.

### DIFF
--- a/src/smart-components/order/order-detail/order-toolbar-actions.js
+++ b/src/smart-components/order/order-detail/order-toolbar-actions.js
@@ -18,7 +18,10 @@ const OrderToolbarActions = ({ state, orderId, portfolioItemName }) => {
       <CancelOrderModal
         onClose={() => setCancelModalOpen(false)}
         isOpen={cancelModalOpen}
-        cancelOrder={() => dispatch(cancelOrder(orderId))}
+        cancelOrder={() => {
+          setCancelModalOpen(false);
+          dispatch(cancelOrder(orderId));
+        }}
         name={portfolioItemName}
       />
       <ActionGroup>

--- a/src/smart-components/order/order-item.js
+++ b/src/smart-components/order/order-item.js
@@ -111,6 +111,7 @@ const OrderItem = memo(
                                   className="pf-u-mb-0"
                                   component={TextVariants.small}
                                 >
+                                  Ordered&nbsp;
                                   <DateFormat
                                     date={item.created_at}
                                     variant="relative"
@@ -130,6 +131,7 @@ const OrderItem = memo(
                                   className="pf-u-mb-0"
                                   component={TextVariants.small}
                                 >
+                                  Last updated&nbsp;
                                   <DateFormat
                                     date={
                                       item.orderItems[0] &&


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1334

- added missing callback for closing cancel modal after cancel action was successful 