### PR TITLE
Add autorefresh for approval requests in order detail screen.

### DIFF
--- a/src/helpers/order/order-helper.js
+++ b/src/helpers/order/order-helper.js
@@ -142,3 +142,8 @@ export const getOrderDetail = (params) => {
     )
   ]);
 };
+
+export const getApprovalRequests = (orderItemId) =>
+  axiosInstance.get(
+    `${CATALOG_API_BASE}/order_items/${orderItemId}/approval_requests`
+  );

--- a/src/redux/action-types.js
+++ b/src/redux/action-types.js
@@ -66,6 +66,7 @@ export const SET_OPENAPI_SCHEMA = '@@open-api/set-schema';
  * TODO Prefix existing action types
  */
 export const SET_ORDER_DETAIL = '@@orders/set-order-detail';
+export const FETCH_APPROVAL_REQUESTS = '@@orders/fetch-order-requests';
 
 /*
  * Portfolio actions

--- a/src/redux/actions/order-actions.js
+++ b/src/redux/actions/order-actions.js
@@ -143,3 +143,21 @@ export const fetchOrderDetails = (params) => (dispatch) => {
       })
     );
 };
+
+export const fetchApprovalRequests = (orderItemId) => (dispatch) => {
+  dispatch({ type: `${ActionTypes.FETCH_APPROVAL_REQUESTS}_PENDING` });
+  return OrderHelper.getApprovalRequests(orderItemId)
+    .then((data) => {
+      dispatch({
+        type: `${ActionTypes.FETCH_APPROVAL_REQUESTS}_FULFILLED`,
+        payload: data
+      });
+      return data;
+    })
+    .catch((err) =>
+      dispatch({
+        type: `${ActionTypes.FETCH_APPROVAL_REQUESTS}_REJECTED`,
+        payload: err
+      })
+    );
+};

--- a/src/redux/reducers/order-reducer.js
+++ b/src/redux/reducers/order-reducer.js
@@ -10,7 +10,8 @@ import {
   SET_LOADING_STATE,
   SET_ORDERS,
   FETCH_ORDERS,
-  SET_ORDER_DETAIL
+  SET_ORDER_DETAIL,
+  FETCH_APPROVAL_REQUESTS
 } from '../action-types';
 import { defaultSettings } from '../../helpers/shared/pagination';
 // Initial State
@@ -81,6 +82,10 @@ const setOrderDetail = (state, { payload }) => ({
   ...state,
   orderDetail: payload
 });
+const updateOrderApprovalRequests = (state, { payload }) => ({
+  ...state,
+  orderDetail: { ...state.orderDetail, approvalRequest: payload }
+});
 
 export default {
   [`${FETCH_SERVICE_PLANS}_PENDING`]: setLoadingState,
@@ -102,5 +107,6 @@ export default {
   [`${FETCH_ORDERS}_PENDING`]: setLoadingState,
   [SET_ORDERS]: setOrders,
   [`${SET_ORDER_DETAIL}_FULFILLED`]: setOrderDetail,
-  [SET_ORDER_DETAIL]: setOrderDetail
+  [SET_ORDER_DETAIL]: setOrderDetail,
+  [`${FETCH_APPROVAL_REQUESTS}_FULFILLED`]: updateOrderApprovalRequests
 };

--- a/src/smart-components/order/order-detail/approval-request.js
+++ b/src/smart-components/order/order-detail/approval-request.js
@@ -1,73 +1,116 @@
-import React, { Fragment } from 'react';
-import { useSelector } from 'react-redux';
+import React, { Fragment, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import {
+  Bullseye,
+  Flex,
+  Spinner,
   TextContent,
   Text,
   TextVariants,
   TextList,
   TextListVariants,
   TextListItem,
-  TextListItemVariants
+  TextListItemVariants,
+  Title
 } from '@patternfly/react-core';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/DateFormat';
+import { fetchApprovalRequests } from '../../../redux/actions/order-actions';
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const checkRequest = async (fetchRequests) => {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const result = await fetchRequests();
+    if (result.data.length > 0) {
+      return 'Finished';
+    }
+
+    await delay(3000);
+  }
+};
 
 const ApprovalRequests = () => {
-  const { order, approvalRequest } = useSelector(
+  const dispatch = useDispatch();
+  const { order, approvalRequest, orderItem } = useSelector(
     ({ orderReducer: { orderDetail } }) => orderDetail
   );
 
+  useEffect(() => {
+    if (approvalRequest.data.length === 0) {
+      checkRequest(() => dispatch(fetchApprovalRequests(orderItem.id)));
+    }
+  }, []);
+
   return (
     <TextContent>
-      <Text component={TextVariants.h2}>Approval requests</Text>
-      {approvalRequest.data.map((request) => (
-        <TextList key={request.id} component={TextListVariants.dl}>
-          <TextListItem component={TextListItemVariants.dt}>
-            Request ID
-          </TextListItem>
-          <TextListItem component={TextListItemVariants.dd}>
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href={`${document.baseURI}ansible/catalog/approval/requests/detail/${request.approval_request_ref}`}
-            >
-              {request.approval_request_ref}
-            </a>
-          </TextListItem>
-          <TextListItem component={TextListItemVariants.dt}>
-            Request created
-          </TextListItem>
-          <TextListItem component={TextListItemVariants.dd}>
-            <DateFormat date={order.created_at} variant="relative" />
-          </TextListItem>
-          <TextListItem component={TextListItemVariants.dt}>State</TextListItem>
-          <TextListItem component={TextListItemVariants.dd}>
-            {request.state}
-          </TextListItem>
-          {request.reason && (
-            <Fragment>
+      {approvalRequest.data.length === 0 ? (
+        <Bullseye>
+          <Flex breakpointMods={[{ modifier: 'column' }, { modifier: 'grow' }]}>
+            <Bullseye>
+              <Title>Creating approval request</Title>
+            </Bullseye>
+            <Bullseye>
+              <Spinner size="xl" />
+            </Bullseye>
+          </Flex>
+        </Bullseye>
+      ) : (
+        <Fragment>
+          <Text component={TextVariants.h2}>Approval requests</Text>
+          {approvalRequest.data.map((request) => (
+            <TextList key={request.id} component={TextListVariants.dl}>
               <TextListItem component={TextListItemVariants.dt}>
-                Approval reason
+                Request ID
               </TextListItem>
               <TextListItem component={TextListItemVariants.dd}>
-                {request.reason}
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={`${document.baseURI}ansible/catalog/approval/requests/detail/${request.approval_request_ref}`}
+                >
+                  {request.approval_request_ref}
+                </a>
               </TextListItem>
-            </Fragment>
-          )}
-          {request.request_completed_at && (
-            <Fragment>
               <TextListItem component={TextListItemVariants.dt}>
-                Completed at
+                Request created
               </TextListItem>
               <TextListItem component={TextListItemVariants.dd}>
-                <DateFormat
-                  date={request.request_completed_at}
-                  variant="relative"
-                />
+                <DateFormat date={order.created_at} variant="relative" />
               </TextListItem>
-            </Fragment>
-          )}
-        </TextList>
-      ))}
+              <TextListItem component={TextListItemVariants.dt}>
+                State
+              </TextListItem>
+              <TextListItem component={TextListItemVariants.dd}>
+                {request.state}
+              </TextListItem>
+              {request.reason && (
+                <Fragment>
+                  <TextListItem component={TextListItemVariants.dt}>
+                    Approval reason
+                  </TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>
+                    {request.reason}
+                  </TextListItem>
+                </Fragment>
+              )}
+              {request.request_completed_at && (
+                <Fragment>
+                  <TextListItem component={TextListItemVariants.dt}>
+                    Completed at
+                  </TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>
+                    <DateFormat
+                      date={request.request_completed_at}
+                      variant="relative"
+                    />
+                  </TextListItem>
+                </Fragment>
+              )}
+            </TextList>
+          ))}
+        </Fragment>
+      )}
     </TextContent>
   );
 };


### PR DESCRIPTION
### Changes
If there are no approval requests for order item, this spinner will show and it will call the API periodically every 3sec, until there are some.

## We should not use this a patter. This is just a placeholder until there is a better way to listen to async tasks from UI.

![approval-polling](https://user-images.githubusercontent.com/22619452/76431349-bed1c080-63b1-11ea-9c6c-ee03c153d531.gif)
