### PR TITLE
Wait for chrome user authentication.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,10 +57,13 @@ const App = () => {
             )
           })
         ),
-      insights.chrome.auth.getUser(),
-      insights.chrome
-        .getUserPermissions()
-        .then((data) => setUserPermissions(data))
+      insights.chrome.auth
+        .getUser()
+        .then(() =>
+          insights.chrome
+            .getUserPermissions()
+            .then((data) => setUserPermissions(data))
+        )
     ]).then(() => setAuth(true));
 
     insights.chrome.identifyApp('catalog');


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1344

### Issues
The UI is trying to access the permissions data before the authentication finished.
That throws a rbac error and there are no permissions data set to the app context and the user gets kicked out to a 401 page.

The permission call now waits for the chrome to authorize the user.
