### PR TITLE
Prefetch select initialValues on first render to avoid missing options.

### DIFF
--- a/src/helpers/approval/approval-helper.js
+++ b/src/helpers/approval/approval-helper.js
@@ -4,16 +4,20 @@ import { defaultSettings } from '../shared/pagination';
 
 export const getApprovalWorkflows = () => getWorkflowApi().listWorkflows();
 
-export const loadWorkflowOptions = (filterValue = '') =>
-  getAxiosInstance()
+export const loadWorkflowOptions = (filterValue = '', initialLookup = []) => {
+  const initialLookupQuery = initialLookup
+    .map((workflow) => `filter[id][]=${workflow}`)
+    .join('&');
+
+  return getAxiosInstance()
     .get(
-      `${APPROVAL_API_BASE}/workflows${
-        filterValue.length > 0 ? `/?filter[name][contains]=${filterValue}` : ''
-      }`
+      `${APPROVAL_API_BASE}/workflows?filter[name][contains]=${filterValue}&${initialLookupQuery ||
+        ''}`
     )
     .then(({ data }) =>
       data.map(({ id, name }) => ({ label: name, value: id }))
     );
+};
 
 export const updateWorkflows = (unlinkIds, linkIds, resourceObject) => {
   const unlinkPromises = unlinkIds

--- a/src/test/presentational-components/shared/__snapshots__/pf4-select-wrapper.test.js.snap
+++ b/src/test/presentational-components/shared/__snapshots__/pf4-select-wrapper.test.js.snap
@@ -22,6 +22,7 @@ exports[`<Pf4SelectWrapper /> should render correctly 1`] = `
     }
     isSearchable={false}
     isValid={true}
+    meta={Object {}}
     multi={false}
     options={
       Array [
@@ -58,6 +59,12 @@ exports[`<Pf4SelectWrapper /> should render correctly in error state 1`] = `
     }
     isSearchable={false}
     isValid={false}
+    meta={
+      Object {
+        "error": "Error",
+        "touched": true,
+      }
+    }
     multi={false}
     options={
       Array [
@@ -100,6 +107,7 @@ exports[`<Pf4SelectWrapper /> should render correctly with description 1`] = `
     }
     isSearchable={false}
     isValid={true}
+    meta={Object {}}
     multi={false}
     options={
       Array [

--- a/src/test/smart-components/common/edit-approval-workflow.test.js
+++ b/src/test/smart-components/common/edit-approval-workflow.test.js
@@ -153,18 +153,32 @@ describe('<EditApprovalWorkflow />', () => {
 
   it('should unlink/link unselected/selected workflows', async (done) => {
     const store = mockStore(initialState);
-    mockApi.onGet(`${APPROVAL_API_BASE}/workflows`).replyOnce(200, {
-      data: [
-        {
-          name: 'workflow1',
-          id: '111'
-        },
-        {
-          name: 'workflow2',
-          id: '222'
-        }
-      ]
-    });
+    mockApi
+      .onGet(
+        `${APPROVAL_API_BASE}/workflows?filter[name][contains]=&filter[id][]=111`
+      )
+      .replyOnce(200, {
+        data: [
+          {
+            name: 'workflow1',
+            id: '111'
+          }
+        ]
+      });
+    mockApi
+      .onGet(`${APPROVAL_API_BASE}/workflows?filter[name][contains]=&`)
+      .reply(200, {
+        data: [
+          {
+            name: 'workflow1',
+            id: '111'
+          },
+          {
+            name: 'workflow2',
+            id: '222'
+          }
+        ]
+      });
     mockApi
       .onGet(
         `${APPROVAL_API_BASE}/workflows/?app_name=catalog&object_type=Portfolio&object_id=123&filter[name][contains]=&limit=50&offset=0`


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-924

### Issues

Select expects its initial values to be included in the first `loadOptions` call. That is required due to incomplete information it gets. Initial values are just literals but options are objects with value and label. So if the initial value is not in options it gets removed. And because API returns only first 100 items, values from second pages were removed on the first render.

Now, the initial load options request for approval filters specifically for selected values alongside the rest of the options.

I tested it by limiting the workflow options request to one or two records.