### PR TITLE
Fixed missing permissions for add products button.

### DIFF
--- a/src/smart-components/portfolio/portfolio-empty-state.js
+++ b/src/smart-components/portfolio/portfolio-empty-state.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { SearchIcon, WrenchIcon } from '@patternfly/react-icons';
 
@@ -6,14 +6,27 @@ import ContentGalleryEmptyState, {
   EmptyStatePrimaryAction
 } from '../../presentational-components/shared/content-gallery-empty-state';
 import { Button } from '@patternfly/react-core';
+import UserContext from '../../user-context';
+import { hasPermission } from '../../helpers/shared/helpers';
 
 const PortfolioEmptyState = ({ url, handleFilterChange, meta }) => {
+  const { permissions } = useContext(UserContext);
   const NoDataAction = () => (
-    <EmptyStatePrimaryAction url={url} label="Add products" />
+    <EmptyStatePrimaryAction
+      url={url}
+      label="Add products"
+      hasPermission={hasPermission(permissions, [
+        'catalog:portfolio_items:create'
+      ])}
+    />
   );
 
   const FilterAction = () => (
-    <Button variant="link" onClick={() => handleFilterChange('')}>
+    <Button
+      id="clear-portfolio-filter"
+      variant="link"
+      onClick={() => handleFilterChange('')}
+    >
       Clear all filters
     </Button>
   );

--- a/src/test/smart-components/portfolio/portfolio-empty-state.test.js
+++ b/src/test/smart-components/portfolio/portfolio-empty-state.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import PortfolioEmptyState from '../../../smart-components/portfolio/portfolio-empty-state';
+import UserContext from '../../../user-context';
+import CatalogLink from '../../../smart-components/common/catalog-link';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('<PortfolioEmptyState />', () => {
+  const initialProps = {
+    url: 'foo/bar',
+    handleFilterChange: jest.fn()
+  };
+
+  it('should render empty state for noData and no permissions', () => {
+    const wrapper = mount(
+      <UserContext.Provider
+        value={{ permissions: [{ permission: 'wrong:permission:rule' }] }}
+      >
+        <PortfolioEmptyState {...initialProps} meta={{ noData: true }} />
+      </UserContext.Provider>
+    );
+
+    expect(wrapper.find(CatalogLink)).toHaveLength(0);
+  });
+
+  it('should render empty state for noData with add products button', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <UserContext.Provider
+          value={{
+            permissions: [{ permission: 'catalog:portfolio_items:create' }]
+          }}
+        >
+          <PortfolioEmptyState {...initialProps} meta={{ noData: true }} />
+        </UserContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(wrapper.find(CatalogLink)).toHaveLength(1);
+  });
+
+  it('should render empty state for no filter result with clear filters action', () => {
+    const handleFilterChange = jest.fn();
+    const wrapper = mount(
+      <UserContext.Provider
+        value={{ permissions: [{ permission: 'wrong:permission:rule' }] }}
+      >
+        <PortfolioEmptyState
+          {...initialProps}
+          handleFilterChange={handleFilterChange}
+          meta={{ noData: false }}
+        />
+      </UserContext.Provider>
+    );
+
+    expect(wrapper.find('button#clear-portfolio-filter')).toHaveLength(1);
+    wrapper.find('button#clear-portfolio-filter').simulate('click');
+    expect(handleFilterChange).toHaveBeenCalledWith('');
+  });
+});


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1362

### Issues
- no permissions on add products button in portfolio empty state

@gmcculloug I've used `catalog:portfolio_items:create` for now. I expect that this will be a part of user capabilities later on. We should probably also prepare some messages for the users if they don't have permission to add portfolio items.