### PR TITLE
Remove duplicate portfolio fetch

### DIFF
--- a/src/helpers/portfolio/portfolio-helper.js
+++ b/src/helpers/portfolio/portfolio-helper.js
@@ -202,7 +202,6 @@ export const getPortfolioItemDetail = (params) =>
     axiosInstance.get(
       `${CATALOG_API_BASE}/portfolio_items/${params.portfolioItem}`
     ),
-    axiosInstance.get(`${CATALOG_API_BASE}/portfolios/${params.portfolio}`),
     axiosInstance
       .get(`${SOURCES_API_BASE}/sources/${params.source}`)
       .catch((error) => {

--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -388,15 +388,15 @@ export const updatePortfolioItem = (values) => (dispatch, getState) => {
     );
 };
 
-export const getPortfolioItemDetail = (params) => (dispatch) => {
+export const getPortfolioItemDetail = (params) => (dispatch, getState) => {
   dispatch({ type: `${ActionTypes.SELECT_PORTFOLIO_ITEM}_PENDING` });
   return PortfolioHelper.getPortfolioItemDetail(params).then(
-    ([portfolioItem, portfolio, source]) =>
+    ([portfolioItem, source]) =>
       dispatch({
         type: `${ActionTypes.SELECT_PORTFOLIO_ITEM}_FULFILLED`,
         payload: {
           portfolioItem,
-          portfolio,
+          portfolio: getState().portfolioReducer.selectedPortfolio,
           source
         }
       })

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-info-bar.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-info-bar.test.js.snap
@@ -218,7 +218,7 @@ exports[`<ItemDetailInfoBar /> should render correctly 1`] = `
                     zIndex={9999}
                   >
                     <span>
-                      12 months ago
+                      Just now
                     </span>
                     <Portal
                       containerInfo={
@@ -461,7 +461,7 @@ exports[`<ItemDetailInfoBar /> should render correctly with fallback values with
                     zIndex={9999}
                   >
                     <span>
-                      12 months ago
+                      Just now
                     </span>
                     <Portal
                       containerInfo={
@@ -732,7 +732,7 @@ exports[`<ItemDetailInfoBar /> should render correctly with vendor 1`] = `
                     zIndex={9999}
                   >
                     <span>
-                      12 months ago
+                      Just now
                     </span>
                     <Portal
                       containerInfo={

--- a/src/test/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.test.js
@@ -6,6 +6,15 @@ import ItemDetailInfoBar from '../../../../smart-components/portfolio/portfolio-
 
 describe('<ItemDetailInfoBar />', () => {
   let initialProps;
+  beforeAll(() => {
+    Date.now = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() =>
+        new Date(
+          'Fri Mar 22 2018 08:36:57 GMT+0100 (Central European Standard Time)'
+        ).getTime()
+      );
+  });
   beforeEach(() => {
     initialProps = {
       product: {

--- a/src/test/smart-components/portfolio/portfolio.test.js
+++ b/src/test/smart-components/portfolio/portfolio.test.js
@@ -470,6 +470,11 @@ describe('<Portfolio />', () => {
 
     mockApi
       .onGet(
+        `${CATALOG_API_BASE}/portfolios/123/portfolio_items?filter[name][contains_i]=nothing&limit=0&offset=0`
+      )
+      .replyOnce(200, { data: [], meta: {} });
+    mockApi
+      .onGet(
         `${CATALOG_API_BASE}/portfolios/321/portfolio_items?filter[name][contains_i]=&limit=50&offset=0`
       )
       .replyOnce(200, { data: [], meta: {} });


### PR DESCRIPTION
### Changes
- remove unnecessary portfolio request
  - portfolio item detail route is nested under portfolio route
  - data about portfolio are available in store, there is no need for additional request
- fixate date now prototype method to always return certain date to avoid snapshot fails