### PR TITLE
Portfolio item user capabilities

### DIFF
--- a/src/helpers/shared/helpers.js
+++ b/src/helpers/shared/helpers.js
@@ -72,9 +72,7 @@ export const readableBytes = (bytes) => {
   return (bytes / Math.pow(1024, i)).toFixed(2) * 1 + ' ' + sizes[i];
 };
 
-export const hasPermission = (userPermissions, permissions) =>
-  userPermissions
-    ? permissions.every((permission) =>
-        userPermissions.find((item) => item.permission === permission)
-      )
-    : false;
+export const hasPermission = (userPermissions = [], permissions = []) =>
+  permissions.every((permission) =>
+    userPermissions.find((item) => item.permission === permission)
+  );

--- a/src/redux/reducers/portfolio-reducer.js
+++ b/src/redux/reducers/portfolio-reducer.js
@@ -31,7 +31,11 @@ export const portfoliosInitialState = {
     }
   },
   portfolioItem: {
-    portfolioItem: {}
+    portfolioItem: {
+      metadata: {
+        user_capabilities: {}
+      }
+    }
   },
   portfolios: {
     data: [],

--- a/src/routing/catalog-route.js
+++ b/src/routing/catalog-route.js
@@ -5,19 +5,43 @@ import PropTypes from 'prop-types';
 import { hasPermission } from '../helpers/shared/helpers';
 import { UnauthorizedRedirect } from '../smart-components/error-pages/error-redirects';
 
-const CatalogRoute = ({ permissions, ...props }) => {
+const resolveCapability = (userCapabilities, requiredCapabilities) =>
+  Array.isArray(requiredCapabilities)
+    ? requiredCapabilities.some((capability) => userCapabilities[capability])
+    : userCapabilities[requiredCapabilities];
+
+const CatalogRoute = ({
+  permissions,
+  userCapabilities,
+  requiredCapabilities,
+  ...props
+}) => {
   const { permissions: userPermissions } = useContext(UserContext);
+
+  if (
+    requiredCapabilities &&
+    !resolveCapability(userCapabilities, requiredCapabilities)
+  ) {
+    return <UnauthorizedRedirect />;
+  }
+
   const hasPermissions = hasPermission(userPermissions, permissions);
 
   return hasPermissions ? <Route {...props} /> : <UnauthorizedRedirect />;
 };
 
 CatalogRoute.propTypes = {
-  permissions: PropTypes.arrayOf(PropTypes.string)
+  permissions: PropTypes.arrayOf(PropTypes.string),
+  userCapabilities: PropTypes.object,
+  requiredCapabilities: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ])
 };
 
 CatalogRoute.defaultProps = {
-  permissions: []
+  permissions: [],
+  userCapabilities: {}
 };
 
 export default CatalogRoute;

--- a/src/routing/catalog-route.js
+++ b/src/routing/catalog-route.js
@@ -5,10 +5,20 @@ import PropTypes from 'prop-types';
 import { hasPermission } from '../helpers/shared/helpers';
 import { UnauthorizedRedirect } from '../smart-components/error-pages/error-redirects';
 
-const resolveCapability = (userCapabilities, requiredCapabilities) =>
-  Array.isArray(requiredCapabilities)
-    ? requiredCapabilities.some((capability) => userCapabilities[capability])
-    : userCapabilities[requiredCapabilities];
+const ReidrectOnAccess = (props) => (
+  <Route {...props}>
+    <UnauthorizedRedirect />
+  </Route>
+);
+
+const hasCapability = (userCapabilities, requiredCapabilities) =>
+  requiredCapabilities
+    ? Array.isArray(requiredCapabilities)
+      ? requiredCapabilities.some(
+          (capability) => userCapabilities[capability] !== false
+        )
+      : userCapabilities[requiredCapabilities] !== false
+    : true;
 
 const CatalogRoute = ({
   permissions,
@@ -17,17 +27,15 @@ const CatalogRoute = ({
   ...props
 }) => {
   const { permissions: userPermissions } = useContext(UserContext);
+  const hasAccess =
+    hasCapability(userCapabilities, requiredCapabilities) &&
+    hasPermission(userPermissions, permissions);
 
-  if (
-    requiredCapabilities &&
-    !resolveCapability(userCapabilities, requiredCapabilities)
-  ) {
-    return <UnauthorizedRedirect />;
+  if (!hasAccess) {
+    return <ReidrectOnAccess {...props} />;
   }
 
-  const hasPermissions = hasPermission(userPermissions, permissions);
-
-  return hasPermissions ? <Route {...props} /> : <UnauthorizedRedirect />;
+  return <Route {...props} />;
 };
 
 CatalogRoute.propTypes = {

--- a/src/smart-components/common/catalog-link.js
+++ b/src/smart-components/common/catalog-link.js
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types';
 import { Link, NavLink, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
-const StyledLink = styled(Link)`
+const StyledLink = styled(({ isDisabled, ...props }) => <Link {...props} />)`
   pointer-events: ${({ isDisabled }) => (isDisabled ? 'none' : 'initial')};
 `;
 
-const StyledNavLink = styled(NavLink)`
+const StyledNavLink = styled(({ isDisabled, ...props }) => (
+  <NavLink {...props} />
+))`
   pointer-events: ${({ isDisabled }) => (isDisabled ? 'none' : 'initial')};
 `;
 

--- a/src/smart-components/common/edit-approval-workflow.js
+++ b/src/smart-components/common/edit-approval-workflow.js
@@ -118,8 +118,12 @@ EditApprovalWorkflow.propTypes = {
   objectType: PropTypes.string.isRequired,
   objectName: PropTypes.func,
   removeQuery: PropTypes.bool,
-  querySelector: PropTypes.oneOf(['portfolio', 'platform', 'inventory'])
-    .isRequired
+  querySelector: PropTypes.oneOf([
+    'portfolio',
+    'platform',
+    'inventory',
+    'portfolio-item'
+  ]).isRequired
 };
 
 export default EditApprovalWorkflow;

--- a/src/smart-components/error-pages/common-api-error.js
+++ b/src/smart-components/error-pages/common-api-error.js
@@ -10,6 +10,7 @@ import {
 } from '@patternfly/react-core';
 import Exclamation from '@patternfly/react-icons/dist/js/icons/exclamation-icon';
 import CatalogLink from '../common/catalog-link';
+import styled from 'styled-components';
 
 const TITLES = {
   '/401': 'Unauthorized'
@@ -18,6 +19,10 @@ const TITLES = {
 const MESSAGES = {
   '/401': 'You are not auhtorized to access this section: '
 };
+
+const SourceSpan = styled.span`
+  white-space: nowrap;
+`;
 
 const CommonApiError = () => {
   const {
@@ -35,8 +40,13 @@ const CommonApiError = () => {
           <Title size="lg">{TITLES[pathname]}</Title>
         </div>
         <EmptyStateBody>
-          {MESSAGES[pathname]} {from.pathname}. If you believe this is a
-          mistake, please contact support.
+          {MESSAGES[pathname]}
+          <SourceSpan>
+            {from.pathname}
+            {from.search}
+          </SourceSpan>
+          <br />
+          If you believe this is a mistake, please contact support.
         </EmptyStateBody>
         <EmptyStatePrimary>
           <CatalogLink pathname="/">Return to catalog</CatalogLink>

--- a/src/smart-components/error-pages/error-redirects.js
+++ b/src/smart-components/error-pages/error-redirects.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Redirect, useLocation } from 'react-router-dom';
 
 export const UnauthorizedRedirect = () => {
-  const location = useLocation;
+  const location = useLocation();
   return (
     <Redirect
       to={{

--- a/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
@@ -142,8 +142,7 @@ const CopyPortfolioItemModal = ({
 
 CopyPortfolioItemModal.propTypes = {
   closeUrl: PropTypes.string.isRequired,
-  portfolioId: PropTypes.string.isRequired,
-  portfolios: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  portfolioId: PropTypes.string,
   portfolioItemId: PropTypes.string.isRequired,
   search: PropTypes.string.isRequired
 };

--- a/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
@@ -19,55 +19,75 @@ const DetailToolbarActions = ({
   isOpen,
   setOpen,
   isFetching,
-  availability
-}) => (
-  <Fragment>
-    <LevelItem>
-      <CatalogLink
-        isDisabled={isFetching || availability === 'unavailable'}
-        pathname={orderUrl}
-        preserveSearch
-      >
-        <ButtonWithSpinner
+  availability,
+  userCapabilities: { update, copy }
+}) => {
+  const dropdownItems = [];
+  if (update) {
+    dropdownItems.push(
+      <DropdownItem
+        aria-label="Edit Portfolio"
+        key="edit-portfolio-item"
+        id="edit-portfolio-item"
+        component={
+          <CatalogLink pathname={editUrl} preserveSearch>
+            Edit
+          </CatalogLink>
+        }
+        role="link"
+      />
+    );
+  }
+
+  if (copy) {
+    dropdownItems.push(
+      <DropdownItem
+        aria-label="Copy Portfolio"
+        key="copy-portfolio-item"
+        id="copy-portfolio-item"
+        component={
+          <CatalogLink pathname={copyUrl} preserveSearch>
+            Copy
+          </CatalogLink>
+        }
+        role="link"
+      />
+    );
+  }
+
+  return (
+    <Fragment>
+      <LevelItem>
+        <CatalogLink
           isDisabled={isFetching || availability === 'unavailable'}
-          showSpinner={isFetching}
-          variant="primary"
-          id="order-portfolio-item"
+          pathname={orderUrl}
+          preserveSearch
         >
-          Order
-        </ButtonWithSpinner>
-      </CatalogLink>
-    </LevelItem>
-    {
+          <ButtonWithSpinner
+            isDisabled={isFetching || availability === 'unavailable'}
+            showSpinner={isFetching}
+            variant="primary"
+            id="order-portfolio-item"
+          >
+            Order
+          </ButtonWithSpinner>
+        </CatalogLink>
+      </LevelItem>
       <LevelItem style={{ marginLeft: 16 }}>
         <Dropdown
           isPlain
           onToggle={setOpen}
           onSelect={() => setOpen(false)}
           position={DropdownPosition.right}
-          toggle={<KebabToggle onToggle={(isOpen) => setOpen(isOpen)} />}
+          toggle={
+            <KebabToggle
+              id="portfolio-item-actions-toggle"
+              onToggle={(isOpen) => setOpen(isOpen)}
+            />
+          }
           isOpen={isOpen}
           dropdownItems={[
-            <DropdownItem
-              aria-label="Edit Portfolio"
-              key="edit-portfolio"
-              component={
-                <CatalogLink pathname={editUrl} preserveSearch>
-                  Edit
-                </CatalogLink>
-              }
-              role="link"
-            />,
-            <DropdownItem
-              aria-label="Copy Portfolio"
-              key="copy-portfolio"
-              component={
-                <CatalogLink pathname={copyUrl} preserveSearch>
-                  Copy
-                </CatalogLink>
-              }
-              role="link"
-            />,
+            ...dropdownItems,
             <DropdownItem
               aria-label="Set approval"
               key="edit-approval_workflow"
@@ -91,9 +111,9 @@ const DetailToolbarActions = ({
           ]}
         />
       </LevelItem>
-    }
-  </Fragment>
-);
+    </Fragment>
+  );
+};
 
 DetailToolbarActions.propTypes = {
   orderUrl: PropTypes.string.isRequired,
@@ -104,7 +124,11 @@ DetailToolbarActions.propTypes = {
   isOpen: PropTypes.bool,
   setOpen: PropTypes.func.isRequired,
   isFetching: PropTypes.bool,
-  availability: PropTypes.oneOf(['available', 'unavailable']).isRequired
+  availability: PropTypes.oneOf(['available', 'unavailable']).isRequired,
+  userCapabilities: PropTypes.shape({
+    update: PropTypes.bool,
+    copy: PropTypes.bool
+  }).isRequired
 };
 
 DetailToolbarActions.defaultProps = {

--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
@@ -6,12 +6,13 @@ import { Text, TextContent, TextVariants } from '@patternfly/react-core';
 import EditPortfolioItem from './edit-portfolio-item';
 import EditApprovalWorkflow from '../../../smart-components/common/edit-approval-workflow';
 import { PORTFOLIO_ITEM_RESOURCE_TYPE } from '../../../utilities/constants';
+import CatalogRoute from '../../../routing/catalog-route';
 
-const ItemDetailDescription = ({ product, url, search }) => (
+const ItemDetailDescription = ({ userCapabilities, product, url, search }) => (
   <Switch>
     <Route
       exact
-      path={`${url}`}
+      path={url}
       render={() => (
         <TextContent>
           {(product.description || product.long_description) && (
@@ -55,11 +56,14 @@ const ItemDetailDescription = ({ product, url, search }) => (
         </TextContent>
       )}
     />
-    <Route
+    <CatalogRoute
       exact
       path={`${url}/edit`}
-      render={() => <EditPortfolioItem cancelUrl={url} product={product} />}
-    />
+      requiredCapabilities="update"
+      userCapabilities={userCapabilities}
+    >
+      <EditPortfolioItem cancelUrl={url} product={product} />
+    </CatalogRoute>
     <Route exact path={`${url}/edit-workflow`}>
       <EditApprovalWorkflow
         pushParam={{ pathname: url, search }}
@@ -82,7 +86,8 @@ ItemDetailDescription.propTypes = {
     id: PropTypes.string.isRequired
   }).isRequired,
   url: PropTypes.string.isRequired,
-  search: PropTypes.string.isRequired
+  search: PropTypes.string.isRequired,
+  userCapabilities: PropTypes.object.isRequired
 };
 
 export default ItemDetailDescription;

--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
@@ -46,10 +46,10 @@ ItemDetailInfoBar.propTypes = {
     created_at: PropTypes.string.isRequired
   }).isRequired,
   source: PropTypes.shape({
-    name: PropTypes.string.isRequired
+    name: PropTypes.string
   }).isRequired,
   portfolio: PropTypes.shape({
-    name: PropTypes.string.isRequired
+    name: PropTypes.string
   }).isRequired
 };
 

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
@@ -106,7 +106,8 @@ PortfolioItemDetailToolbar.propTypes = {
   setOpen: PropTypes.func.isRequired,
   isFetching: PropTypes.bool,
   uploadIcon: PropTypes.func.isRequired,
-  availability: PropTypes.oneOf(['available', 'unavailable']).isRequired
+  availability: PropTypes.oneOf(['available', 'unavailable']).isRequired,
+  userCapabilities: PropTypes.object
 };
 
 PortfolioItemDetailToolbar.defaultProps = {
@@ -200,6 +201,5 @@ SurveyEditingToolbar.propTypes = {
   isFetching: PropTypes.bool,
   isValid: PropTypes.bool,
   modified: PropTypes.bool,
-  handleResetSurvey: PropTypes.func,
-  userCapabilities: PropTypes.object.isRequired
+  handleResetSurvey: PropTypes.func
 };

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
@@ -45,7 +45,8 @@ export const PortfolioItemDetailToolbar = ({
   setOpen,
   isFetching,
   uploadIcon,
-  availability
+  availability,
+  userCapabilities
 }) => (
   <TopToolbar breadcrumbsSpacing={false}>
     <Level>
@@ -75,6 +76,7 @@ export const PortfolioItemDetailToolbar = ({
                 workflowUrl={`${url}/edit-workflow`}
                 isFetching={isFetching}
                 availability={availability}
+                userCapabilities={userCapabilities}
                 {...args}
               />
             )}
@@ -198,5 +200,6 @@ SurveyEditingToolbar.propTypes = {
   isFetching: PropTypes.bool,
   isValid: PropTypes.bool,
   modified: PropTypes.bool,
-  handleResetSurvey: PropTypes.func
+  handleResetSurvey: PropTypes.func,
+  userCapabilities: PropTypes.object.isRequired
 };

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -33,9 +33,14 @@ const PortfolioItemDetail = () => {
   const dispatch = useDispatch();
   const [queryValues, search] = useQuery(requiredParams);
   const { url } = useRouteMatch(PORTFOLIO_ITEM_ROUTE);
-  const { portfolioItem, portfolio, source } = useSelector(
-    ({ portfolioReducer: { portfolioItem } }) => portfolioItem
-  );
+  const {
+    portfolioItem: {
+      metadata: { user_capabilities: userCapabilities },
+      ...portfolioItem
+    },
+    portfolio,
+    source
+  } = useSelector(({ portfolioReducer: { portfolioItem } }) => portfolioItem);
 
   useEffect(() => {
     setIsFetching(true);
@@ -97,6 +102,7 @@ const PortfolioItemDetail = () => {
               setOpen={setOpen}
               isFetching={isFetching}
               availability={availability}
+              userCapabilities={userCapabilities}
             />
             {unavailable.length > 0 && (
               <div className="pf-u-mr-lg pf-u-ml-lg">{unavailable}</div>

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -18,6 +18,7 @@ import {
 import { uploadPortfolioItemIcon } from '../../../helpers/portfolio/portfolio-helper';
 import useQuery from '../../../utilities/use-query';
 import { PORTFOLIO_ITEM_ROUTE } from '../../../constants/routes';
+import CatalogRoute from '../../../routing/catalog-route';
 
 const SurveyEditor = lazy(() =>
   import(
@@ -65,7 +66,6 @@ const PortfolioItemDetail = () => {
   }
 
   const availability = source.availability_status || 'unavailable';
-
   const unavailable = [source]
     .filter(({ notFound }) => notFound)
     .map(({ object }) => (
@@ -128,20 +128,22 @@ const PortfolioItemDetail = () => {
                 <Route path={`${url}/order`}>
                   <OrderModal closeUrl={url} />
                 </Route>
-                <Route
+                <CatalogRoute
                   path={`${url}/copy`}
-                  render={(props) => (
-                    <CopyPortfolioItemModal
-                      {...props}
-                      search={search}
-                      portfolioItemId={portfolioItem.id}
-                      portfolioId={portfolio.id}
-                      closeUrl={url}
-                    />
-                  )}
-                />
+                  requiredCapabilities="copy"
+                  userCapabilities={userCapabilities}
+                >
+                  <CopyPortfolioItemModal
+                    search={search}
+                    portfolioItemId={portfolioItem.id}
+                    portfolioId={portfolio.id}
+                    closeUrl={url}
+                  />
+                </CatalogRoute>
+
                 <ItemDetailDescription
                   product={portfolioItem}
+                  userCapabilities={userCapabilities}
                   url={url}
                   search={search}
                 />

--- a/src/smart-components/portfolio/portfolio-item.js
+++ b/src/smart-components/portfolio/portfolio-item.js
@@ -20,7 +20,7 @@ const PortfolioItem = (props) => (
             src={`${CATALOG_API_BASE}/portfolio_items/${props.id}/icon`}
             sourceId={props.service_offering_source_ref}
           />
-          {props.isSelectable && (
+          {props.isSelectable && props.metadata?.user_capabilities?.destroy && (
             <CardCheckbox
               handleCheck={() => props.onSelect(props.id)}
               isChecked={props.isSelected}
@@ -44,7 +44,10 @@ PortfolioItem.propTypes = {
   onSelect: PropTypes.func,
   orderUrl: PropTypes.string,
   removeInProgress: PropTypes.bool,
-  portfolio_id: PropTypes.string
+  portfolio_id: PropTypes.string,
+  metadata: PropTypes.shape({
+    user_capabilities: PropTypes.shape({ destroy: PropTypes.bool }).isRequired
+  }).isRequired
 };
 
 export default PortfolioItem;

--- a/src/smart-components/portfolio/portfolio-item.js
+++ b/src/smart-components/portfolio/portfolio-item.js
@@ -20,7 +20,7 @@ const PortfolioItem = (props) => (
             src={`${CATALOG_API_BASE}/portfolio_items/${props.id}/icon`}
             sourceId={props.service_offering_source_ref}
           />
-          {props.isSelectable && props.metadata?.user_capabilities?.destroy && (
+          {props.isSelectable && (
             <CardCheckbox
               handleCheck={() => props.onSelect(props.id)}
               isChecked={props.isSelected}

--- a/src/smart-components/portfolio/portfolio-items.js
+++ b/src/smart-components/portfolio/portfolio-items.js
@@ -26,6 +26,7 @@ import {
   NESTED_WORKFLOW_PORTFOLIO_ROUTE,
   NESTED_ORDER_PORTFOLIO_ROUTE
 } from '../../constants/routes';
+import CatalogRoute from '../../routing/catalog-route';
 
 const PortfolioItems = ({
   routes,
@@ -109,12 +110,19 @@ const PortfolioItems = ({
           userCapabilities
         })}
       />
-      <Route exact path={NESTED_EDIT_PORTFOLIO_ROUTE}>
+      <CatalogRoute
+        userCapabilities={userCapabilities}
+        requiredCapabilities="update"
+        exact
+        path={NESTED_EDIT_PORTFOLIO_ROUTE}
+      >
         <AddPortfolioModal
           closeTarget={{ pathname: PORTFOLIO_ROUTE, search }}
         />
-      </Route>
-      <Route
+      </CatalogRoute>
+      <CatalogRoute
+        userCapabilities={userCapabilities}
+        requiredCapabilities="destroy"
         exact
         path={NESTED_REMOVE_PORTFOLIO_ROUTE}
         component={RemovePortfolioModal}

--- a/src/smart-components/portfolio/portfolio-items.js
+++ b/src/smart-components/portfolio/portfolio-items.js
@@ -74,7 +74,7 @@ const PortfolioItems = ({
         'portfolio-item': item.id
       }}
       preserveSearch
-      isSelectable
+      isSelectable={userCapabilities.update}
       onSelect={(selectedItem) =>
         stateDispatch({ type: 'selectItem', payload: selectedItem })
       }

--- a/src/smart-components/portfolio/portfolio.js
+++ b/src/smart-components/portfolio/portfolio.js
@@ -21,6 +21,7 @@ import useQuery from '../../utilities/use-query';
 import useBreadcrumbs from '../../utilities/use-breadcrumbs';
 import { PORTFOLIO_ROUTE } from '../../constants/routes';
 import { UnauthorizedRedirect } from '../error-pages/error-redirects';
+import CatalogRoute from '../../routing/catalog-route';
 
 const initialState = {
   selectedItems: [],
@@ -161,9 +162,13 @@ const Portfolio = () => {
 
   return (
     <Switch>
-      <Route path={routes.addProductsRoute}>
+      <CatalogRoute
+        path={routes.addProductsRoute}
+        userCapabilities={portfolio.metadata.user_capabilities}
+        requiredCapabilities="update"
+      >
         <AddProductsToPortfolio portfolioRoute={routes.portfolioRoute} />
-      </Route>
+      </CatalogRoute>
       <Route path={routes.portfolioItemRoute}>
         <PortfolioItemDetail portfolioLoaded={!state.isFetching} />
       </Route>

--- a/src/test/presentational-components/platform/__snapshots__/platform-card.test.js.snap
+++ b/src/test/presentational-components/platform/__snapshots__/platform-card.test.js.snap
@@ -52,7 +52,7 @@ exports[`<PlatformCard /> should choose card image 1`] = `
                           }
                         }
                       >
-                        <Styled(Link)
+                        <Styled(Component)
                           to={
                             Object {
                               "pathname": "/platform/platform-templates",
@@ -60,7 +60,7 @@ exports[`<PlatformCard /> should choose card image 1`] = `
                             }
                           }
                         >
-                          <Link
+                          <Component
                             className="sc-AxiKw drCTeX"
                             to={
                               Object {
@@ -69,35 +69,45 @@ exports[`<PlatformCard /> should choose card image 1`] = `
                               }
                             }
                           >
-                            <LinkAnchor
+                            <Link
                               className="sc-AxiKw drCTeX"
-                              href="/platform/platform-templates?platform=undefined"
-                              navigate={[Function]}
+                              to={
+                                Object {
+                                  "pathname": "/platform/platform-templates",
+                                  "search": "?platform=undefined",
+                                }
+                              }
                             >
-                              <a
+                              <LinkAnchor
                                 className="sc-AxiKw drCTeX"
                                 href="/platform/platform-templates?platform=undefined"
-                                onClick={[Function]}
+                                navigate={[Function]}
                               >
-                                <Text
-                                  className="pf-u-mb-0"
-                                  component="h3"
+                                <a
+                                  className="sc-AxiKw drCTeX"
+                                  href="/platform/platform-templates?platform=undefined"
+                                  onClick={[Function]}
                                 >
-                                  <h3
+                                  <Text
                                     className="pf-u-mb-0"
-                                    data-pf-content={true}
+                                    component="h3"
                                   >
-                                    <styled.div>
-                                      <div
-                                        className="sc-AxirZ ZcaGf"
-                                      />
-                                    </styled.div>
-                                  </h3>
-                                </Text>
-                              </a>
-                            </LinkAnchor>
-                          </Link>
-                        </Styled(Link)>
+                                    <h3
+                                      className="pf-u-mb-0"
+                                      data-pf-content={true}
+                                    >
+                                      <styled.div>
+                                        <div
+                                          className="sc-AxirZ ZcaGf"
+                                        />
+                                      </styled.div>
+                                    </h3>
+                                  </Text>
+                                </a>
+                              </LinkAnchor>
+                            </Link>
+                          </Component>
+                        </Styled(Component)>
                       </CatalogLink>
                     </div>
                   </TextContent>
@@ -198,7 +208,7 @@ exports[`<PlatformCard /> should render correctly 1`] = `
                           }
                         }
                       >
-                        <Styled(Link)
+                        <Styled(Component)
                           to={
                             Object {
                               "pathname": "/platform/platform-templates",
@@ -206,7 +216,7 @@ exports[`<PlatformCard /> should render correctly 1`] = `
                             }
                           }
                         >
-                          <Link
+                          <Component
                             className="sc-AxiKw drCTeX"
                             to={
                               Object {
@@ -215,35 +225,45 @@ exports[`<PlatformCard /> should render correctly 1`] = `
                               }
                             }
                           >
-                            <LinkAnchor
+                            <Link
                               className="sc-AxiKw drCTeX"
-                              href="/platform/platform-templates?platform=undefined"
-                              navigate={[Function]}
+                              to={
+                                Object {
+                                  "pathname": "/platform/platform-templates",
+                                  "search": "?platform=undefined",
+                                }
+                              }
                             >
-                              <a
+                              <LinkAnchor
                                 className="sc-AxiKw drCTeX"
                                 href="/platform/platform-templates?platform=undefined"
-                                onClick={[Function]}
+                                navigate={[Function]}
                               >
-                                <Text
-                                  className="pf-u-mb-0"
-                                  component="h3"
+                                <a
+                                  className="sc-AxiKw drCTeX"
+                                  href="/platform/platform-templates?platform=undefined"
+                                  onClick={[Function]}
                                 >
-                                  <h3
+                                  <Text
                                     className="pf-u-mb-0"
-                                    data-pf-content={true}
+                                    component="h3"
                                   >
-                                    <styled.div>
-                                      <div
-                                        className="sc-AxirZ ZcaGf"
-                                      />
-                                    </styled.div>
-                                  </h3>
-                                </Text>
-                              </a>
-                            </LinkAnchor>
-                          </Link>
-                        </Styled(Link)>
+                                    <h3
+                                      className="pf-u-mb-0"
+                                      data-pf-content={true}
+                                    >
+                                      <styled.div>
+                                        <div
+                                          className="sc-AxirZ ZcaGf"
+                                        />
+                                      </styled.div>
+                                    </h3>
+                                  </Text>
+                                </a>
+                              </LinkAnchor>
+                            </Link>
+                          </Component>
+                        </Styled(Component)>
                       </CatalogLink>
                     </div>
                   </TextContent>

--- a/src/test/presentational-components/shared/__snapshots__/conditional-link.test.js.snap
+++ b/src/test/presentational-components/shared/__snapshots__/conditional-link.test.js.snap
@@ -10,7 +10,7 @@ exports[`<ConditionalLink /> should render children wrapped in router Link compo
     preserveSearch={false}
     searchParams={Object {}}
   >
-    <Styled(Link)
+    <Styled(Component)
       to={
         Object {
           "pathname": "/some/url",
@@ -18,7 +18,7 @@ exports[`<ConditionalLink /> should render children wrapped in router Link compo
         }
       }
     >
-      <Link
+      <Component
         className="sc-AxjAm jfRa-DE"
         to={
           Object {
@@ -27,23 +27,33 @@ exports[`<ConditionalLink /> should render children wrapped in router Link compo
           }
         }
       >
-        <LinkAnchor
+        <Link
           className="sc-AxjAm jfRa-DE"
-          href="/some/url"
-          navigate={[Function]}
+          to={
+            Object {
+              "pathname": "/some/url",
+              "search": "",
+            }
+          }
         >
-          <a
+          <LinkAnchor
             className="sc-AxjAm jfRa-DE"
             href="/some/url"
-            onClick={[Function]}
+            navigate={[Function]}
           >
-            <div>
-              Link children
-            </div>
-          </a>
-        </LinkAnchor>
-      </Link>
-    </Styled(Link)>
+            <a
+              className="sc-AxjAm jfRa-DE"
+              href="/some/url"
+              onClick={[Function]}
+            >
+              <div>
+                Link children
+              </div>
+            </a>
+          </LinkAnchor>
+        </Link>
+      </Component>
+    </Styled(Component)>
   </CatalogLink>
 </ConditionalLink>
 `;

--- a/src/test/routing/catalog-route.test.js
+++ b/src/test/routing/catalog-route.test.js
@@ -1,0 +1,149 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { MemoryRouter, Route, Switch } from 'react-router-dom';
+
+import CatalogRoute from '../../routing/catalog-route';
+import CommonApiError from '../../smart-components/error-pages/common-api-error';
+import UserContext from '../../user-context';
+
+describe('<CatalogRoute />', () => {
+  it('should redirect to unauthorized page if capabilities is an array and fail', () => {
+    const wrapper = mount(
+      <UserContext.Provider value={{ permissions: [] }}>
+        <MemoryRouter initialEntries={['/protected']}>
+          <Switch>
+            <CatalogRoute
+              path="/protected"
+              requiredCapabilities={['protected']}
+              userCapabilities={{ protected: false }}
+            >
+              <div id="behind-protected-route"></div>
+            </CatalogRoute>
+            <Route path="/401">
+              <CommonApiError />
+            </Route>
+          </Switch>
+        </MemoryRouter>
+      </UserContext.Provider>
+    );
+    expect(
+      wrapper.find(MemoryRouter).instance().history.location.pathname
+    ).toEqual('/401');
+    expect(wrapper.find(CommonApiError)).toHaveLength(1);
+    expect(wrapper.find('#behind-protected-route')).toHaveLength(0);
+  });
+
+  it('should redirect to unauthorized page if capabilities is string and fail', () => {
+    const wrapper = mount(
+      <UserContext.Provider value={{ permissions: [] }}>
+        <MemoryRouter initialEntries={['/protected']}>
+          <Switch>
+            <CatalogRoute
+              path="/protected"
+              requiredCapabilities="protected"
+              userCapabilities={{ protected: false }}
+            >
+              <div id="behind-protected-route"></div>
+            </CatalogRoute>
+            <Route path="/401">
+              <CommonApiError />
+            </Route>
+          </Switch>
+        </MemoryRouter>
+      </UserContext.Provider>
+    );
+    expect(
+      wrapper.find(MemoryRouter).instance().history.location.pathname
+    ).toEqual('/401');
+    expect(wrapper.find(CommonApiError)).toHaveLength(1);
+    expect(wrapper.find('#behind-protected-route')).toHaveLength(0);
+  });
+
+  it('should allow rending route if user has capabilities', () => {
+    const wrapper = mount(
+      <UserContext.Provider value={{ permissions: [] }}>
+        <MemoryRouter initialEntries={['/protected']}>
+          <Switch>
+            <CatalogRoute
+              path="/protected"
+              requiredCapabilities="protected"
+              userCapabilities={{ protected: true }}
+            >
+              <div id="behind-protected-route"></div>
+            </CatalogRoute>
+            <Route path="/401">
+              <CommonApiError />
+            </Route>
+          </Switch>
+        </MemoryRouter>
+      </UserContext.Provider>
+    );
+    expect(
+      wrapper.find(MemoryRouter).instance().history.location.pathname
+    ).toEqual('/protected');
+    expect(wrapper.find(CommonApiError)).toHaveLength(0);
+    expect(wrapper.find('#behind-protected-route')).toHaveLength(1);
+  });
+
+  it('should redirect to unauthorized page if user does not have necessary permissions', () => {
+    const wrapper = mount(
+      <UserContext.Provider value={{ permissions: [] }}>
+        <MemoryRouter initialEntries={['/protected']}>
+          <Switch>
+            <CatalogRoute
+              path="/protected"
+              requiredCapabilities="protected"
+              userCapabilities={{ protected: true }}
+              permissions={['user:needs:permission']}
+            >
+              <div id="behind-protected-route"></div>
+            </CatalogRoute>
+            <Route path="/401">
+              <CommonApiError />
+            </Route>
+          </Switch>
+        </MemoryRouter>
+      </UserContext.Provider>
+    );
+    expect(
+      wrapper.find(MemoryRouter).instance().history.location.pathname
+    ).toEqual('/401');
+    expect(wrapper.find(CommonApiError)).toHaveLength(1);
+    expect(wrapper.find('#behind-protected-route')).toHaveLength(0);
+  });
+
+  it('should render page if user has necessary permissions', () => {
+    const wrapper = mount(
+      <UserContext.Provider
+        value={{
+          permissions: [
+            {
+              permission: 'user:needs:permission'
+            }
+          ]
+        }}
+      >
+        <MemoryRouter initialEntries={['/protected']}>
+          <Switch>
+            <CatalogRoute
+              path="/protected"
+              requiredCapabilities="protected"
+              userCapabilities={{ protected: true }}
+              permissions={['user:needs:permission']}
+            >
+              <div id="behind-protected-route"></div>
+            </CatalogRoute>
+            <Route path="/401">
+              <CommonApiError />
+            </Route>
+          </Switch>
+        </MemoryRouter>
+      </UserContext.Provider>
+    );
+    expect(
+      wrapper.find(MemoryRouter).instance().history.location.pathname
+    ).toEqual('/protected');
+    expect(wrapper.find(CommonApiError)).toHaveLength(0);
+    expect(wrapper.find('#behind-protected-route')).toHaveLength(1);
+  });
+});

--- a/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
+++ b/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
@@ -5,6 +5,13 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
   description="Bar"
   display_name="quux"
   id="1"
+  metadata={
+    Object {
+      "user_capabilities": Object {
+        "destroy": true,
+      },
+    }
+  }
   name="Foo"
   orderUrl="/order"
 >
@@ -117,6 +124,13 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                 description="Bar"
                 display_name="quux"
                 id="1"
+                metadata={
+                  Object {
+                    "user_capabilities": Object {
+                      "destroy": true,
+                    },
+                  }
+                }
                 name="Foo"
                 orderUrl="/order"
               >
@@ -156,6 +170,13 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                       <ItemDetails
                         description="Bar"
                         id="1"
+                        metadata={
+                          Object {
+                            "user_capabilities": Object {
+                              "destroy": true,
+                            },
+                          }
+                        }
                         orderUrl="/order"
                         toDisplay={
                           Array [

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
@@ -28,7 +28,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
         preserveSearch={true}
         searchParams={Object {}}
       >
-        <Styled(Link)
+        <Styled(Component)
           isDisabled={false}
           to={
             Object {
@@ -37,7 +37,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
             }
           }
         >
-          <Link
+          <Component
             className="sc-AxiKw drCTeX"
             isDisabled={false}
             to={
@@ -47,95 +47,103 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
               }
             }
           >
-            <LinkAnchor
+            <Link
               className="sc-AxiKw drCTeX"
-              href="foo/bar"
-              isDisabled={false}
-              navigate={[Function]}
+              to={
+                Object {
+                  "pathname": "foo/bar",
+                  "search": "",
+                }
+              }
             >
-              <a
+              <LinkAnchor
                 className="sc-AxiKw drCTeX"
                 href="foo/bar"
-                isDisabled={false}
-                onClick={[Function]}
+                navigate={[Function]}
               >
-                <ButtonWithSpinner
-                  id="order-portfolio-item"
-                  isDisabled={false}
-                  showSpinner={false}
-                  variant="primary"
+                <a
+                  className="sc-AxiKw drCTeX"
+                  href="foo/bar"
+                  onClick={[Function]}
                 >
-                  <Styled(Component)
+                  <ButtonWithSpinner
                     id="order-portfolio-item"
                     isDisabled={false}
+                    showSpinner={false}
                     variant="primary"
                   >
-                    <Component
-                      className="sc-AxjAm jhCAUI"
+                    <Styled(Component)
                       id="order-portfolio-item"
                       isDisabled={false}
                       variant="primary"
                     >
-                      <ComponentWithOuia
-                        component={[Function]}
-                        componentProps={
-                          Object {
-                            "children": Array [
+                      <Component
+                        className="sc-AxjAm jhCAUI"
+                        id="order-portfolio-item"
+                        isDisabled={false}
+                        variant="primary"
+                      >
+                        <ComponentWithOuia
+                          component={[Function]}
+                          componentProps={
+                            Object {
+                              "children": Array [
+                                <styled.span
+                                  showSpinner={false}
+                                >
+                                  Order
+                                </styled.span>,
+                                false,
+                              ],
+                              "className": "sc-AxjAm jhCAUI",
+                              "id": "order-portfolio-item",
+                              "isDisabled": false,
+                              "variant": "primary",
+                            }
+                          }
+                          consumerContext={null}
+                        >
+                          <Button
+                            className="sc-AxjAm jhCAUI"
+                            id="order-portfolio-item"
+                            isDisabled={false}
+                            ouiaContext={
+                              Object {
+                                "isOuia": false,
+                                "ouiaId": null,
+                              }
+                            }
+                            variant="primary"
+                          >
+                            <button
+                              aria-disabled={null}
+                              aria-label={null}
+                              className="pf-c-button pf-m-primary sc-AxjAm jhCAUI"
+                              disabled={false}
+                              id="order-portfolio-item"
+                              tabIndex={null}
+                              type="button"
+                            >
                               <styled.span
                                 showSpinner={false}
                               >
-                                Order
-                              </styled.span>,
-                              false,
-                            ],
-                            "className": "sc-AxjAm jhCAUI",
-                            "id": "order-portfolio-item",
-                            "isDisabled": false,
-                            "variant": "primary",
-                          }
-                        }
-                        consumerContext={null}
-                      >
-                        <Button
-                          className="sc-AxjAm jhCAUI"
-                          id="order-portfolio-item"
-                          isDisabled={false}
-                          ouiaContext={
-                            Object {
-                              "isOuia": false,
-                              "ouiaId": null,
-                            }
-                          }
-                          variant="primary"
-                        >
-                          <button
-                            aria-disabled={null}
-                            aria-label={null}
-                            className="pf-c-button pf-m-primary sc-AxjAm jhCAUI"
-                            disabled={false}
-                            id="order-portfolio-item"
-                            tabIndex={null}
-                            type="button"
-                          >
-                            <styled.span
-                              showSpinner={false}
-                            >
-                              <span
-                                className="sc-AxirZ fnlrkz"
-                              >
-                                Order
-                              </span>
-                            </styled.span>
-                          </button>
-                        </Button>
-                      </ComponentWithOuia>
-                    </Component>
-                  </Styled(Component)>
-                </ButtonWithSpinner>
-              </a>
-            </LinkAnchor>
-          </Link>
-        </Styled(Link)>
+                                <span
+                                  className="sc-AxirZ fnlrkz"
+                                >
+                                  Order
+                                </span>
+                              </styled.span>
+                            </button>
+                          </Button>
+                        </ComponentWithOuia>
+                      </Component>
+                    </Styled(Component)>
+                  </ButtonWithSpinner>
+                </a>
+              </LinkAnchor>
+            </Link>
+          </Component>
+        </Styled(Component)>
       </CatalogLink>
     </div>
   </LevelItem>

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
@@ -11,6 +11,12 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
   orderUrl="foo/bar"
   pathname="foo/bar"
   setOpen={[MockFunction]}
+  userCapabilities={
+    Object {
+      "copy": true,
+      "update": true,
+    }
+  }
   workflowUrl="foo/workflow"
 >
   <LevelItem>
@@ -162,6 +168,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                   Edit
                 </CatalogLink>
               }
+              id="edit-portfolio-item"
               role="link"
             />,
             <DropdownItem
@@ -176,6 +183,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                   Copy
                 </CatalogLink>
               }
+              id="copy-portfolio-item"
               role="link"
             />,
             <DropdownItem
@@ -215,6 +223,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
         position="right"
         toggle={
           <KebabToggle
+            id="portfolio-item-actions-toggle"
             onToggle={[Function]}
           />
         }
@@ -234,6 +243,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                     Edit
                   </CatalogLink>
                 }
+                id="edit-portfolio-item"
                 role="link"
               />,
               <DropdownItem
@@ -248,6 +258,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                     Copy
                   </CatalogLink>
                 }
+                id="copy-portfolio-item"
                 role="link"
               />,
               <DropdownItem
@@ -286,6 +297,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
           position="right"
           toggle={
             <KebabToggle
+              id="portfolio-item-actions-toggle"
               onToggle={[Function]}
             />
           }
@@ -307,6 +319,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                         Edit
                       </CatalogLink>
                     }
+                    id="edit-portfolio-item"
                     role="link"
                   />,
                   <DropdownItem
@@ -321,6 +334,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                         Copy
                       </CatalogLink>
                     }
+                    id="copy-portfolio-item"
                     role="link"
                   />,
                   <DropdownItem
@@ -357,6 +371,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                 "onToggle": [MockFunction],
                 "position": "right",
                 "toggle": <KebabToggle
+                  id="portfolio-item-actions-toggle"
                   onToggle={[Function]}
                 />,
               }
@@ -381,6 +396,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                         Edit
                       </CatalogLink>
                     }
+                    id="edit-portfolio-item"
                     role="link"
                   />,
                   <DropdownItem
@@ -395,6 +411,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                         Copy
                       </CatalogLink>
                     }
+                    id="copy-portfolio-item"
                     role="link"
                   />,
                   <DropdownItem
@@ -442,6 +459,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
               position="right"
               toggle={
                 <KebabToggle
+                  id="portfolio-item-actions-toggle"
                   onToggle={[Function]}
                 />
               }
@@ -452,7 +470,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
               >
                 <KebabToggle
                   ariaHasPopup={true}
-                  id="pf-toggle-id-0"
+                  id="portfolio-item-actions-toggle"
                   isOpen={false}
                   isPlain={true}
                   key=".0"
@@ -468,7 +486,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                           aria-haspopup="true"
                           aria-label="Actions"
                           class="pf-c-dropdown__toggle pf-m-plain"
-                          id="pf-toggle-id-0"
+                          id="portfolio-item-actions-toggle"
                           type="button"
                         >
                           <svg
@@ -495,7 +513,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                     ariaHasPopup={true}
                     bubbleEvent={false}
                     className=""
-                    id="pf-toggle-id-0"
+                    id="portfolio-item-actions-toggle"
                     isActive={false}
                     isDisabled={false}
                     isFocused={false}
@@ -516,7 +534,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                             aria-haspopup="true"
                             aria-label="Actions"
                             class="pf-c-dropdown__toggle pf-m-plain"
-                            id="pf-toggle-id-0"
+                            id="portfolio-item-actions-toggle"
                             type="button"
                           >
                             <svg
@@ -544,7 +562,7 @@ exports[`<DetailToolbarActions /> should render correctly 1`] = `
                       aria-label="Actions"
                       className="pf-c-dropdown__toggle pf-m-plain"
                       disabled={false}
-                      id="pf-toggle-id-0"
+                      id="portfolio-item-actions-toggle"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       type="button"

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/portfolio-item-detail-toolbar.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/portfolio-item-detail-toolbar.test.js.snap
@@ -13,5 +13,11 @@ exports[`<PortfolioItemDetailToolbar /> should render correctly 1`] = `
   setOpen={[MockFunction]}
   setWorkflow={[MockFunction]}
   url="/foo"
+  userCapabilities={
+    Object {
+      "copy": true,
+      "update": true,
+    }
+  }
 />
 `;

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/portfolio-item-details.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/portfolio-item-details.test.js.snap
@@ -1,20 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<PortfolioItemDetail /> should render correctly 1`] = `
-<Provider
-  store={
+<ContextProvider
+  value={
     Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
+      "permissions": Array [],
     }
   }
 >
-  <MemoryRouter>
-    <PortfolioItemDetail />
-  </MemoryRouter>
-</Provider>
+  <Provider
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  >
+    <MemoryRouter>
+      <PortfolioItemDetail />
+    </MemoryRouter>
+  </Provider>
+  .
+</ContextProvider>
 `;

--- a/src/test/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.test.js
@@ -5,6 +5,16 @@ import { MemoryRouter } from 'react-router-dom';
 
 import DetailToolbarActions from '../../../../smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions';
 
+const prepareTruthyCapability = (truthyCapability) => ({
+  copy: false,
+  update: false,
+  ...(truthyCapability
+    ? {
+        [truthyCapability]: true
+      }
+    : {})
+});
+
 describe('<DetailToolbarActions />', () => {
   let initialProps;
 
@@ -18,7 +28,11 @@ describe('<DetailToolbarActions />', () => {
       availability: 'available',
       editSurveyUrl: 'foo/edit-survey',
       workflowUrl: 'foo/workflow',
-      pathname: 'foo/bar'
+      pathname: 'foo/bar',
+      userCapabilities: {
+        copy: true,
+        update: true
+      }
     };
   });
 
@@ -29,5 +43,35 @@ describe('<DetailToolbarActions />', () => {
       </MemoryRouter>
     );
     expect(toJson(wrapper.find(DetailToolbarActions))).toMatchSnapshot();
+  });
+
+  it('should show copy action in dropdown', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <DetailToolbarActions
+          {...initialProps}
+          isOpen
+          userCapabilities={prepareTruthyCapability('copy')}
+        />
+      </MemoryRouter>
+    );
+
+    expect(wrapper.find('li')).toHaveLength(3);
+    expect(wrapper.find('li#copy-portfolio-item')).toHaveLength(1);
+  });
+
+  it('should show edit action in dropdown', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <DetailToolbarActions
+          {...initialProps}
+          isOpen
+          userCapabilities={prepareTruthyCapability('update')}
+        />
+      </MemoryRouter>
+    );
+
+    expect(wrapper.find('li')).toHaveLength(3);
+    expect(wrapper.find('li#edit-portfolio-item')).toHaveLength(1);
   });
 });

--- a/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.test.js
@@ -32,7 +32,11 @@ describe('<PortfolioItemDetailToolbar />', () => {
       },
       setOpen: jest.fn(),
       setWorkflow: jest.fn(),
-      handleUpdate: jest.fn()
+      handleUpdate: jest.fn(),
+      userCapabilities: {
+        copy: true,
+        update: true
+      }
     };
 
     initialState = {

--- a/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
@@ -21,6 +21,7 @@ import ItemDetailDescription from '../../../../smart-components/portfolio/portfo
 import { PortfolioItemDetailToolbar } from '../../../../smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar';
 import { mockApi } from '../../../__mocks__/user-login';
 import { Alert } from '@patternfly/react-core';
+import UserContext from '../../../../user-context';
 
 describe('<PortfolioItemDetail />', () => {
   let initialProps;
@@ -34,11 +35,17 @@ describe('<PortfolioItemDetail />', () => {
     initialEntries,
     initialIndex
   }) => (
-    <Provider store={store}>
-      <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
-        {children}
-      </MemoryRouter>
-    </Provider>
+    <UserContext.Provider value={{ permissions: [] }}>
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={initialEntries}
+          initialIndex={initialIndex}
+        >
+          {children}
+        </MemoryRouter>
+      </Provider>
+      .
+    </UserContext.Provider>
   );
 
   beforeEach(() => {
@@ -66,6 +73,7 @@ describe('<PortfolioItemDetail />', () => {
           },
           source: { id: '111', name: 'Source name' },
           portfolio: {
+            id: '333',
             name: 'Portfolio name'
           }
         }
@@ -169,7 +177,8 @@ describe('<PortfolioItemDetail />', () => {
         portfolioItem: {
           ...initialState.portfolioReducer.portfolioItem,
           source: {
-            notFound: true
+            notFound: true,
+            object: 'source'
           }
         }
       }

--- a/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
@@ -55,7 +55,14 @@ describe('<PortfolioItemDetail />', () => {
             id: '123',
             service_offering_source_ref: '111',
             created_at: '123',
-            name: 'bar'
+            name: 'bar',
+            metadata: {
+              user_capabilities: {
+                copy: true,
+                update: true,
+                destroy: true
+              }
+            }
           },
           source: { id: '111', name: 'Source name' },
           portfolio: {

--- a/src/test/smart-components/portfolio/portfolio-item.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item.test.js
@@ -28,7 +28,12 @@ describe('<PortfolioItem />', () => {
       id: '1',
       name: 'Foo',
       description: 'Bar',
-      display_name: 'quux'
+      display_name: 'quux',
+      metadata: {
+        user_capabilities: {
+          destroy: true
+        }
+      }
     };
     initialState = {
       platformReducer: {
@@ -42,7 +47,12 @@ describe('<PortfolioItem />', () => {
               id: '1',
               name: 'Foo',
               description: 'Bar',
-              display_name: 'quux'
+              display_name: 'quux',
+              metadata: {
+                user_capabilities: {
+                  destroy: true
+                }
+              }
             }
           ]
         }
@@ -80,5 +90,25 @@ describe('<PortfolioItem />', () => {
       expect(onSelect).toHaveBeenCalledWith('1');
       done();
     });
+  });
+
+  it('should not render checkbox if capability destroy is set to false', () => {
+    const onSelect = jest.fn();
+    const store = mockStore(initialState);
+    const wrapper = mount(
+      <ComponentWrapper store={store}>
+        <PortfolioItem
+          {...initialProps}
+          metadata={{
+            user_capabilities: {
+              destroy: false
+            }
+          }}
+          onSelect={onSelect}
+          isSelectable
+        />
+      </ComponentWrapper>
+    );
+    expect(wrapper.find(PortfolioItem).find('input')).toHaveLength(0);
   });
 });

--- a/src/test/smart-components/portfolio/portfolio-item.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item.test.js
@@ -91,24 +91,4 @@ describe('<PortfolioItem />', () => {
       done();
     });
   });
-
-  it('should not render checkbox if capability destroy is set to false', () => {
-    const onSelect = jest.fn();
-    const store = mockStore(initialState);
-    const wrapper = mount(
-      <ComponentWrapper store={store}>
-        <PortfolioItem
-          {...initialProps}
-          metadata={{
-            user_capabilities: {
-              destroy: false
-            }
-          }}
-          onSelect={onSelect}
-          isSelectable
-        />
-      </ComponentWrapper>
-    );
-    expect(wrapper.find(PortfolioItem).find('input')).toHaveLength(0);
-  });
 });

--- a/src/test/smart-components/portfolio/portfolio.test.js
+++ b/src/test/smart-components/portfolio/portfolio.test.js
@@ -314,7 +314,12 @@ describe('<Portfolio />', () => {
               id: '123',
               name: 'Foo',
               description: 'desc',
-              modified: 'sometimes'
+              modified: 'sometimes',
+              metadata: {
+                user_capabilities: {
+                  destroy: true
+                }
+              }
             }
           ],
           meta: {


### PR DESCRIPTION
waiting for: https://github.com/RedHatInsights/catalog-ui/pull/475

jira: https://projects.engineering.redhat.com/browse/SSP-1372, https://projects.engineering.redhat.com/browse/SSP-1376

### Changes
- added restrictions on portfolio items based on user capabilities
- added user capabilities check on catalog route
- fixed up some prop types errors

@lgalis @gmcculloug I used the portfolio item `destroy` capability do hide/show the checkbox for selecting the card. I know that @lgalis mentioned that it should be based on the portfolio `update` capability. Just want to double-check which one of these flags is the correct one, 
