### PR TITLE
Add empty state for order approvals.

### DIFF
--- a/src/smart-components/order/order-detail/approval-request.js
+++ b/src/smart-components/order/order-detail/approval-request.js
@@ -14,6 +14,7 @@ import {
   Title
 } from '@patternfly/react-core';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/DateFormat';
+import InfoIcon from '@patternfly/react-icons/dist/js/icons/info-icon';
 import { fetchApprovalRequests } from '../../../redux/actions/order-actions';
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -37,10 +38,27 @@ const ApprovalRequests = () => {
   );
 
   useEffect(() => {
-    if (approvalRequest.data.length === 0) {
+    if (order.state !== 'Failed' && approvalRequest.data.length === 0) {
       checkRequest(() => dispatch(fetchApprovalRequests(orderItem.id)));
     }
   }, []);
+
+  if (order.state === 'Failed' && approvalRequest.data.length === 0) {
+    return (
+      <Bullseye>
+        <Flex breakpointMods={[{ modifier: 'column' }, { modifier: 'grow' }]}>
+          <Bullseye>
+            <InfoIcon size="xl" />
+          </Bullseye>
+          <Bullseye>
+            <Title>
+              We were unable to find any approval requests for this order.
+            </Title>
+          </Bullseye>
+        </Flex>
+      </Bullseye>
+    );
+  }
 
   return (
     <TextContent>


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1375

So far the code checks if the order is Failed and has no approval requests. I do have a question about the possibility of having order in the completed state but with no approval requests. If that is possible, we need more information to determine whether the approval requests will eventually exist or if there are simply no requests.

![screenshot-ci foo redhat com_1337-2020 03 25-08_54_46](https://user-images.githubusercontent.com/22619452/77514139-913b4b80-6e76-11ea-9a5c-a30458cefdc3.png)
