### PR TITLE
Replace react-content-loader with css implementation.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17028,11 +17028,6 @@
         "use-memo-one": "^1.1.1"
       }
     },
-    "react-content-loader": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-4.3.2.tgz",
-      "integrity": "sha512-Af2RW2G57+mFRXsiSXROtgvz3KmPz0lATRHNUpJ57DyVw6SRzDRNRXo04I2xhcwmwVnXsfx4s2hsHrU+Lq5jRw=="
-    },
     "react-dom": {
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "prop-types": "^15.7.2",
     "qs": "^6.9.1",
     "react": "^16.13.1",
-    "react-content-loader": "^4.3.2",
     "react-dom": "^16.13.0",
     "react-intl": "^3.6.2",
     "react-json-view": "^1.19.1",

--- a/src/App.js
+++ b/src/App.js
@@ -20,7 +20,6 @@ import '@redhat-cloud-services/frontend-components-notifications/index.css';
 import '@redhat-cloud-services/frontend-components/index.css';
 import { getAxiosInstance } from './helpers/shared/user-login';
 import { CATALOG_API_BASE, SOURCES_API_BASE } from './utilities/constants';
-import GlobalStyle from './global-styles';
 import UserContext from './user-context';
 
 smoothscroll.polyfill();
@@ -112,7 +111,6 @@ const App = () => {
         value={{ permissions: userPermissions, userIdentity }}
       >
         <Fragment>
-          <GlobalStyle />
           <NotificationsPortal />
           <Main className="pf-u-p-0 pf-u-ml-0">
             <Grid style={{ minHeight: MIN_SCREEN_HEIGHT }}>

--- a/src/presentational-components/shared/loader-placeholders.js
+++ b/src/presentational-components/shared/loader-placeholders.js
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react';
-import ContentLoader, { List } from 'react-content-loader';
 import PropTypes from 'prop-types';
 import { Main } from '@redhat-cloud-services/frontend-components/components/Main';
 import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner/Spinner';
@@ -20,10 +19,64 @@ import {
   FormGroup,
   TextContent,
   Text,
-  TextVariants
+  TextVariants,
+  ActionGroup,
+  Button
 } from '@patternfly/react-core';
+import styled, { keyframes } from 'styled-components';
 
-export const CardLoader = ({ items, ...props }) => (
+const wave = keyframes`
+  0% {
+    transform: translateX(-100%);
+  }
+  60% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+`;
+
+const Skeleton = ({ component: Component = 'span', ...props }) => {
+  return (
+    <SkeletonContainer {...props}>
+      <Component />
+    </SkeletonContainer>
+  );
+};
+
+Skeleton.propTypes = {
+  component: PropTypes.string
+};
+
+const SkeletonContainer = styled.div`
+  & > * {
+    position: relative;
+    overflow: hidden;
+    width: ${({ width }) =>
+      width ? `${width}${typeof width === 'number' ? 'px' : ''}` : '100%'};
+    height: ${({ height }) =>
+      height ? `${height}${typeof height === 'number' ? 'px' : ''}` : '20px'};
+    display: block;
+    border-radius: 3px;
+    background-color: ${({ secondaryColor }) =>
+      secondaryColor ? secondaryColor : '#f3f3f3'};
+    &:after {
+      animation: 2s ${wave} linear 0.5s infinite;
+      background: linear-gradient(90deg, transparent, #ecebeb, transparent);
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      top: 0;
+      transform: translateX(-100%);
+      z-index: 1;
+    }
+  }
+`;
+
+export const CardLoader = ({ items }) => (
   <Grid gutter="md">
     <GridItem sm={12} className="pf-u-p-md">
       <Gallery gutter="md">
@@ -31,41 +84,10 @@ export const CardLoader = ({ items, ...props }) => (
           <GalleryItem key={index}>
             <Card style={{ height: 350 }}>
               <CardBody>
-                <ContentLoader
-                  height={160}
-                  width={300}
-                  speed={2}
-                  primaryColor="#f3f3f3"
-                  secondaryColor="#ecebeb"
-                  {...props}
-                >
-                  <rect x="2" y="99" rx="3" ry="3" width="300" height="6.4" />
-                  <rect
-                    x="2"
-                    y="119.72"
-                    rx="3"
-                    ry="3"
-                    width="290"
-                    height="5.76"
-                  />
-                  <rect x="2" y="139" rx="3" ry="3" width="201" height="6.4" />
-                  <rect
-                    x="-2.16"
-                    y="0.67"
-                    rx="0"
-                    ry="0"
-                    width="271.6"
-                    height="82.74"
-                  />
-                  <rect
-                    x="136.84"
-                    y="37.67"
-                    rx="0"
-                    ry="0"
-                    width="6"
-                    height="3"
-                  />
-                </ContentLoader>
+                <Skeleton height={70} width="85%" className="pf-u-mb-lg" />
+                <Skeleton height={5} width="90%" className="pf-u-mb-sm" />
+                <Skeleton height={5} width="100%" className="pf-u-mb-sm" />
+                <Skeleton height={5} width="76%" className="pf-u-mb-sm" />
               </CardBody>
             </Card>
           </GalleryItem>
@@ -83,47 +105,10 @@ CardLoader.defaultProps = {
   items: 13
 };
 
-export const PortfolioLoader = ({ items, ...props }) => (
-  <Grid gutter="md">
-    <GridItem sm={12}>
-      <ContentLoader
-        height={16}
-        width={300}
-        speed={2}
-        primaryColor="#FFFFFF"
-        secondaryColor="#FFFFFF"
-        {...props}
-      >
-        <rect x="0" y="0" rx="0" ry="0" width="420" height="16" />
-      </ContentLoader>
-    </GridItem>
-    <GridItem sm={12} style={{ paddingLeft: 16, paddingRight: 16 }}>
-      <CardLoader items={items} />
-    </GridItem>
-  </Grid>
-);
-
-PortfolioLoader.propTypes = {
-  items: PropTypes.number
-};
-
-PortfolioLoader.defaultProps = {
-  items: 5
-};
-
-export const AppPlaceholder = (props) => (
+export const AppPlaceholder = () => (
   <Main className="pf-u-m-0 pf-u-p-0">
-    <ContentLoader
-      height={16}
-      width={300}
-      speed={2}
-      primaryColor="#FFFFFF"
-      secondaryColor="#FFFFFF"
-      {...props}
-    >
-      <rect x="0" y="0" rx="0" ry="0" width="420" height="10" />
-    </ContentLoader>
-    <div>
+    <Skeleton height={32} className="pf-u-p-lg global-primary-background" />
+    <div className="pf-u-mt-lg">
       <Bullseye>
         <Spinner />
       </Bullseye>
@@ -131,36 +116,27 @@ export const AppPlaceholder = (props) => (
   </Main>
 );
 
-export const ToolbarTitlePlaceholder = (props) => (
-  <ContentLoader
-    height={21}
-    width={200}
-    speed={2}
-    primaryColor="#f3f3f3"
-    secondaryColor="#ecebeb"
-    {...props}
-  >
-    <rect x="0" y="0" rx="0" ry="0" width="200" height="21" />
-  </ContentLoader>
-);
+export const ToolbarTitlePlaceholder = () => <Skeleton height={30} />;
 
-export const ProductLoaderPlaceholder = (props) => (
+const ProducLoaderColumn = styled.div`
+  width: 100%;
+  max-width: 250px;
+`;
+
+export const ProductLoaderPlaceholder = () => (
   <Fragment>
-    <ContentLoader
-      height={15}
-      width={200}
-      speed={2}
-      primaryColor="#f3f3f3"
-      secondaryColor="#ecebeb"
-      {...props}
-    >
-      <rect x="0" y="0" rx="0" ry="0" width="200" height="10" />
-    </ContentLoader>
-    <div style={{ width: 300 }}>
-      <List />
-      <List speed={3} />
-      <List />
-    </div>
+    <Skeleton height={70} className="pf-u-mb-xl" />
+    <ProducLoaderColumn>
+      {[...Array(3)].map((_, index) => (
+        <Fragment key={index}>
+          <Skeleton height={8} className="pf-u-mb-sm" />
+          <Skeleton height={8} className="pf-u-ml-md pf-u-mb-sm" width="60%" />
+          <Skeleton height={8} className="pf-u-ml-md pf-u-mb-sm" width="50%" />
+          <Skeleton height={8} className="pf-u-mb-sm" width="80%" />
+          <Skeleton height={8} className="pf-u-ml-md pf-u-mb-lg" width="40%" />
+        </Fragment>
+      ))}
+    </ProducLoaderColumn>
   </Fragment>
 );
 
@@ -178,17 +154,7 @@ IconPlaceholder.defaultProps = {
   height: '40'
 };
 
-const FormItemLoader = () => (
-  <ContentLoader
-    height={36}
-    width={400}
-    speed={2}
-    primaryColor="#ffffff"
-    secondaryColor="#ecebeb"
-  >
-    <rect x="0" y="0" rx="0" ry="0" width="400" height="36" />
-  </ContentLoader>
-);
+const FormItemLoader = () => <Skeleton height={38} className="pf-u-mb-lg" />;
 
 export const ShareLoader = () => (
   <Form>
@@ -212,18 +178,18 @@ export const ShareLoader = () => (
 
 export const WorkflowLoader = () => (
   <Form>
-    <FormGroup fieldId="1">
-      <TextContent>
-        <Text component={TextVariants.medium}>Approval workflow</Text>
-      </TextContent>
-    </FormGroup>
-    <FormGroup fieldId="2">
+    <FormGroup fieldId="2" label="Select workflow">
       <FormItemLoader />
     </FormGroup>
+    <ActionGroup>
+      <Button variant="primary" isDisabled>
+        Save
+      </Button>
+    </ActionGroup>
   </Form>
 );
 
-export const ListLoader = ({ items, ...props }) => (
+export const ListLoader = ({ items }) => (
   <DataList aria-label="list-loader" aria-labelledby="datalist-placeholder">
     {[...Array(items)].map((_item, index) => (
       <DataListItem key={index} aria-labelledby="datalist-item-placeholder">
@@ -231,16 +197,7 @@ export const ListLoader = ({ items, ...props }) => (
           <DataListItemCells
             dataListCells={[
               <DataListCell key="1">
-                <ContentLoader
-                  height={12}
-                  width={300}
-                  speed={2}
-                  primaryColor="#FFFFFF"
-                  secondaryColor="#ecebeb"
-                  {...props}
-                >
-                  <rect x="0" y="0" rx="0" ry="0" width="300" height="12" />
-                </ContentLoader>
+                <Skeleton height={67} />
               </DataListCell>
             ]}
           />
@@ -258,10 +215,4 @@ ListLoader.defaultProps = {
   items: 5
 };
 
-export const OrderDetailToolbarPlaceholder = () => (
-  <div>
-    <ContentLoader height={20} width={300}>
-      <rect x="0" y="0" rx="0" ry="0" width="300" height="12" />
-    </ContentLoader>
-  </div>
-);
+export const OrderDetailToolbarPlaceholder = () => <Skeleton height={70} />;

--- a/src/router.js
+++ b/src/router.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import AppContext from './app-context';
+import GlobalStyle from './global-styles';
 
 const pathName = window.location.pathname.split('/');
 pathName.shift();
@@ -13,6 +14,7 @@ if (pathName[0] === 'beta') {
 
 const Router = () => (
   <AppContext.Provider value={{ release }}>
+    <GlobalStyle />
     <BrowserRouter basename={`${release}${pathName[0]}/${pathName[1]}`}>
       <App />
     </BrowserRouter>

--- a/src/test/presentational-components/platform/__snapshots__/platform-item.test.js.snap
+++ b/src/test/presentational-components/platform/__snapshots__/platform-item.test.js.snap
@@ -8,10 +8,10 @@ exports[`<PlatformItem /> should render correctly 1`] = `
     key="Foo"
   >
     <Card
-      className="sc-Axmtr bVdtCA"
+      className="sc-fzozJi dCCegk"
     >
       <article
-        className="pf-c-card sc-Axmtr bVdtCA"
+        className="pf-c-card sc-fzozJi dCCegk"
       >
         <CardHeader>
           <div
@@ -29,7 +29,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                     height={40}
                   >
                     <div
-                      className="sc-AxirZ kGKGpr"
+                      className="sc-AxhCb kcBhCv"
                       height={40}
                     >
                       <IconPlaceholder
@@ -59,7 +59,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                         <t
                           afterLoad={[Function]}
                           beforeLoad={[Function]}
-                          className="sc-AxjAm fBVHdt"
+                          className="sc-AxiKw kPfjgK"
                           delayMethod="throttle"
                           delayTime={0}
                           effect=""
@@ -76,7 +76,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                           <t
                             afterLoad={[Function]}
                             beforeLoad={[Function]}
-                            className="sc-AxjAm fBVHdt"
+                            className="sc-AxiKw kPfjgK"
                             delayMethod="throttle"
                             delayTime={0}
                             height={0}
@@ -84,7 +84,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                             visibleByDefault={false}
                           >
                             <img
-                              className="sc-AxjAm fBVHdt"
+                              className="sc-AxiKw kPfjgK"
                               height={0}
                               hidden={true}
                               onError={[Function]}
@@ -106,10 +106,10 @@ exports[`<PlatformItem /> should render correctly 1`] = `
         >
           <Styled(CardBody)>
             <CardBody
-              className="sc-AxheI fdbZUy"
+              className="sc-AxmLO yfVDw"
             >
               <div
-                className="pf-c-card__body sc-AxheI fdbZUy"
+                className="pf-c-card__body sc-AxmLO yfVDw"
               >
                 <TextContent>
                   <div
@@ -125,7 +125,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                         >
                           <styled.div>
                             <div
-                              className="sc-AxgMl ytwOc"
+                              className="sc-Axmtr TurKp"
                             />
                           </styled.div>
                         </h3>
@@ -145,7 +145,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                     key="card-prop-long_description"
                   >
                     <div
-                      className="sc-AxiKw iUXPLF"
+                      className="sc-AxhUy cLUHxg"
                     />
                   </styled.div>
                 </ItemDetails>

--- a/src/test/presentational-components/shared/__snapshots__/loader-placeholders.test.js.snap
+++ b/src/test/presentational-components/shared/__snapshots__/loader-placeholders.test.js.snap
@@ -4,24 +4,13 @@ exports[`Loader placeholders should render <AppPlaceholder /> correctly 1`] = `
 <Connect(Main)
   className="pf-u-m-0 pf-u-p-0"
 >
-  <ContentLoader
-    height={16}
-    primaryColor="#FFFFFF"
-    secondaryColor="#FFFFFF"
-    speed={2}
-    store={[Function]}
-    width={300}
+  <Skeleton
+    className="pf-u-p-lg global-primary-background"
+    height={32}
+  />
+  <div
+    className="pf-u-mt-lg"
   >
-    <rect
-      height="10"
-      rx="0"
-      ry="0"
-      width="420"
-      x="0"
-      y="0"
-    />
-  </ContentLoader>
-  <div>
     <Bullseye>
       <Spinner />
     </Bullseye>
@@ -51,54 +40,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -113,54 +74,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -175,54 +108,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -237,54 +142,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -299,54 +176,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -361,54 +210,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -423,54 +244,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -485,54 +278,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -547,54 +312,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -609,54 +346,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -671,54 +380,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -733,54 +414,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -795,54 +448,26 @@ exports[`Loader placeholders should render <CardLoader /> correctly 1`] = `
           }
         >
           <CardBody>
-            <ContentLoader
-              height={160}
-              primaryColor="#f3f3f3"
-              secondaryColor="#ecebeb"
-              speed={2}
-              width={300}
-            >
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="300"
-                x="2"
-                y="99"
-              />
-              <rect
-                height="5.76"
-                rx="3"
-                ry="3"
-                width="290"
-                x="2"
-                y="119.72"
-              />
-              <rect
-                height="6.4"
-                rx="3"
-                ry="3"
-                width="201"
-                x="2"
-                y="139"
-              />
-              <rect
-                height="82.74"
-                rx="0"
-                ry="0"
-                width="271.6"
-                x="-2.16"
-                y="0.67"
-              />
-              <rect
-                height="3"
-                rx="0"
-                ry="0"
-                width="6"
-                x="136.84"
-                y="37.67"
-              />
-            </ContentLoader>
+            <Skeleton
+              className="pf-u-mb-lg"
+              height={70}
+              width="85%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="90%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="100%"
+            />
+            <Skeleton
+              className="pf-u-mb-sm"
+              height={5}
+              width="76%"
+            />
           </CardBody>
         </Card>
       </GalleryItem>
@@ -867,22 +492,9 @@ exports[`Loader placeholders should render <ListLoader /> correctly 1`] = `
         dataListCells={
           Array [
             <DataListCell>
-              <ContentLoader
-                height={12}
-                primaryColor="#FFFFFF"
-                secondaryColor="#ecebeb"
-                speed={2}
-                width={300}
-              >
-                <rect
-                  height="12"
-                  rx="0"
-                  ry="0"
-                  width="300"
-                  x="0"
-                  y="0"
-                />
-              </ContentLoader>
+              <Skeleton
+                height={67}
+              />
             </DataListCell>,
           ]
         }
@@ -900,22 +512,9 @@ exports[`Loader placeholders should render <ListLoader /> correctly 1`] = `
         dataListCells={
           Array [
             <DataListCell>
-              <ContentLoader
-                height={12}
-                primaryColor="#FFFFFF"
-                secondaryColor="#ecebeb"
-                speed={2}
-                width={300}
-              >
-                <rect
-                  height="12"
-                  rx="0"
-                  ry="0"
-                  width="300"
-                  x="0"
-                  y="0"
-                />
-              </ContentLoader>
+              <Skeleton
+                height={67}
+              />
             </DataListCell>,
           ]
         }
@@ -933,22 +532,9 @@ exports[`Loader placeholders should render <ListLoader /> correctly 1`] = `
         dataListCells={
           Array [
             <DataListCell>
-              <ContentLoader
-                height={12}
-                primaryColor="#FFFFFF"
-                secondaryColor="#ecebeb"
-                speed={2}
-                width={300}
-              >
-                <rect
-                  height="12"
-                  rx="0"
-                  ry="0"
-                  width="300"
-                  x="0"
-                  y="0"
-                />
-              </ContentLoader>
+              <Skeleton
+                height={67}
+              />
             </DataListCell>,
           ]
         }
@@ -966,22 +552,9 @@ exports[`Loader placeholders should render <ListLoader /> correctly 1`] = `
         dataListCells={
           Array [
             <DataListCell>
-              <ContentLoader
-                height={12}
-                primaryColor="#FFFFFF"
-                secondaryColor="#ecebeb"
-                speed={2}
-                width={300}
-              >
-                <rect
-                  height="12"
-                  rx="0"
-                  ry="0"
-                  width="300"
-                  x="0"
-                  y="0"
-                />
-              </ContentLoader>
+              <Skeleton
+                height={67}
+              />
             </DataListCell>,
           ]
         }
@@ -999,22 +572,9 @@ exports[`Loader placeholders should render <ListLoader /> correctly 1`] = `
         dataListCells={
           Array [
             <DataListCell>
-              <ContentLoader
-                height={12}
-                primaryColor="#FFFFFF"
-                secondaryColor="#ecebeb"
-                speed={2}
-                width={300}
-              >
-                <rect
-                  height="12"
-                  rx="0"
-                  ry="0"
-                  width="300"
-                  x="0"
-                  y="0"
-                />
-              </ContentLoader>
+              <Skeleton
+                height={67}
+              />
             </DataListCell>,
           ]
         }
@@ -1022,44 +582,4 @@ exports[`Loader placeholders should render <ListLoader /> correctly 1`] = `
     </DataListItemRow>
   </DataListItem>
 </DataList>
-`;
-
-exports[`Loader placeholders should render <PortfolioLoader /> correctly 1`] = `
-<Grid
-  gutter="md"
->
-  <GridItem
-    sm={12}
-  >
-    <ContentLoader
-      height={16}
-      primaryColor="#FFFFFF"
-      secondaryColor="#FFFFFF"
-      speed={2}
-      width={300}
-    >
-      <rect
-        height="16"
-        rx="0"
-        ry="0"
-        width="420"
-        x="0"
-        y="0"
-      />
-    </ContentLoader>
-  </GridItem>
-  <GridItem
-    sm={12}
-    style={
-      Object {
-        "paddingLeft": 16,
-        "paddingRight": 16,
-      }
-    }
-  >
-    <CardLoader
-      items={5}
-    />
-  </GridItem>
-</Grid>
 `;

--- a/src/test/presentational-components/shared/loader-placeholders.test.js
+++ b/src/test/presentational-components/shared/loader-placeholders.test.js
@@ -4,7 +4,6 @@ import toJson from 'enzyme-to-json';
 import configureStore from 'redux-mock-store';
 import {
   AppPlaceholder,
-  PortfolioLoader,
   CardLoader,
   ListLoader
 } from '../../../presentational-components/shared/loader-placeholders';
@@ -15,10 +14,6 @@ describe('Loader placeholders', () => {
     expect(
       toJson(shallow(<AppPlaceholder store={mockStore} />))
     ).toMatchSnapshot();
-  });
-
-  it('should render <PortfolioLoader /> correctly', () => {
-    expect(toJson(shallow(<PortfolioLoader />))).toMatchSnapshot();
   });
 
   it('should render <CardLoader /> correctly', () => {

--- a/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
+++ b/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
@@ -10,17 +10,17 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
 >
   <Styled(GalleryItem)>
     <GalleryItem
-      className="sc-AxmLO bSqRm"
+      className="sc-fzoLsD iHpspR"
     >
       <div
-        className="sc-AxmLO bSqRm"
+        className="sc-fzoLsD iHpspR"
       >
         <Styled(Card)>
           <Card
-            className="sc-Axmtr bVdtCA"
+            className="sc-fzozJi dCCegk"
           >
             <article
-              className="pf-c-card sc-Axmtr bVdtCA"
+              className="pf-c-card sc-fzozJi dCCegk"
             >
               <CardHeader
                 className="card_header"
@@ -41,7 +41,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                           height={40}
                         >
                           <div
-                            className="sc-AxirZ kGKGpr"
+                            className="sc-AxhCb kcBhCv"
                             height={40}
                           >
                             <IconPlaceholder
@@ -71,7 +71,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                               <t
                                 afterLoad={[Function]}
                                 beforeLoad={[Function]}
-                                className="sc-AxjAm fBVHdt"
+                                className="sc-AxiKw kPfjgK"
                                 delayMethod="throttle"
                                 delayTime={0}
                                 effect=""
@@ -88,7 +88,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                 <t
                                   afterLoad={[Function]}
                                   beforeLoad={[Function]}
-                                  className="sc-AxjAm fBVHdt"
+                                  className="sc-AxiKw kPfjgK"
                                   delayMethod="throttle"
                                   delayTime={0}
                                   height={0}
@@ -96,7 +96,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                   visibleByDefault={false}
                                 >
                                   <img
-                                    className="sc-AxjAm fBVHdt"
+                                    className="sc-AxiKw kPfjgK"
                                     height={0}
                                     hidden={true}
                                     onError={[Function]}
@@ -122,10 +122,10 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
               >
                 <Styled(CardBody)>
                   <CardBody
-                    className="sc-AxheI fdbZUy"
+                    className="sc-AxmLO yfVDw"
                   >
                     <div
-                      className="pf-c-card__body sc-AxheI fdbZUy"
+                      className="pf-c-card__body sc-AxmLO yfVDw"
                     >
                       <TextContent>
                         <div
@@ -143,7 +143,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                               >
                                 <styled.div>
                                   <div
-                                    className="sc-AxgMl ytwOc"
+                                    className="sc-Axmtr TurKp"
                                   >
                                     Foo
                                   </div>
@@ -167,7 +167,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                           key="card-prop-description"
                         >
                           <div
-                            className="sc-AxiKw iUXPLF"
+                            className="sc-AxhUy cLUHxg"
                           >
                             Bar
                           </div>


### PR DESCRIPTION
a detailed description of the issue:  https://github.com/danilowoz/react-content-loader/issues/93

jira: https://projects.engineering.redhat.com/browse/SSP-1385

There are no visual changes

### Issues
- safari browser is displaying black stripes in content loaders
- fix for safari broke chrome on Linux so I removed the library and implemented it using CSS
- CSS implementation should have much better browser support and is actually customizable
