### PR TITLE
Fixed styled card body spacing.

### DIFF
--- a/src/presentational-components/styled-components/card.js
+++ b/src/presentational-components/styled-components/card.js
@@ -4,6 +4,6 @@ import { CardBody } from '@patternfly/react-core';
 export const StyledCardBody = styled(CardBody)`
   height: 230px;
   overflow: hidden;
-  padding: 0;
+  padding: 0 !important;
   margin: 0 24px 24px;
 `;

--- a/src/test/presentational-components/platform/__snapshots__/platform-card.test.js.snap
+++ b/src/test/presentational-components/platform/__snapshots__/platform-card.test.js.snap
@@ -33,10 +33,10 @@ exports[`<PlatformCard /> should choose card image 1`] = `
             </CardHeader>
             <Styled(CardBody)>
               <CardBody
-                className="sc-AxheI fdbZUy"
+                className="sc-AxheI dqZNlB"
               >
                 <div
-                  className="pf-c-card__body sc-AxheI fdbZUy"
+                  className="pf-c-card__body sc-AxheI dqZNlB"
                 >
                   <TextContent>
                     <div
@@ -189,10 +189,10 @@ exports[`<PlatformCard /> should render correctly 1`] = `
             </CardHeader>
             <Styled(CardBody)>
               <CardBody
-                className="sc-AxheI fdbZUy"
+                className="sc-AxheI dqZNlB"
               >
                 <div
-                  className="pf-c-card__body sc-AxheI fdbZUy"
+                  className="pf-c-card__body sc-AxheI dqZNlB"
                 >
                   <TextContent>
                     <div

--- a/src/test/presentational-components/platform/__snapshots__/platform-item.test.js.snap
+++ b/src/test/presentational-components/platform/__snapshots__/platform-item.test.js.snap
@@ -106,10 +106,10 @@ exports[`<PlatformItem /> should render correctly 1`] = `
         >
           <Styled(CardBody)>
             <CardBody
-              className="sc-AxmLO yfVDw"
+              className="sc-AxmLO dGjJwL"
             >
               <div
-                className="pf-c-card__body sc-AxmLO yfVDw"
+                className="pf-c-card__body sc-AxmLO dGjJwL"
               >
                 <TextContent>
                   <div

--- a/src/test/presentational-components/shared/__snapshots__/service-offering-body.test.js.snap
+++ b/src/test/presentational-components/shared/__snapshots__/service-offering-body.test.js.snap
@@ -9,10 +9,10 @@ exports[`<ServiceOfferingCardBody /> should render correctly 1`] = `
 >
   <Styled(CardBody)>
     <CardBody
-      className="sc-AxhUy gRhpOq"
+      className="sc-AxhUy loBGYF"
     >
       <div
-        className="pf-c-card__body sc-AxhUy gRhpOq"
+        className="pf-c-card__body sc-AxhUy loBGYF"
       >
         <TextContent>
           <div
@@ -81,10 +81,10 @@ exports[`<ServiceOfferingCardBody /> should render correctly with alternative va
 >
   <Styled(CardBody)>
     <CardBody
-      className="sc-AxhUy gRhpOq"
+      className="sc-AxhUy loBGYF"
     >
       <div
-        className="pf-c-card__body sc-AxhUy gRhpOq"
+        className="pf-c-card__body sc-AxhUy loBGYF"
       >
         <TextContent>
           <div

--- a/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
+++ b/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
@@ -139,10 +139,10 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                 >
                   <Styled(CardBody)>
                     <CardBody
-                      className="sc-AxmLO yfVDw"
+                      className="sc-AxmLO dGjJwL"
                     >
                       <div
-                        className="pf-c-card__body sc-AxmLO yfVDw"
+                        className="pf-c-card__body sc-AxmLO dGjJwL"
                       >
                         <TextContent>
                           <div


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1424

This issue was caused by a different order of loading CSS assets. PF css was loaded after the catalog styles, which meant it was overriding catalog styles. The `!important` flag should be an easy fix.

### Before
![screenshot-ci foo redhat com_1337-2020 04 07-09_32_17](https://user-images.githubusercontent.com/22619452/78642971-d79b9c00-78b3-11ea-8fd8-73702b452d88.png)

### After
![screenshot-ci foo redhat com_1337-2020 04 07-09_39_24](https://user-images.githubusercontent.com/22619452/78642983-db2f2300-78b3-11ea-8b54-86cf28ab9d2b.png)
