### PR TITLE
Use portfolio directly from selectedPortfolio in portfolio item detail.

### DIFF
--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -396,7 +396,7 @@ export const updatePortfolioItem = (values) => (dispatch, getState) => {
     );
 };
 
-export const getPortfolioItemDetail = (params) => (dispatch, getState) => {
+export const getPortfolioItemDetail = (params) => (dispatch) => {
   dispatch({ type: `${ActionTypes.SELECT_PORTFOLIO_ITEM}_PENDING` });
   return PortfolioHelper.getPortfolioItemDetail(params).then(
     ([portfolioItem, source]) =>
@@ -404,7 +404,6 @@ export const getPortfolioItemDetail = (params) => (dispatch, getState) => {
         type: `${ActionTypes.SELECT_PORTFOLIO_ITEM}_FULFILLED`,
         payload: {
           portfolioItem,
-          portfolio: getState().portfolioReducer.selectedPortfolio,
           source
         }
       })

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -39,9 +39,11 @@ const PortfolioItemDetail = () => {
       metadata: { user_capabilities: userCapabilities },
       ...portfolioItem
     },
-    portfolio,
     source
   } = useSelector(({ portfolioReducer: { portfolioItem } }) => portfolioItem);
+  const portfolio = useSelector(
+    ({ portfolioReducer: { selectedPortfolio } }) => selectedPortfolio
+  );
 
   useEffect(() => {
     setIsFetching(true);

--- a/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
@@ -57,6 +57,10 @@ describe('<PortfolioItemDetail />', () => {
         platformIconMapping: {}
       },
       portfolioReducer: {
+        selectedPortfolio: {
+          id: '333',
+          name: 'Portfolio name'
+        },
         portfolioItem: {
           portfolioItem: {
             id: '123',
@@ -71,11 +75,7 @@ describe('<PortfolioItemDetail />', () => {
               }
             }
           },
-          source: { id: '111', name: 'Source name' },
-          portfolio: {
-            id: '333',
-            name: 'Portfolio name'
-          }
+          source: { id: '111', name: 'Source name' }
         }
       },
       orderReducer: {


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1417

### Changes
- in portfolio item detail, use `selectedPortfolio` instead of assigning it to the `portfolioItem` in the action creator (portfolio might not exist at that point)
- there were issues with missing data if the request for portfolio item finished before the request for the selected portfolio