### PR TITLE
Encode view state to URL fragment

### DIFF
--- a/src/redux/actions/order-actions.js
+++ b/src/redux/actions/order-actions.js
@@ -4,6 +4,7 @@ import { addNotification } from '@redhat-cloud-services/frontend-components-noti
 import * as ActionTypes from '../action-types';
 import * as OrderHelper from '../../helpers/order/order-helper';
 import OrderNotification from '../../presentational-components/order/order-notification';
+import { defaultSettings } from '../../helpers/shared/pagination';
 
 export const fetchServicePlans = (portfolioItemId) => ({
   type: ActionTypes.FETCH_SERVICE_PLANS,
@@ -75,7 +76,9 @@ export const cancelOrder = (orderId) => (dispatch, getState) => {
     });
 };
 
-export const fetchOrders = (filters, pagination) => (dispatch) => {
+export const fetchOrders = (filters, pagination = defaultSettings) => (
+  dispatch
+) => {
   const queryFilter = Object.entries(filters)
     .filter(([, value]) => value && value.length > 0)
     .map(([key, value]) =>
@@ -93,7 +96,13 @@ export const fetchOrders = (filters, pagination) => (dispatch) => {
       });
       return dispatch({
         type: `${ActionTypes.FETCH_ORDERS}_FULFILLED`,
-        meta: { filter: queryFilter },
+        meta: {
+          ...pagination,
+          filter: queryFilter,
+          filters,
+          storeState: true,
+          stateKey: 'orders'
+        },
         payload: orders
       });
     })

--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -14,20 +14,26 @@ export const doFetchPortfolios = ({
   ...options
 } = defaultSettings) => ({
   type: ActionTypes.FETCH_PORTFOLIOS,
-  meta: { filter },
+  meta: { filter, ...options },
   payload: PortfolioHelper.listPortfolios(filter, options)
 });
 
-export const fetchPortfolios = (...args) => (dispatch) => {
-  return dispatch(doFetchPortfolios(...args));
-};
+export const fetchPortfolios = (options) => (dispatch) =>
+  dispatch(doFetchPortfolios(options));
+
+export const fetchPortfoliosWithState = (options = defaultSettings) => (
+  dispatch
+) =>
+  dispatch(
+    doFetchPortfolios({ ...options, storeState: true, stateKey: 'portfolio' })
+  );
 
 export const fetchPortfolioItems = (
   filter = '',
   options = defaultSettings
 ) => ({
   type: ActionTypes.FETCH_PORTFOLIO_ITEMS,
-  meta: { filter },
+  meta: { filter, storeState: true, stateKey: 'products' },
   payload: PortfolioHelper.listPortfolioItems(
     options.limit,
     options.offset,
@@ -40,8 +46,12 @@ export const fetchPortfolioItemsWithPortfolio = (
   options = defaultSettings
 ) => ({
   type: ActionTypes.FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO,
-  meta: { filter: options.filter },
-  payload: PortfolioHelper.getPortfolioItemsWithPortfolio(portfolioId, options)
+  payload: PortfolioHelper.getPortfolioItemsWithPortfolio(portfolioId, options),
+  meta: {
+    ...options,
+    storeState: true,
+    stateKey: 'portfolioItems'
+  }
 });
 
 export const fetchSelectedPortfolio = (id) => ({

--- a/src/routing/uri-state-manager.js
+++ b/src/routing/uri-state-manager.js
@@ -1,0 +1,26 @@
+export const decodeState = (encodedState) => {
+  try {
+    return JSON.parse(atob(decodeURIComponent(encodedState)));
+  } catch (error) {
+    return undefined;
+  }
+};
+
+export const encodeState = (state, stateKey) => {
+  const stateObject = stateKey
+    ? {
+        ...decodeState(window.location.hash),
+        [stateKey]: state
+      }
+    : state;
+  try {
+    return encodeURIComponent(btoa(JSON.stringify(stateObject)));
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'View state is not a valid JSON, state has will not be generated. View state: ',
+      state
+    );
+    return '';
+  }
+};

--- a/src/routing/use-initial-uri-hash.js
+++ b/src/routing/use-initial-uri-hash.js
@@ -1,0 +1,5 @@
+import { decodeState } from './uri-state-manager';
+
+const useInitialUriHash = () => decodeState(window.location.hash.substring(1));
+
+export default useInitialUriHash;

--- a/src/test/redux/actions/portfolio-actions.test.js
+++ b/src/test/redux/actions/portfolio-actions.test.js
@@ -65,12 +65,25 @@ describe('Portfolio actions', () => {
     const expectedActions = [
       {
         type: `${FETCH_PORTFOLIOS}_PENDING`,
-        meta: { filter: '' }
+        meta: {
+          count: 0,
+          filter: '',
+          limit: 50,
+          offset: 0
+        }
       },
       {
         type: `${FETCH_PORTFOLIOS}_FULFILLED`,
-        meta: { filter: '' },
-        payload: { data: [expectedPortfolio], meta: {} }
+        meta: {
+          count: 0,
+          filter: '',
+          limit: 50,
+          offset: 0
+        },
+        payload: {
+          data: [expectedPortfolio],
+          meta: {}
+        }
       }
     ];
 
@@ -89,7 +102,7 @@ describe('Portfolio actions', () => {
     const expectedActions = expect.arrayContaining([
       {
         type: `${FETCH_PORTFOLIOS}_PENDING`,
-        meta: { filter: '' }
+        meta: { filter: '', count: 0, limit: 50, offset: 0 }
       },
       expect.objectContaining({
         type: ADD_NOTIFICATION,
@@ -134,11 +147,11 @@ describe('Portfolio actions', () => {
     const expectedActions = [
       {
         type: `${FETCH_PORTFOLIO_ITEMS}_PENDING`,
-        meta: { filter: '123' }
+        meta: { filter: '123', stateKey: 'products', storeState: true }
       },
       {
         type: `${FETCH_PORTFOLIO_ITEMS}_FULFILLED`,
-        meta: { filter: '123' },
+        meta: { filter: '123', stateKey: 'products', storeState: true },
         payload: {
           data: [
             {
@@ -168,11 +181,25 @@ describe('Portfolio actions', () => {
     const expectedActions = [
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`,
-        meta: { filter: '' }
+        meta: {
+          count: 0,
+          filter: '',
+          limit: 50,
+          offset: 0,
+          stateKey: 'portfolioItems',
+          storeState: true
+        }
       },
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_FULFILLED`,
-        meta: { filter: '' },
+        meta: {
+          count: 0,
+          filter: '',
+          limit: 50,
+          offset: 0,
+          stateKey: 'portfolioItems',
+          storeState: true
+        },
         payload: { data: ['foo'] }
       }
     ];
@@ -381,13 +408,21 @@ describe('Portfolio actions', () => {
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`,
         meta: {
-          filter: ''
+          filter: '',
+          limit: 0,
+          offset: 0,
+          stateKey: 'portfolioItems',
+          storeState: true
         }
       },
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_FULFILLED`,
         meta: {
-          filter: ''
+          filter: '',
+          limit: 0,
+          offset: 0,
+          stateKey: 'portfolioItems',
+          storeState: true
         },
         payload: []
       },
@@ -455,11 +490,25 @@ describe('Portfolio actions', () => {
       expect.objectContaining({ type: CLEAR_NOTIFICATIONS }),
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`,
-        meta: { filter: '' }
+        meta: {
+          count: 0,
+          filter: '',
+          limit: 50,
+          offset: 0,
+          stateKey: 'portfolioItems',
+          storeState: true
+        }
       },
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_FULFILLED`,
-        meta: { filter: '' },
+        meta: {
+          count: 0,
+          filter: '',
+          limit: 50,
+          offset: 0,
+          stateKey: 'portfolioItems',
+          storeState: true
+        },
         payload: { data: [] }
       },
       expect.objectContaining({ type: ADD_NOTIFICATION })

--- a/src/test/smart-components/portfolio/portfolio.test.js
+++ b/src/test/smart-components/portfolio/portfolio.test.js
@@ -130,7 +130,14 @@ describe('<Portfolio />', () => {
       },
       {
         type: `${FETCH_PORTFOLIO_ITEMS_WITH_PORTFOLIO}_PENDING`,
-        meta: { filter: '' }
+        meta: {
+          filter: '',
+          count: 0,
+          limit: 50,
+          offset: 0,
+          storeState: true,
+          stateKey: 'portfolioItems'
+        }
       },
       expect.objectContaining({
         type: `${FETCH_PORTFOLIO}_FULFILLED`

--- a/src/test/smart-components/portfolio/portfolios.test.js
+++ b/src/test/smart-components/portfolio/portfolios.test.js
@@ -85,7 +85,14 @@ describe('<Portfolios />', () => {
     const expectedActions = [
       {
         type: `${FETCH_PORTFOLIOS}_PENDING`,
-        meta: { filter: '' }
+        meta: {
+          filter: '',
+          count: 0,
+          limit: 50,
+          offset: 0,
+          storeState: true,
+          stateKey: 'portfolio'
+        }
       },
       expect.objectContaining({
         type: `${FETCH_PORTFOLIOS}_FULFILLED`

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -33,6 +33,7 @@ import emptyDataMiddleware from './empty-data-middleware';
 import breadcrumbsReducer, {
   initialBreadcrumbsState
 } from '../redux/reducers/breadcrumbs-reducer';
+import viewStateMiddleware from './view-state-middleware';
 
 const prodMiddlewares = [
   notificationsMiddleware({
@@ -53,6 +54,7 @@ const prodMiddlewares = [
 const baseMiddlewares = [
   thunk,
   promiseMiddleware,
+  viewStateMiddleware,
   loadingStateMiddleware,
   emptyDataMiddleware
 ];

--- a/src/utilities/view-state-middleware.js
+++ b/src/utilities/view-state-middleware.js
@@ -1,0 +1,21 @@
+import { encodeState } from '../routing/uri-state-manager';
+
+const viewStateMiddleware = () => (dispatch) => (action) => {
+  if (
+    action.type.match(/_FULFILLED$/) &&
+    action?.payload?.meta &&
+    action?.meta?.storeState
+  ) {
+    window.location.hash = encodeState(
+      {
+        ...action.meta,
+        ...action.payload.meta
+      },
+      action.meta.stateKey
+    );
+  }
+
+  return dispatch(action);
+};
+
+export default viewStateMiddleware;


### PR DESCRIPTION
### Changes
- added hash to URL which represents the filter state of certain pages
  - allows for sharing exact view-state via URL
  - for example, you can create a filter for completed orders with a specific user and bookmark it
- persistent URL is applied on portfolios, portfolio items (of some portfolio), orders and products list screens
- it can be added to any screen by adding some flags to redux action creators
- the view state is encoded via `atob (btoa)` and then added to hash part of URL. It is not sent to servers and it's not limited by 2083 character limit (give or take, depends on ob browser).

![persitent-url-filters](https://user-images.githubusercontent.com/22619452/78782050-a5686800-79a1-11ea-90aa-3babafd81ffc.gif)
