### PR TITLE
Use table to force order title to be aligned.

### DIFF
--- a/src/presentational-components/styled-components/table.js
+++ b/src/presentational-components/styled-components/table.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import styled from 'styled-components';
+
+const childrenPropType = PropTypes.oneOfType([
+  PropTypes.node,
+  PropTypes.arrayOf(PropTypes.node)
+]);
+
+export const Table = ({ children, className, ...props }) => (
+  <table className={clsx('pf-c-table', 'pf-m-grid-md', className)} {...props}>
+    {children}
+  </table>
+);
+
+Table.propTypes = {
+  children: childrenPropType.isRequired,
+  className: PropTypes.string
+};
+
+export const Tbody = ({ children, ...props }) => (
+  <tbody {...props}>{children}</tbody>
+);
+
+Tbody.propTypes = {
+  children: childrenPropType.isRequired
+};
+
+export const TableCell = styled(({ shrink, children, ...props }) => (
+  <td {...props}>{children}</td>
+))`
+  vertical-align: middle !important;
+  width: ${({ shrink }) => (shrink ? '10%' : 'initial')};
+  img {
+    object-fit: cover;
+  }
+`;

--- a/src/smart-components/order/order-item.js
+++ b/src/smart-components/order/order-item.js
@@ -2,16 +2,10 @@ import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import {
-  DataListCell,
-  DataListItem,
-  DataListItemCells,
-  DataListItemRow,
   Grid,
   GridItem,
   Level,
   LevelItem,
-  Split,
-  SplitItem,
   Text,
   TextContent,
   TextVariants
@@ -31,6 +25,7 @@ import {
   ORDER_APPROVAL_ROUTE,
   ORDER_LIFECYCLE_ROUTE
 } from '../../constants/routes';
+import { TableCell } from '../../presentational-components/styled-components/table';
 
 const routeMapper = {
   'Approval Pending': ORDER_APPROVAL_ROUTE,
@@ -65,105 +60,75 @@ const OrderItem = memo(
       portfolio: orderPortfolio
     };
     return (
-      <React.Fragment>
-        <DataListItem
-          aria-labelledby={`${item.id}-expand`}
-          className="data-list-expand-fix"
-        >
-          <DataListItemRow>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="1">
-                  <Split gutter="sm">
-                    <SplitItem>
-                      <CardIcon
-                        height={60}
-                        src={getOrderIcon(item)}
-                        sourceId={orderPlatform}
+      <tr
+        aria-labelledby={`${item.id}-expand`}
+        className="data-list-expand-fix"
+      >
+        <TableCell shrink className="pf-u-pl-xl">
+          <CardIcon
+            height={60}
+            src={getOrderIcon(item)}
+            sourceId={orderPlatform}
+          />
+        </TableCell>
+        <TableCell>
+          <TextContent>
+            <Grid gutter="sm" className="pf-u-gg-md">
+              <GridItem>
+                <Level>
+                  <LevelItem>
+                    <Text className="pf-u-mb-0" component={TextVariants.h5}>
+                      <CatalogLink
+                        pathname={ORDER_ROUTE}
+                        searchParams={searchParams}
+                      >
+                        {orderName} - Order # {item.id}
+                      </CatalogLink>
+                    </Text>
+                  </LevelItem>
+                  <LevelItem>
+                    <CatalogLink
+                      pathname={routeMapper[item.state] || ORDER_ROUTE}
+                      searchParams={searchParams}
+                    >
+                      {item.state === 'Failed' && (
+                        <ExclamationCircleIcon className="pf-u-mr-sm icon-danger-fill" />
+                      )}
+                      {item.state}
+                    </CatalogLink>
+                  </LevelItem>
+                </Level>
+              </GridItem>
+              <GridItem>
+                <Level>
+                  <LevelItem>
+                    <Text className="pf-u-mb-0" component={TextVariants.small}>
+                      Ordered&nbsp;
+                      <DateFormat date={item.created_at} variant="relative" />
+                    </Text>
+                  </LevelItem>
+                  <LevelItem>
+                    <Text className="pf-u-mb-0" component={TextVariants.small}>
+                      Ordered by {item.owner}
+                    </Text>
+                  </LevelItem>
+                  <LevelItem>
+                    <Text className="pf-u-mb-0" component={TextVariants.small}>
+                      Last updated&nbsp;
+                      <DateFormat
+                        date={
+                          item.orderItems[0] && item.orderItems[0].updated_at
+                        }
+                        variant="relative"
                       />
-                    </SplitItem>
-                    <SplitItem isFilled>
-                      <TextContent>
-                        <Grid gutter="sm" className="pf-u-gg-md">
-                          <GridItem>
-                            <Level>
-                              <LevelItem>
-                                <Text
-                                  className="pf-u-mb-0"
-                                  component={TextVariants.h5}
-                                >
-                                  <CatalogLink
-                                    pathname={ORDER_ROUTE}
-                                    searchParams={searchParams}
-                                  >
-                                    {orderName} - Order # {item.id}
-                                  </CatalogLink>
-                                </Text>
-                              </LevelItem>
-                              <LevelItem>
-                                <CatalogLink
-                                  pathname={
-                                    routeMapper[item.state] || ORDER_ROUTE
-                                  }
-                                  searchParams={searchParams}
-                                >
-                                  {item.state === 'Failed' && (
-                                    <ExclamationCircleIcon className="pf-u-mr-sm icon-danger-fill" />
-                                  )}
-                                  {item.state}
-                                </CatalogLink>
-                              </LevelItem>
-                            </Level>
-                          </GridItem>
-                          <GridItem>
-                            <Level>
-                              <LevelItem>
-                                <Text
-                                  className="pf-u-mb-0"
-                                  component={TextVariants.small}
-                                >
-                                  Ordered&nbsp;
-                                  <DateFormat
-                                    date={item.created_at}
-                                    variant="relative"
-                                  />
-                                </Text>
-                              </LevelItem>
-                              <LevelItem>
-                                <Text
-                                  className="pf-u-mb-0"
-                                  component={TextVariants.small}
-                                >
-                                  Ordered by {item.owner}
-                                </Text>
-                              </LevelItem>
-                              <LevelItem>
-                                <Text
-                                  className="pf-u-mb-0"
-                                  component={TextVariants.small}
-                                >
-                                  Last updated&nbsp;
-                                  <DateFormat
-                                    date={
-                                      item.orderItems[0] &&
-                                      item.orderItems[0].updated_at
-                                    }
-                                    variant="relative"
-                                  />
-                                </Text>
-                              </LevelItem>
-                            </Level>
-                          </GridItem>
-                        </Grid>
-                      </TextContent>
-                    </SplitItem>
-                  </Split>
-                </DataListCell>
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>
-      </React.Fragment>
+                    </Text>
+                  </LevelItem>
+                </Level>
+              </GridItem>
+            </Grid>
+          </TextContent>
+        </TableCell>
+      </tr>
     );
   },
   (prevProps, nextProps) => prevProps.id === nextProps.id

--- a/src/smart-components/order/orders-list.js
+++ b/src/smart-components/order/orders-list.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useReducer } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
-  DataList,
   Grid,
   GridItem,
   Title,
@@ -26,6 +25,10 @@ import OrderItem from './order-item';
 import AsyncPagination from '../common/async-pagination';
 import asyncFormValidator from '../../utilities/async-form-validator';
 import { defaultSettings } from '../../helpers/shared/pagination';
+import {
+  Table,
+  Tbody
+} from '../../presentational-components/styled-components/table';
 
 const debouncedFilter = asyncFormValidator(
   (filters, meta = defaultSettings, dispatch, filteringCallback) => {
@@ -215,50 +218,56 @@ const OrdersList = () => {
               }
             />
           )}
-          <DataList aria-label="order-list">
-            {isFiltering || isFetching ? (
-              <ListLoader />
-            ) : data.length > 0 ? (
-              data.map((item, index) => (
-                <OrderItem key={item.id} index={index} item={item} />
-              ))
-            ) : (
-              <EmptyTable>
-                <Bullseye>
-                  <EmptyState>
-                    <Bullseye>
-                      <EmptyStateIcon icon={SearchIcon} />
-                    </Bullseye>
-                    <Title size="lg">
-                      {meta.noData ? 'No orders' : 'No results found'}
-                    </Title>
-                    <EmptyStateBody>
-                      {meta.noData
-                        ? 'No orders have been created.'
-                        : 'No results match the filter criteria. Remove all filters or clear all filters to show results.'}
-                    </EmptyStateBody>
+          <Table aria-label="order-list">
+            <Tbody>
+              {isFetching || isFiltering ? (
+                <tr>
+                  <td className="pf-u-p-0">
+                    <ListLoader />
+                  </td>
+                </tr>
+              ) : data.length > 0 ? (
+                data.map((item, index) => (
+                  <OrderItem key={item.id} index={index} item={item} />
+                ))
+              ) : (
+                <EmptyTable>
+                  <Bullseye>
+                    <EmptyState>
+                      <Bullseye>
+                        <EmptyStateIcon icon={SearchIcon} />
+                      </Bullseye>
+                      <Title size="lg">
+                        {meta.noData ? 'No orders' : 'No results found'}
+                      </Title>
+                      <EmptyStateBody>
+                        {meta.noData
+                          ? 'No orders have been created.'
+                          : 'No results match the filter criteria. Remove all filters or clear all filters to show results.'}
+                      </EmptyStateBody>
 
-                    <EmptyStateSecondaryActions>
-                      {!meta.noData && (
-                        <Button
-                          variant="link"
-                          onClick={() => {
-                            stateDispatch({
-                              type: 'setFilteringFlag',
-                              payload: true
-                            });
-                            handleFilterItems('');
-                          }}
-                        >
-                          Clear all filters
-                        </Button>
-                      )}
-                    </EmptyStateSecondaryActions>
-                  </EmptyState>
-                </Bullseye>
-              </EmptyTable>
-            )}
-          </DataList>
+                      <EmptyStateSecondaryActions>
+                        {!meta.noData && (
+                          <Button
+                            variant="link"
+                            onClick={() => {
+                              stateDispatch({
+                                type: 'setFilteringFlag',
+                                payload: true
+                              });
+                              handleFilterItems('');
+                            }}
+                          >
+                            Clear all filters
+                          </Button>
+                        )}
+                      </EmptyStateSecondaryActions>
+                    </EmptyState>
+                  </Bullseye>
+                </EmptyTable>
+              )}
+            </Tbody>
+          </Table>
           <TableToolbar>
             <div className="bottom-pagination-container">
               <Flex


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1428

### Changes
- switched from data list to table in the orders view
  - it does use PF styles and class names but no the react tabular version, just the elements (no need for the whole thing on static table)
  - if the image is too large, it will be cropped but the aspect ration will be kept

![screenshot-ci foo redhat com_1337-2020 04 08-15_23_57](https://user-images.githubusercontent.com/22619452/78790131-62f95800-79ae-11ea-8dcb-035848dbdd88.png)

cc @sbuenafe-rh