### PR TITLE
Update ddf to v2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3272,9 +3272,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.8.7.tgz",
-      "integrity": "sha512-R8zbPiv25S0pGfMqAr55dRRxWB8vUeo3wicI4g9PFVBKmsy/9wmQUV1AaYW/kxRHUhx42TTh6F0+QO+4pwfYWg==",
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.2.tgz",
+      "integrity": "sha512-ZLwsFnNm3WpIARU1aLFtufjMHsmEnc8TjtrfAjmbgMbeoyR+LuQoyESoNdTfeDhL6IdY12SpeycXMgSgl8XGXA==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -3350,31 +3350,20 @@
       }
     },
     "@data-driven-forms/form-builder": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/form-builder/-/form-builder-0.0.8.tgz",
-      "integrity": "sha512-7LkVQW3yidIpUYbqzbWCAL3siQPe3b622tAm54zj+hALjT3ySzs72EfCnWYdkiPp/ZFyNGkBf/Nhr3bHDhs4DQ==",
+      "version": "0.0.10-rc6",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/form-builder/-/form-builder-0.0.10-rc6.tgz",
+      "integrity": "sha512-v+jCAlg5pIdgJqqDB31xygne7NyCMMnfzJd3slVtovnCHAQ9egmqTb7O30BYw7IMuyjU/7zu0PlbsDP7o1ur/g==",
       "requires": {
-        "@data-driven-forms/react-form-renderer": "^1.29.1",
         "clsx": "^1.0.4",
-        "final-form": "4.18.5",
         "lodash": "^4.17.15",
         "prop-types": "^15.7.2",
-        "react": "^16.12.0",
+        "react": "^16.13.1",
         "react-beautiful-dnd": "^12.1.1",
-        "react-dom": "^16.12.0",
-        "react-final-form": "^6.3.5",
+        "react-dom": "^16.13.1",
         "react-redux": "^7.1.3",
         "redux": "^4.0.5"
       },
       "dependencies": {
-        "final-form": {
-          "version": "4.18.5",
-          "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.18.5.tgz",
-          "integrity": "sha512-DH/I2W7fWxU8J8ZsbYJ5jLvUbhbatCvLhIKlsU17MvY6W3QnetPEyuX5mcxXgIGFNFKxfvqsG3pDy/1/VwOiTw==",
-          "requires": {
-            "@babel/runtime": "^7.3.1"
-          }
-        },
         "redux": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
@@ -3387,35 +3376,50 @@
       }
     },
     "@data-driven-forms/pf4-component-mapper": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-1.29.2.tgz",
-      "integrity": "sha512-Pe1GuIV3f4qiNFhKMz3gUVRlQrE3oB3e0GWhxikTwuau4jPRx6pm/Epa6plbSvOKiqUpwqGPS+WulX22hZyFTA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-2.4.5.tgz",
+      "integrity": "sha512-pyV3NkyO/liQIeCgJov2uF/In3uOAdjGe5gELo9z5D/NgvB2Pb82PD1A+vduUtO4mHhqVgyXZ8G5+eDtvkh5JA==",
       "requires": {
         "@patternfly/patternfly-next": "^1.0.175",
+        "prop-types": "^15.7.2",
         "react-final-form-arrays": "2.0.3",
         "react-select": "^3.0.4"
       }
     },
     "@data-driven-forms/react-form-renderer": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-1.29.2.tgz",
-      "integrity": "sha512-j7jNx2weykZG+AR8TAvbK6ScmluUUc+rA67ECrgrtUuMU+4P8YS/FKuwjGX/WjLaKtIu49jC0gaVDWav/N3ycw==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-2.4.5.tgz",
+      "integrity": "sha512-371nWUvasIZBOaUotEAIMrqUaSnFr20tLUPdBYn3CPlfHRT6S8dqYM89YVCXGqhHIG+bvTTFOCnSuo4EupraSw==",
       "requires": {
-        "final-form": "^4.12.0",
-        "final-form-arrays": "^3.0.1",
+        "final-form": "^4.19.1",
+        "final-form-arrays": "^3.0.2",
         "final-form-focus": "^1.1.2",
         "lodash": "^4.17.15",
-        "react-final-form": "^4.1.0",
-        "react-final-form-arrays": "^2.0.1"
+        "prop-types": "^15.7.2",
+        "react-final-form": "^6.4.0",
+        "react-final-form-arrays": "^3.1.1"
       },
       "dependencies": {
-        "react-final-form": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-4.1.0.tgz",
-          "integrity": "sha512-O8p1EPQ/PFWNcX3bYGsLzuo/KnGeNfGfFi2UAX8jXLXrGcGdTfZMnyo/DFHdEKA9aKso61d/PHekQ9sst0cOmw==",
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
           "requires": {
-            "@babel/runtime": "^7.3.4"
+            "regenerator-runtime": "^0.13.4"
           }
+        },
+        "react-final-form-arrays": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/react-final-form-arrays/-/react-final-form-arrays-3.1.1.tgz",
+          "integrity": "sha512-e6S1x9597cvI4QPniOPmllXXandDAqCCuBo4AvXstZYgcV8whsqzk8aCrmQEy6eEfy2tEhvn6f4VI1GY+JBRsg==",
+          "requires": {
+            "@babel/runtime": "^7.4.5"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         }
       }
     },
@@ -3476,9 +3480,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -3516,9 +3520,9 @@
           "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
         },
         "regenerator-runtime": {
-          "version": "0.13.4",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         }
       }
     },
@@ -3565,9 +3569,9 @@
           "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
         },
         "babel-plugin-emotion": {
-          "version": "10.0.29",
-          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.29.tgz",
-          "integrity": "sha512-7Jpi1OCxjyz0k163lKtqP+LHMg5z3S6A7vMBfHnF06l2unmtsOmFDzZBpGf0CWo1G4m8UACfVcDJiSiRuu/cSw==",
+          "version": "10.0.33",
+          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+          "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
           "requires": {
             "@babel/helper-module-imports": "^7.0.0",
             "@emotion/hash": "0.8.0",
@@ -5186,6 +5190,11 @@
           "dev": true
         }
       }
+    },
+    "@scarf/scarf": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.5.tgz",
+      "integrity": "sha512-9WKaGVpQH905Aqkk+BczFEeLQxS07rl04afFRPUG9IcSlOwmo5EVVuuNu0d4M9LMYucObvK0LoAe+5HfMW2QhQ=="
     },
     "@sentry/browser": {
       "version": "5.15.5",
@@ -8742,9 +8751,9 @@
       }
     },
     "css-box-model": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.0.tgz",
-      "integrity": "sha512-lri0br+jSNV0kkkiGEp9y9y3Njq2PmpqbeGWRFQJuZteZzY9iC9GZhQ8Y4WpPwM/2YocjHePxy14igJY7YKzkA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
       "requires": {
         "tiny-invariant": "^1.0.6"
       }
@@ -9189,11 +9198,32 @@
       }
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
+      "integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^2.6.7"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "csstype": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
+          "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
       }
     },
     "dom-serializer": {
@@ -10756,25 +10786,26 @@
       }
     },
     "final-form": {
-      "version": "4.18.7",
-      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.18.7.tgz",
-      "integrity": "sha512-XdlYYGDcoUcKKVzRJxLg8N/ZG3wVLZvhO7K7PKQWVMjCiIUWdmtBwApw2NFS4P7RJvg8OdF73qGXhhE3K5PuDQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.20.0.tgz",
+      "integrity": "sha512-kdPGNlR/23M2p7ccVwE/vCBQH9TH1NAhhMVkETHbaQXkTWIJdEii3ZdHrOgYvFY7O87myEhcqzx3zjMERtoNJg==",
       "requires": {
-        "@babel/runtime": "^7.8.3"
+        "@babel/runtime": "^7.10.0",
+        "@scarf/scarf": "^1.0.5"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.4",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         }
       }
     },
@@ -17899,18 +17930,19 @@
       }
     },
     "react-final-form": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-6.3.5.tgz",
-      "integrity": "sha512-btqEp1+n1WO4bUDopBdvUoIuoGHf91n/EOJg0QU5YjhX9CK+4RIsBI0M41lmyT3H6hWv6NELdX5n5zBJyOIXoA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-6.5.0.tgz",
+      "integrity": "sha512-H97PLCtfMIN32NHqm85E738Pj+NOF1p0eQEG+h5DbdaofwtqDRp7taHu45+PlXOqg9ANbM6MyXkYxWpIiE6qbQ==",
       "requires": {
-        "@babel/runtime": "^7.8.3",
-        "ts-essentials": "^5.0.0"
+        "@babel/runtime": "^7.10.0",
+        "@scarf/scarf": "^1.0.5",
+        "ts-essentials": "^6.0.5"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -18059,9 +18091,9 @@
       }
     },
     "react-select": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.0.8.tgz",
-      "integrity": "sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.1.0.tgz",
+      "integrity": "sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@emotion/cache": "^10.0.9",
@@ -18070,21 +18102,21 @@
         "memoize-one": "^5.0.0",
         "prop-types": "^15.6.0",
         "react-input-autosize": "^2.2.2",
-        "react-transition-group": "^2.2.1"
+        "react-transition-group": "^4.3.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.4",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         }
       }
     },
@@ -18109,14 +18141,29 @@
       }
     },
     "react-transition-group": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
       "requires": {
-        "dom-helpers": "^3.4.0",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
       }
     },
     "read-pkg": {
@@ -21486,9 +21533,9 @@
       "dev": true
     },
     "ts-essentials": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-5.0.0.tgz",
-      "integrity": "sha512-ftKWOm6Jq+/UCBekDfxUjLODEd5XGN2EM/+TIQV9LJ5xSV12je4GqdRyv7pXXGGYmEt/nQa6F00xTWYJ5PMjIQ=="
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-6.0.5.tgz",
+      "integrity": "sha512-RSAKlpu+E0DCGY8FsbG92EveRLw2Y+UgK3ksX01w1VaHeG01dKkYo/KtAV4q0qPT6nPbLfyerb2YPVSediP+8g=="
     },
     "tslib": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@data-driven-forms/form-builder": "0.0.8",
-    "@data-driven-forms/pf4-component-mapper": "^1.29.2",
-    "@data-driven-forms/react-form-renderer": "^1.29.2",
+    "@data-driven-forms/form-builder": "0.0.10-rc6",
+    "@data-driven-forms/pf4-component-mapper": "^2.4.5",
+    "@data-driven-forms/react-form-renderer": "^2.4.5",
     "@patternfly/react-core": "3.141.4",
     "@patternfly/react-table": "2.28.47",
     "@patternfly/react-icons": "3.15.17",

--- a/src/forms/edit-portfolio-item-form.schema.js
+++ b/src/forms/edit-portfolio-item-form.schema.js
@@ -1,7 +1,5 @@
-import {
-  componentTypes,
-  validatorTypes
-} from '@data-driven-forms/react-form-renderer';
+import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
+import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
 
 const editPortfolioItemSchema = {
   fields: [

--- a/src/forms/edit-workflow_form.schema.js
+++ b/src/forms/edit-workflow_form.schema.js
@@ -1,4 +1,4 @@
-import { componentTypes } from '@data-driven-forms/react-form-renderer';
+import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
 import asyncFormValidator from '../utilities/async-form-validator';
 
 const editWorkflowSchema = (loadWorkflows) => ({

--- a/src/forms/form-fields/shage-group-edit.js
+++ b/src/forms/form-fields/shage-group-edit.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { rawComponents } from '@data-driven-forms/pf4-component-mapper';
+import { InternalSelect } from '@data-driven-forms/pf4-component-mapper/dist/cjs/select';
+import useFieldApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-field-api';
 import {
   Text,
   TextContent,
@@ -9,7 +10,8 @@ import {
   Grid
 } from '@patternfly/react-core';
 
-const ShareGroupEdit = ({ FieldProvider, label, ...props }) => {
+const ShareGroupEdit = (props) => {
+  const { input, label, ...rest } = useFieldApi(props);
   return (
     <Grid gutter="md" className="share-column">
       <GridItem span={7}>
@@ -18,21 +20,13 @@ const ShareGroupEdit = ({ FieldProvider, label, ...props }) => {
         </TextContent>
       </GridItem>
       <GridItem span={5}>
-        <FieldProvider
-          {...props}
-          menuIsPortal
-          render={({ input, ...props }) => (
-            <rawComponents.Select {...input} {...props} />
-          )}
-        />
+        <InternalSelect menuIsPortal {...input} {...rest} />
       </GridItem>
     </Grid>
   );
 };
 
 ShareGroupEdit.propTypes = {
-  FieldProvider: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
-    .isRequired,
   label: PropTypes.string.isRequired
 };
 

--- a/src/forms/form-fields/share-group-select.js
+++ b/src/forms/form-fields/share-group-select.js
@@ -1,88 +1,70 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { rawComponents } from '@data-driven-forms/pf4-component-mapper';
+import { InternalSelect } from '@data-driven-forms/pf4-component-mapper/dist/cjs/select';
 import { Grid, GridItem } from '@patternfly/react-core';
 import asyncFormValidator from '../../utilities/async-form-validator';
+import useFieldApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-field-api';
 
 export const ShareGroupSelect = ({
-  FieldProvider,
   inputName,
   selectName,
   loadOptions,
   permissions
 }) => {
+  const inputProps = useFieldApi({ name: inputName });
+  const selectProps = useFieldApi({ name: selectName });
+
   return (
     <Grid gutter="md" className="share-column">
       <GridItem span={7}>
-        <FieldProvider
-          name={inputName}
+        <InternalSelect
+          isSearchable
+          isClearable
+          menuIsPortal
           loadOptions={asyncFormValidator(loadOptions)}
-          render={({ input, ...props }) => (
-            <React.Fragment>
-              <rawComponents.Select
-                isSearchable
-                isClearable
-                menuIsPortal
-                loadOptions={asyncFormValidator(loadOptions)}
-                placeholder="Select group"
-                isValid={!(props?.meta?.error && props.meta.touched)}
-                {...input}
-                {...props}
-              />
-              {props?.meta?.error && props.meta.touched && (
-                <div
-                  className="pf-c-form__helper-text pf-m-error"
-                  id="permission-helper"
-                  aria-live="polite"
-                >
-                  {props.meta.error}
-                </div>
-              )}
-            </React.Fragment>
-          )}
+          placeholder="Select group"
+          isValid={!(inputProps?.meta?.error && inputProps.meta.touched)}
+          {...inputProps}
+          {...inputProps.input}
         />
+        {inputProps?.meta?.error && inputProps.meta.touched && (
+          <div
+            className="pf-c-form__helper-text pf-m-error"
+            id="permission-helper"
+            aria-live="polite"
+          >
+            {selectProps.meta.error}
+          </div>
+        )}
       </GridItem>
       <GridItem span={5}>
-        <FieldProvider
-          name={selectName}
+        <InternalSelect
           options={permissions}
           menuIsPortal
-          render={({ input, ...props }) => (
-            <React.Fragment>
-              <rawComponents.Select
-                placeholder="Select permission"
-                isValid={!(props?.meta?.error && props.meta.touched)}
-                {...input}
-                {...props}
-              />
-              {props?.meta?.error && props.meta.touched && (
-                <div
-                  className="pf-c-form__helper-text pf-m-error"
-                  id="permission-helper"
-                  aria-live="polite"
-                >
-                  {props.meta.error}
-                </div>
-              )}
-            </React.Fragment>
-          )}
+          placeholder="Select permission"
+          isValid={!(selectProps?.meta?.error && selectProps.meta.touched)}
+          {...selectProps}
+          {...selectProps.input}
         />
+        {selectProps?.meta?.error && selectProps.meta.touched && (
+          <div
+            className="pf-c-form__helper-text pf-m-error"
+            id="permission-helper"
+            aria-live="polite"
+          >
+            {selectProps.meta.error}
+          </div>
+        )}
       </GridItem>
     </Grid>
   );
 };
 
 ShareGroupSelect.propTypes = {
-  FieldProvider: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
-    .isRequired,
   inputName: PropTypes.string.isRequired,
   selectName: PropTypes.string.isRequired,
   loadOptions: PropTypes.func.isRequired,
-  permissions: PropTypes.any,
-  meta: PropTypes.shape({
-    touched: PropTypes.bool,
-    error: PropTypes.string
-  })
+  permissions: PropTypes.any
 };
 
 export default ShareGroupSelect;

--- a/src/forms/portfolio-form.schema.js
+++ b/src/forms/portfolio-form.schema.js
@@ -5,19 +5,18 @@ import asyncFormValidator from '../utilities/async-form-validator';
 import { fetchPortfolioByName } from '../helpers/portfolio/portfolio-helper';
 
 export const validateName = (name, portfolioId) =>
-  fetchPortfolioByName(name)
-    .then(({ data }) => {
-      if (!name || name.trim().length === 0) {
-        return 'Required';
-      }
+  fetchPortfolioByName(name).then(({ data }) => {
+    if (!name || name.trim().length === 0) {
+      throw 'Required';
+    }
 
-      return data.find(
-        (portfolio) => portfolio.name === name && portfolio.id !== portfolioId
-      )
-        ? 'Name has already been taken'
-        : undefined;
-    })
-    .catch((error) => error.data);
+    const conflict = data.find(
+      (portfolio) => portfolio.name === name && portfolio.id !== portfolioId
+    );
+    if (conflict) {
+      throw 'Name has already been taken';
+    }
+  });
 
 const debouncedValidator = asyncFormValidator(validateName);
 

--- a/src/forms/portfolio-form.schema.js
+++ b/src/forms/portfolio-form.schema.js
@@ -1,4 +1,4 @@
-import { componentTypes } from '@data-driven-forms/react-form-renderer';
+import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
 import { DEFAULT_MAX_LENGTH } from '../utilities/constants';
 
 import asyncFormValidator from '../utilities/async-form-validator';

--- a/src/presentational-components/shared/filter-select.js
+++ b/src/presentational-components/shared/filter-select.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { rawComponents } from '@data-driven-forms/pf4-component-mapper';
+import { InternalSelect } from '@data-driven-forms/pf4-component-mapper/dist/cjs/select'
 import { FilterIcon } from '@patternfly/react-icons';
 
 const ValueContainer = ({ children }) => (
@@ -25,7 +25,7 @@ const FilterSelect = (props) => {
         id="filter-select-placeholder"
         className="filter-select"
       >
-        <rawComponents.Select
+        <InternalSelect
           components={{ ValueContainer }}
           simpleValue={false}
           options={[]}
@@ -38,7 +38,7 @@ const FilterSelect = (props) => {
 
   return (
     <div key="filter-select" id="filter-select" className="filter-select">
-      <rawComponents.Select
+      <InternalSelect
         components={{ ValueContainer }}
         simpleValue={false}
         {...props}

--- a/src/presentational-components/shared/filter-select.js
+++ b/src/presentational-components/shared/filter-select.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { InternalSelect } from '@data-driven-forms/pf4-component-mapper/dist/cjs/select'
+import { InternalSelect } from '@data-driven-forms/pf4-component-mapper/dist/cjs/select';
 import { FilterIcon } from '@patternfly/react-icons';
 
 const ValueContainer = ({ children }) => (

--- a/src/presentational-components/shared/pf4-select-wrapper.js
+++ b/src/presentational-components/shared/pf4-select-wrapper.js
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import useFieldApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-field-api';
+import { InternalSelect } from '@data-driven-forms/pf4-component-mapper/dist/cjs/select';
 import {
   FormGroup,
   TextContent,
   Text,
   TextVariants
 } from '@patternfly/react-core';
-import { rawComponents } from '@data-driven-forms/pf4-component-mapper';
+import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
 
 const createOptions = (options, inputValue, isRequired) => {
   if (inputValue && isRequired) {
@@ -26,13 +28,13 @@ const Select = ({
   isDisabled,
   FieldProvider,
   isRequired,
-  formOptions: { change },
   multi,
   loadOptions,
   meta,
   ...rest
 }) => {
   const [initialFetch, setInitialFetch] = useState(true);
+  const { change } = useFormApi;
   let loadOptionsOverride = loadOptions;
   if (loadOptions && meta.initial) {
     const lookupArguments = Array.isArray(meta.initial)
@@ -59,7 +61,7 @@ const Select = ({
   }
 
   return (
-    <rawComponents.Select
+    <InternalSelect
       hideSelectedOptions={false}
       menuIsPortal
       {...input}
@@ -74,7 +76,11 @@ const Select = ({
         }
       }}
       isMulti={multi}
-      options={createOptions(options, input.value, isRequired)}
+      options={
+        !loadOptions
+          ? createOptions(options, input.value, isRequired)
+          : undefined
+      }
       isDisabled={isDisabled || isReadOnly}
       closeMenuOnSelect={!multi}
     />
@@ -94,9 +100,6 @@ Select.propTypes = {
   isRequired: PropTypes.bool,
   isSearchable: PropTypes.bool,
   FieldProvider: PropTypes.any,
-  formOptions: PropTypes.shape({
-    change: PropTypes.func
-  }),
   multi: PropTypes.bool,
   loadOptions: PropTypes.func,
   meta: PropTypes.shape({
@@ -105,27 +108,26 @@ Select.propTypes = {
 };
 
 Select.defaultProps = {
-  formOptions: {},
   isSearchable: false,
   multi: false,
   options: []
 };
 
-const Pf4SelectWrapper = ({
-  componentType,
-  label,
-  isRequired,
-  helperText,
-  meta,
-  description,
-  hideLabel,
-  formOptions,
-  dataType,
-  initialKey,
-  id,
-  initialValue,
-  ...rest
-}) => {
+const Pf4SelectWrapper = (props) => {
+  const {
+    componentType,
+    label,
+    isRequired,
+    helperText,
+    meta,
+    description,
+    hideLabel,
+    dataType,
+    initialKey,
+    id,
+    initialValue,
+    ...rest
+  } = useFieldApi(props);
   const { error, touched } = meta;
   const showError = touched && error;
   const { name } = rest.input;
@@ -145,7 +147,6 @@ const Pf4SelectWrapper = ({
         </TextContent>
       )}
       <Select
-        formOptions={formOptions}
         id={id || name}
         meta={meta}
         label={label}
@@ -166,7 +167,6 @@ Pf4SelectWrapper.propTypes = {
   meta: PropTypes.object,
   description: PropTypes.string,
   hideLabel: PropTypes.bool,
-  formOptions: PropTypes.object,
   dataType: PropTypes.string,
   initialKey: PropTypes.any,
   initialValue: PropTypes.any

--- a/src/smart-components/common/form-renderer.js
+++ b/src/smart-components/common/form-renderer.js
@@ -1,17 +1,21 @@
 import React, { createContext, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@patternfly/react-core';
-import ReactFormRender, {
-  componentTypes,
-  layoutComponents
-} from '@data-driven-forms/react-form-renderer';
-import {
-  layoutMapper,
-  formFieldsMapper
-} from '@data-driven-forms/pf4-component-mapper';
+import { Button, FormGroup, TextContent, Text } from '@patternfly/react-core';
+import ReactFormRender from '@data-driven-forms/react-form-renderer/dist/cjs/form-renderer';
+import validatorMapper from '@data-driven-forms/react-form-renderer/dist/cjs/validator-mapper';
+import FormTemplate from '@data-driven-forms/pf4-component-mapper/dist/cjs/form-template';
+import TextField from '@data-driven-forms/pf4-component-mapper/dist/cjs/text-field';
+import Textarea from '@data-driven-forms/pf4-component-mapper/dist/cjs/textarea';
+import SubForm from '@data-driven-forms/pf4-component-mapper/dist/cjs/sub-form';
+import PlainText from '@data-driven-forms/pf4-component-mapper/dist/cjs/plain-text';
+import Checkbox from '@data-driven-forms/pf4-component-mapper/dist/cjs/checkbox';
+import Radio from '@data-driven-forms/pf4-component-mapper/dist/cjs/radio';
+import Switch from '@data-driven-forms/pf4-component-mapper/dist/cjs/switch';
 import Pf4SelectWrapper from '../../presentational-components/shared/pf4-select-wrapper';
 import ShareGroupSelect from '../../forms/form-fields/share-group-select';
 import ShareGroupEdit from '../../forms/form-fields/shage-group-edit';
+import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
+import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
 
 const FormContext = createContext({});
 
@@ -34,22 +38,65 @@ FormButton.propTypes = {
   variant: PropTypes.string
 };
 
-const FormRenderer = ({ componentMapper, formContainer, ...rest }) => {
+const ValueOnly = ({ name, label, value }) => (
+  <FormGroup label={label} fieldId={name}>
+    <TextContent>
+      <Text component="h6">{value}</Text>
+    </TextContent>
+  </FormGroup>
+);
+
+ValueOnly.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired
+};
+
+const catalogComponentMapper = {
+  [componentTypes.TEXT_FIELD]: TextField,
+  [componentTypes.TEXTAREA]: Textarea,
+  [componentTypes.PLAIN_TEXT]: PlainText,
+  [componentTypes.SELECT]: Pf4SelectWrapper,
+  [componentTypes.CHECKBOX]: Checkbox,
+  [componentTypes.RADIO]: Radio,
+  [componentTypes.SWITCH]: Switch,
+  [componentTypes.SUB_FORM]: SubForm,
+  'share-group-select': ShareGroupSelect,
+  'share-group-edit': ShareGroupEdit,
+  'value-only': ValueOnly,
+  'textarea-field': Textarea,
+  'select-field': Pf4SelectWrapper
+};
+
+const catalogValidatorMapper = {
+  ...validatorMapper,
+  'exact-length-validator': validatorMapper[validatorTypes.EXACT_LENGTH],
+  'max-length-validator': validatorMapper[validatorTypes.MAX_LENGTH],
+  'min-items-validator': validatorMapper[validatorTypes.MIN_ITEMS],
+  'min-length-validator': validatorMapper[validatorTypes.MIN_LENGTH],
+  'pattern-validator': validatorMapper[validatorTypes.PATTERN],
+  'required-validator': validatorMapper[validatorTypes.REQUIRED],
+  'url-validator': validatorMapper[validatorTypes.URL]
+};
+
+export const catalogValidatorAlias = {
+  'exact-length-validator': validatorTypes.EXACT_LENGTH,
+  'max-length-validator': validatorTypes.MAX_LENGTH,
+  'min-items-validator': validatorTypes.MIN_ITEMS,
+  'min-length-validator': validatorTypes.MIN_LENGTH,
+  'pattern-validator': validatorTypes.PATTERN,
+  'required-validator': validatorTypes.REQUIRED,
+  'url-validator': validatorTypes.URL
+};
+
+const FormRenderer = ({ formContainer, ...rest }) => {
   return (
     <div>
       <FormContext.Provider value={{ formContainer }}>
         <ReactFormRender
-          formFieldsMapper={{
-            ...formFieldsMapper,
-            ...componentMapper,
-            [componentTypes.SELECT]: Pf4SelectWrapper,
-            'share-group-select': ShareGroupSelect,
-            'share-group-edit': ShareGroupEdit
-          }}
-          layoutMapper={{
-            ...layoutMapper,
-            [layoutComponents.BUTTON]: FormButton
-          }}
+          componentMapper={catalogComponentMapper}
+          FormTemplate={FormTemplate}
+          validatorMapper={catalogValidatorMapper}
           {...rest}
         />
       </FormContext.Provider>
@@ -58,12 +105,10 @@ const FormRenderer = ({ componentMapper, formContainer, ...rest }) => {
 };
 
 FormRenderer.propTypes = {
-  componentMapper: PropTypes.object,
   formContainer: PropTypes.oneOf(['default', 'modal'])
 };
 
 FormRenderer.defaultProps = {
-  componentMapper: {},
   formContainer: 'default'
 };
 

--- a/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
@@ -2,13 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import {
-  FormGroup,
-  Modal,
-  TextContent,
-  Text,
-  TextVariants
-} from '@patternfly/react-core';
+import { Modal } from '@patternfly/react-core';
 import { componentTypes } from '@data-driven-forms/react-form-renderer';
 
 import FormRenderer from '../../common/form-renderer';
@@ -55,24 +49,6 @@ const copySchema = (portfolioName, portfolioChange, nameFetching) => ({
     }
   ]
 });
-
-const ValueOnly = ({ name, label, value }) => (
-  <FormGroup label={label} fieldId={name}>
-    <TextContent>
-      <Text component={TextVariants.h6}>{value}</Text>
-    </TextContent>
-  </FormGroup>
-);
-
-ValueOnly.propTypes = {
-  name: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  value: PropTypes.string
-};
-
-ValueOnly.defaultProps = {
-  value: ''
-};
 
 const CopyPortfolioItemModal = ({
   portfolioId,
@@ -148,7 +124,6 @@ const CopyPortfolioItemModal = ({
           })
         }
         formContainer="modal"
-        componentMapper={{ 'value-only': ValueOnly }}
         buttonsLabels={{ submitLabel: 'Save' }}
         disableSubmit={submitting ? ['pristine', 'dirty'] : []}
       />

--- a/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { Modal } from '@patternfly/react-core';
-import { componentTypes } from '@data-driven-forms/react-form-renderer';
+import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
 
 import FormRenderer from '../../common/form-renderer';
 import { getPortfolioItemApi } from '../../../helpers/shared/user-login';

--- a/src/smart-components/portfolio/portfolio-item-detail/edit-portfolio-item.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/edit-portfolio-item.js
@@ -6,24 +6,6 @@ import { useLocation, useHistory } from 'react-router-dom';
 import FormRenderer from '../../common/form-renderer';
 import editPortfolioItemSchema from '../../../forms/edit-portfolio-item-form.schema';
 import { updatePortfolioItem } from '../../../redux/actions/portfolio-actions';
-import { Button, ActionGroup } from '@patternfly/react-core';
-
-const FormButtons = ({ onCancel, submitting, valid }) => (
-  <ActionGroup>
-    <Button isDisabled={submitting || !valid} type="submit" variant="primary">
-      Save
-    </Button>
-    <Button onClick={onCancel} variant="link">
-      Cancel
-    </Button>
-  </ActionGroup>
-);
-
-FormButtons.propTypes = {
-  onCancel: PropTypes.func.isRequired,
-  submitting: PropTypes.bool.isRequired,
-  valid: PropTypes.bool
-};
 
 const EditPortfolioItem = ({
   cancelUrl,
@@ -49,17 +31,12 @@ const EditPortfolioItem = ({
         );
       }}
       schema={editPortfolioItemSchema}
-      renderFormButtons={(props) => (
-        <FormButtons
-          {...props}
-          onCancel={() =>
-            push({
-              pathname: cancelUrl,
-              search
-            })
-          }
-        />
-      )}
+      onCancel={() =>
+        push({
+          pathname: cancelUrl,
+          search
+        })
+      }
     />
   );
 };

--- a/src/smart-components/survey-editing/survey-editor.js
+++ b/src/smart-components/survey-editing/survey-editor.js
@@ -112,7 +112,7 @@ const pf4Skin = {
   componentProperties
 };
 
-// remove after full migration to v2
+// remove after API full migration to v2
 const changeValidators = (schema) => {
   const result = { ...schema };
   result.fields = result.fields.map(({ validate, ...rest }) => {
@@ -129,7 +129,7 @@ const changeValidators = (schema) => {
   return result;
 };
 
-// remove after full mugration to v2
+// remove after API full migration to v2
 const appendValidator = (schema) => {
   const result = { ...schema };
   result.fields = result.fields.map(({ validate, ...rest }) => {

--- a/src/smart-components/survey-editing/survey-editor.js
+++ b/src/smart-components/survey-editing/survey-editor.js
@@ -1,15 +1,15 @@
 import React, { useEffect, useState, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
-import { componentTypes } from '@data-driven-forms/react-form-renderer';
-import FormBuilder from '@data-driven-forms/form-builder';
+import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
+import FormBuilder from '@data-driven-forms/form-builder/dist/cjs';
 import {
   builderMapper,
   fieldProperties,
   pickerMapper,
   propertiesMapper,
   BuilderTemplate
-} from '@data-driven-forms/form-builder/dist/pf4-builder-mappers';
+} from '@data-driven-forms/form-builder/dist/cjs/pf4-builder-mappers';
 import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner/Spinner';
 
 import {
@@ -21,6 +21,8 @@ import { Bullseye } from '@patternfly/react-core';
 import { SurveyEditingToolbar } from '../portfolio/portfolio-item-detail/portfolio-item-detail-toolbar';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/cjs/actions';
+import { catalogValidatorAlias } from '../common/form-renderer';
+import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
 
 const componentProperties = {
   [componentTypes.TEXT_FIELD]: {
@@ -91,11 +93,61 @@ const componentProperties = {
   }
 };
 
+componentProperties['select-field'] =
+  componentProperties[componentTypes.SELECT];
+componentProperties['textarea-field'] =
+  componentProperties[componentTypes.TEXTAREA];
 const pf4Skin = {
-  componentMapper: builderMapper,
-  pickerMapper,
+  componentMapper: {
+    ...builderMapper,
+    'select-field': builderMapper[componentTypes.SELECT],
+    'textarea-field': builderMapper[componentTypes.TEXTAREA]
+  },
+  pickerMapper: {
+    ...pickerMapper,
+    'select-field': pickerMapper[componentTypes.SELECT],
+    'textarea-field': pickerMapper[componentTypes.TEXTAREA]
+  },
   propertiesMapper,
   componentProperties
+};
+
+// remove after full migration to v2
+const changeValidators = (schema) => {
+  const result = { ...schema };
+  result.fields = result.fields.map(({ validate, ...rest }) => {
+    return validate
+      ? {
+          ...rest,
+          validate: validate.map(({ type, ...rest }) => ({
+            ...rest,
+            type: catalogValidatorAlias[type] || type
+          }))
+        }
+      : rest;
+  });
+  return result;
+};
+
+// remove after full mugration to v2
+const appendValidator = (schema) => {
+  const result = { ...schema };
+  result.fields = result.fields.map(({ validate, ...rest }) => {
+    return validate
+      ? {
+          ...rest,
+          validate: validate.map(({ type, ...rest }) => ({
+            ...rest,
+            type:
+              type !== validatorTypes.MAX_NUMBER_VALUE &&
+              type !== validatorTypes.MIN_NUMBER_VALUE
+                ? `${type}-validator`
+                : type
+          }))
+        }
+      : rest;
+  });
+  return result;
 };
 
 const BuilderWrapper = (props) => <FormBuilder {...props} />;
@@ -123,12 +175,14 @@ const SurveyEditor = ({ closeUrl, search, portfolioItem, uploadIcon }) => {
           return getAxiosInstance()
             .get(`${CATALOG_API_BASE}/service_plans/${servicePlan[0].id}/base`)
             .then((baseSchema) => {
-              setBaseSchema(baseSchema.create_json_schema.schema);
-              return schema;
+              setBaseSchema(
+                changeValidators(baseSchema.create_json_schema.schema)
+              );
+              return changeValidators(schema);
             });
         }
 
-        return schema;
+        return changeValidators(schema);
       })
       .then((schema) => {
         setSchema(schema);
@@ -153,9 +207,8 @@ const SurveyEditor = ({ closeUrl, search, portfolioItem, uploadIcon }) => {
       );
   const handleSaveSurvey = (editedTemplate) => {
     setIsFetching(true);
-    let submitCall = servicePlan.imported ? modifySurvey : createSurvey;
-
-    return submitCall(editedTemplate)
+    const submitCall = servicePlan.imported ? modifySurvey : createSurvey;
+    return submitCall(appendValidator(editedTemplate))
       .then(() => {
         setIsFetching(false);
         dispatch(

--- a/src/test/forms/__snapshots__/portfolio-form.schema.test.js.snap
+++ b/src/test/forms/__snapshots__/portfolio-form.schema.test.js.snap
@@ -14,7 +14,7 @@ Object {
       ],
     },
     Object {
-      "component": "textarea-field",
+      "component": "textarea",
       "label": "Description",
       "name": "description",
     },
@@ -36,7 +36,7 @@ Object {
       ],
     },
     Object {
-      "component": "textarea-field",
+      "component": "textarea",
       "label": "Description",
       "name": "description",
     },

--- a/src/test/forms/portfolio-form.schema.test.js
+++ b/src/test/forms/portfolio-form.schema.test.js
@@ -23,19 +23,19 @@ describe('createPortfolioSchema', () => {
   });
 
   it('should not pass unique name validation', () => {
-    return validateName('should-conflict', '123').then((data) => {
+    return validateName('should-conflict', '123').catch((data) => {
       expect(data).toEqual('Name has already been taken');
     });
   });
 
   it('should not pass unique name validation if no name is passed', () => {
-    return validateName('', '123').then((data) => {
+    return validateName('', '123').catch((data) => {
       expect(data).toEqual('Required');
     });
   });
 
   it('should pass unique name validation if the portfolio conflicts with itself', () => {
-    return validateName('should-conflict', 'conflict-id').then((data) => {
+    return validateName('should-conflict', 'conflict-id').catch((data) => {
       expect(data).toBeUndefined();
     });
   });

--- a/src/test/integration/portfolio-integration.test.js
+++ b/src/test/integration/portfolio-integration.test.js
@@ -165,7 +165,6 @@ describe('Integration test for portfolio entity', () => {
     wrapper
       .find('div.ddorg__pf4-component-mapper__select__control')
       .simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
-
     expect(
       wrapper.find('div.ddorg__pf4-component-mapper__select__option')
     ).toHaveLength(2);

--- a/src/test/presentational-components/shared/__snapshots__/pf4-select-wrapper.test.js.snap
+++ b/src/test/presentational-components/shared/__snapshots__/pf4-select-wrapper.test.js.snap
@@ -1,122 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Pf4SelectWrapper /> should render correctly 1`] = `
-<FormGroup
-  fieldId="bazz"
-  isValid={true}
->
-  <Select
-    FieldProvider={[Function]}
-    formOptions={
+<Pf4SelectWrapper
+  id="bazz"
+  name="bazz"
+  options={
+    Array [
       Object {
-        "change": [MockFunction],
-      }
-    }
-    id="bazz"
-    input={
-      Object {
-        "name": "bazz",
-        "onChange": [MockFunction],
-        "value": "",
-      }
-    }
-    isSearchable={false}
-    isValid={true}
-    meta={Object {}}
-    multi={false}
-    options={
-      Array [
-        Object {
-          "label": "Foo",
-          "value": "bar",
-        },
-      ]
-    }
-  />
-</FormGroup>
+        "label": "Foo",
+        "value": "bar",
+      },
+    ]
+  }
+/>
 `;
 
 exports[`<Pf4SelectWrapper /> should render correctly in error state 1`] = `
-<FormGroup
-  fieldId="bazz"
-  helperTextInvalid="Error"
-  isValid={false}
->
-  <Select
-    FieldProvider={[Function]}
-    formOptions={
+<Pf4SelectWrapper
+  id="bazz"
+  isRequired={true}
+  name="bazz"
+  options={
+    Array [
       Object {
-        "change": [MockFunction],
-      }
-    }
-    id="bazz"
-    input={
-      Object {
-        "name": "bazz",
-        "onChange": [MockFunction],
-        "value": "",
-      }
-    }
-    isSearchable={false}
-    isValid={false}
-    meta={
-      Object {
-        "error": "Error",
-        "touched": true,
-      }
-    }
-    multi={false}
-    options={
-      Array [
-        Object {
-          "label": "Foo",
-          "value": "bar",
-        },
-      ]
-    }
-  />
-</FormGroup>
+        "label": "Foo",
+        "value": "bar",
+      },
+    ]
+  }
+  validate={[Function]}
+/>
 `;
 
 exports[`<Pf4SelectWrapper /> should render correctly with description 1`] = `
-<FormGroup
-  fieldId="bazz"
-  isValid={true}
->
-  <TextContent>
-    <Text
-      component="small"
-    >
-      description
-    </Text>
-  </TextContent>
-  <Select
-    FieldProvider={[Function]}
-    formOptions={
+<Pf4SelectWrapper
+  description="description"
+  id="bazz"
+  name="bazz"
+  options={
+    Array [
       Object {
-        "change": [MockFunction],
-      }
-    }
-    id="bazz"
-    input={
-      Object {
-        "name": "bazz",
-        "onChange": [MockFunction],
-        "value": "",
-      }
-    }
-    isSearchable={false}
-    isValid={true}
-    meta={Object {}}
-    multi={false}
-    options={
-      Array [
-        Object {
-          "label": "Foo",
-          "value": "bar",
-        },
-      ]
-    }
-  />
-</FormGroup>
+        "label": "Foo",
+        "value": "bar",
+      },
+    ]
+  }
+/>
 `;

--- a/src/test/presentational-components/shared/pf4-select-wrapper.test.js
+++ b/src/test/presentational-components/shared/pf4-select-wrapper.test.js
@@ -1,89 +1,108 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
-import { rawComponents } from '@data-driven-forms/pf4-component-mapper';
 import Pf4SelectWrapper from '../../../presentational-components/shared/pf4-select-wrapper';
+import { InternalSelect } from '@data-driven-forms/pf4-component-mapper/dist/cjs/select';
+import Form from '@data-driven-forms/react-form-renderer/dist/cjs/form';
 
 describe('<Pf4SelectWrapper />', () => {
   let initialProps;
   beforeEach(() => {
     initialProps = {
       id: 'bazz',
-      input: {
-        name: 'bazz',
-        value: '',
-        onChange: jest.fn()
-      },
-      meta: {},
+      name: 'bazz',
       options: [
         {
           label: 'Foo',
           value: 'bar'
         }
-      ],
-      formOptions: {
-        change: jest.fn()
-      },
-      FieldProvider: () => <div />
+      ]
     };
   });
 
   it('should render correctly', () => {
-    const wrapper = shallow(<Pf4SelectWrapper {...initialProps} />);
+    const wrapper = shallow(
+      <Form onSubmit={Function}>
+        {() => <Pf4SelectWrapper {...initialProps} />}
+      </Form>
+    ).dive();
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should create empty option', () => {
-    const wrapper = mount(<Pf4SelectWrapper {...initialProps} />);
-    const options = wrapper.find(rawComponents.Select).props().options;
+    const wrapper = mount(
+      <Form onSubmit={Function}>
+        {() => <Pf4SelectWrapper {...initialProps} />}
+      </Form>
+    );
+    const options = wrapper.find(InternalSelect).props().options;
     expect(options).toHaveLength(2);
   });
 
   it('should create empty option for required field', () => {
-    const wrapper = mount(<Pf4SelectWrapper isRequired {...initialProps} />);
-    const options = wrapper.find(rawComponents.Select).props().options;
+    const wrapper = mount(
+      <Form onSubmit={Function}>
+        {() => <Pf4SelectWrapper isRequired {...initialProps} />}
+      </Form>
+    );
+    const options = wrapper.find(InternalSelect).props().options;
     expect(options).toHaveLength(2);
     expect(options[0].label).toEqual('Please choose');
   });
 
   it('should not create empty option', () => {
     const wrapper = mount(
-      <Pf4SelectWrapper
-        {...initialProps}
-        options={[{ label: 'Foo', value: 'bar' }, { label: 'Empty value' }]}
-      />
+      <Form onSubmit={Function}>
+        {() => (
+          <Pf4SelectWrapper
+            {...initialProps}
+            options={[{ label: 'Foo', value: 'bar' }, { label: 'Empty value' }]}
+          />
+        )}
+      </Form>
     );
-    const options = wrapper.find(rawComponents.Select).props().options;
+    const options = wrapper.find(InternalSelect).props().options;
     expect(options).toHaveLength(2);
   });
 
   it('should not create empty option if select has value and is required', () => {
     const wrapper = mount(
-      <Pf4SelectWrapper
-        isRequired
-        {...initialProps}
-        input={{ ...initialProps.input, value: 'some value' }}
-        options={[{ label: 'Foo', value: 'bar' }]}
-      />
+      <Form onSubmit={Function}>
+        {() => (
+          <Pf4SelectWrapper
+            isRequired
+            {...initialProps}
+            initialValue="bar"
+            options={[{ label: 'Foo', value: 'bar' }]}
+          />
+        )}
+      </Form>
     );
-    const options = wrapper.find(rawComponents.Select).props().options;
+    const options = wrapper.find(InternalSelect).props().options;
     expect(options).toHaveLength(1);
   });
 
   it('should render correctly in error state', () => {
     const wrapper = shallow(
-      <Pf4SelectWrapper
-        {...initialProps}
-        meta={{ error: 'Error', touched: true }}
-      />
-    );
+      <Form onSubmit={Function}>
+        {() => (
+          <Pf4SelectWrapper
+            {...initialProps}
+            isRequired
+            validate={() => false}
+          />
+        )}
+      </Form>
+    ).dive();
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render correctly with description', () => {
     const wrapper = shallow(
-      <Pf4SelectWrapper {...initialProps} description="description" />
-    );
+      <Form onSubmit={Function}>
+        {() => <Pf4SelectWrapper {...initialProps} description="description" />}
+      </Form>
+    ).dive();
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 });

--- a/src/test/smart-components/portfolio/add-products-to-portfolio/add-products-to-portfolio.test.js
+++ b/src/test/smart-components/portfolio/add-products-to-portfolio/add-products-to-portfolio.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import thunk from 'redux-thunk';
-import { rawComponents } from '@data-driven-forms/pf4-component-mapper';
+import { InternalSelect } from '@data-driven-forms/pf4-component-mapper/dist/cjs/select';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
@@ -134,7 +134,7 @@ describe('<AddProductsToPortfolio />', () => {
       })
     ];
 
-    const select = wrapper.find(rawComponents.Select);
+    const select = wrapper.find(InternalSelect);
     await act(async () => {
       select.props().onChange({ id: '1' });
     });
@@ -223,7 +223,7 @@ describe('<AddProductsToPortfolio />', () => {
     });
 
     await act(async () => {
-      let select = wrapper.find(rawComponents.Select).props();
+      let select = wrapper.find(InternalSelect).props();
       select.onChange({
         id: '1'
       });

--- a/src/test/smart-components/portfolio/share-portfolio-modal.test.js
+++ b/src/test/smart-components/portfolio/share-portfolio-modal.test.js
@@ -6,15 +6,13 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { MemoryRouter, Route } from 'react-router-dom';
 import promiseMiddleware from 'redux-promise-middleware';
-import ReactFormRender from '@data-driven-forms/react-form-renderer';
 import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications/';
 
-import FormRenderer from '../../../smart-components/common/form-renderer';
 import { CATALOG_API_BASE, RBAC_API_BASE } from '../../../utilities/constants';
 import SharePortfolioModal from '../../../smart-components/portfolio/share-portfolio-modal';
 import { mockApi } from '../../../helpers/shared/__mocks__/user-login';
 
-describe('<SharePortfolioModal', () => {
+describe('<SharePortfolioModal/>', () => {
   let initialProps;
   let initialState;
   const middlewares = [thunk, promiseMiddleware, notificationsMiddleware()];
@@ -26,16 +24,20 @@ describe('<SharePortfolioModal', () => {
     </Provider>
   );
 
+  afterEach(() => {
+    mockApi.restore();
+    mockApi.resetHandlers();
+  });
+
   beforeEach(() => {
     initialProps = {
       addNotification: jest.fn(),
-      portfolioId: '123',
       closeUrl: '/foo'
     };
     initialState = {
       portfolioReducer: {
         selectedPortfolio: {
-          id: '123',
+          id: '2',
           name: 'Portfolio 1',
           metadata: {
             user_capabilities: {
@@ -70,52 +72,28 @@ describe('<SharePortfolioModal', () => {
     mockStore = configureStore(middlewares);
   });
 
-  it('should mount and load data', async (done) => {
-    const store = mockStore(initialState);
-
-    mockApi
-      .onGet(`${CATALOG_API_BASE}/portfolios/123/share_info`)
-      .replyOnce(200, { data: {} });
-    mockApi.onGet(`${RBAC_API_BASE}/groups/`).replyOnce(200, { data: [] });
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mount(
-        <ComponentWrapper store={store} initialEntries={['/portfolio/123']}>
-          <Route
-            path="/portfolio/:id"
-            render={(args) => (
-              <SharePortfolioModal {...args} {...initialProps} />
-            )}
-          />
-        </ComponentWrapper>
-      );
-    });
-
-    wrapper.update();
-    expect(wrapper.find(SharePortfolioModal)).toHaveLength(1);
-    expect(wrapper.find(FormRenderer)).toHaveLength(1);
-    done();
-  });
-
   it('should submit share data', async (done) => {
-    expect.assertions(3);
+    jest.useFakeTimers();
+    expect.assertions(1);
     const store = mockStore(initialState);
 
     /**
      * download data endpoints
      */
     mockApi
-      .onGet(`${CATALOG_API_BASE}/portfolios/123/share_info`)
-      .replyOnce(200, { data: {} });
-    mockApi.onGet(`${RBAC_API_BASE}/groups/`).replyOnce(200, { data: [] });
-    mockApi.onGet(`${RBAC_API_BASE}/groups/`).replyOnce(200, { data: [] });
+      .onGet(`${CATALOG_API_BASE}/portfolios/2/share_info`)
+      .replyOnce(200, {
+        data: []
+      });
+    mockApi.onGet(`${RBAC_API_BASE}/groups/`).replyOnce(200, {
+      data: [{ uuid: '123', name: 'Group 123' }]
+    });
 
     /**
      * submit data endpoints
      */
     mockApi
-      .onPost(`${CATALOG_API_BASE}/portfolios/123/share`)
+      .onPost(`${CATALOG_API_BASE}/portfolios/2/share`)
       .replyOnce((req) => {
         expect(JSON.parse(req.data)).toEqual({
           permissions: ['all'],
@@ -123,54 +101,52 @@ describe('<SharePortfolioModal', () => {
         });
         return [200, {}];
       });
-    mockApi
-      .onPost(`${CATALOG_API_BASE}/portfolios/123/unshare`)
-      .replyOnce((req) => {
-        expect(JSON.parse(req.data)).toEqual({
-          permissions: ['update'],
-          group_uuids: [null]
-        });
-        return [200, {}];
-      });
-    mockApi
-      .onGet(
-        `${CATALOG_API_BASE}/portfolios?filter[name][contains_i]=&limit=50&offset=0`
-      )
-      .replyOnce((req) => {
-        expect(req).toBeTruthy();
-        return [200, { data: [] }];
-      });
     mockApi.onGet(`${RBAC_API_BASE}/groups/`).replyOnce(200, { data: [] });
     let wrapper;
     await act(async () => {
       wrapper = mount(
         <ComponentWrapper
           store={store}
-          initialEntries={['/portfolio?portfolio=123']}
+          initialEntries={['/portfolio/share-portfolio?portfolio=2']}
         >
-          <Route
-            path="/portfolio"
-            render={(args) => (
-              <SharePortfolioModal {...args} {...initialProps} />
-            )}
-          />
+          <Route exact path="/portfolio/share-portfolio">
+            <SharePortfolioModal {...initialProps} />
+          </Route>
         </ComponentWrapper>
       );
     });
 
-    wrapper.update();
-    const form = wrapper
-      .find(ReactFormRender)
-      .children()
-      .instance().form;
-    /*
-     * simulate form changes
-     * group_uuid
-     * permissions
-     */
+    await act(async () => {
+      jest.runAllTimers();
+      wrapper.update();
+    });
 
-    form.change('group_uuid', '123');
-    form.change('permissions', 'all');
+    await act(async () => {
+      jest.runAllTimers();
+      wrapper.update();
+    });
+
+    wrapper
+      .find('div.ddorg__pf4-component-mapper__select__control')
+      .first()
+      .simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
+    await act(async () => {
+      wrapper
+        .find('div.ddorg__pf4-component-mapper__select__option')
+        .first()
+        .simulate('click');
+    });
+    wrapper
+      .find('div.ddorg__pf4-component-mapper__select__control')
+      .at(1)
+      .simulate('keyDown', { key: 'ArrowDown', keyCode: 40 });
+    await act(async () => {
+      wrapper
+        .find('div.ddorg__pf4-component-mapper__select__option')
+        .first()
+        .simulate('click');
+    });
+
     await act(async () => {
       wrapper.find('form').simulate('submit');
     });
@@ -196,16 +172,19 @@ describe('<SharePortfolioModal', () => {
     });
 
     mockApi
-      .onGet(`${CATALOG_API_BASE}/portfolios/123/share_info`)
-      .replyOnce(200, { data: {} });
+      .onGet(`${CATALOG_API_BASE}/portfolios/3/share_info`)
+      .replyOnce(200, { data: [] });
     mockApi.onGet(`${RBAC_API_BASE}/groups/`).replyOnce(200, { data: [] });
 
     let wrapper;
     await act(async () => {
       wrapper = mount(
-        <ComponentWrapper store={store} initialEntries={['/portfolio/123']}>
+        <ComponentWrapper
+          store={store}
+          initialEntries={['/portfolio/share-portfolio?portfolio=3']}
+        >
           <Route
-            path="/portfolio/:id"
+            path="/portfolio/share-portfolio"
             render={(args) => (
               <SharePortfolioModal {...args} {...initialProps} />
             )}
@@ -214,7 +193,9 @@ describe('<SharePortfolioModal', () => {
       );
     });
 
-    wrapper.update();
+    await act(async () => {
+      wrapper.update();
+    });
     expect(
       wrapper.find(MemoryRouter).instance().history.location.pathname
     ).toEqual('/403');


### PR DESCRIPTION
It can wait for weeks. Just putting it out there so we won't forget: https://github.com/RedHatInsights/catalog-api/pull/671

Currently, there are components with old keys in the component mapper to serve as a bridge between the new version of DDF and older schemas in DB.

Redundant components and validators should be removed after DB migration.