### PR TITLE
Fix Order icon in mobile layout

### DIFF
--- a/src/presentational-components/styled-components/table.js
+++ b/src/presentational-components/styled-components/table.js
@@ -31,9 +31,11 @@ Tbody.propTypes = {
 export const TableCell = styled(({ shrink, children, ...props }) => (
   <td {...props}>{children}</td>
 ))`
-  vertical-align: middle !important;
-  width: ${({ shrink }) => (shrink ? '10%' : 'initial')};
-  img {
-    object-fit: cover;
+  @media screen and (min-width: 768px) {
+    vertical-align: middle !important;
+    width: ${({ shrink }) => (shrink ? '10%' : 'initial')};
+    img {
+      object-fit: cover;
+    }
   }
 `;

--- a/src/smart-components/order/order-item.js
+++ b/src/smart-components/order/order-item.js
@@ -64,7 +64,7 @@ const OrderItem = memo(
         aria-labelledby={`${item.id}-expand`}
         className="data-list-expand-fix"
       >
-        <TableCell className="pf-u-pl-xl">
+        <TableCell shrink className="pf-u-pl-xl">
           <CardIcon
             height={60}
             src={getOrderIcon(item)}

--- a/src/smart-components/order/order-item.js
+++ b/src/smart-components/order/order-item.js
@@ -64,7 +64,7 @@ const OrderItem = memo(
         aria-labelledby={`${item.id}-expand`}
         className="data-list-expand-fix"
       >
-        <TableCell shrink className="pf-u-pl-xl">
+        <TableCell className="pf-u-pl-xl">
           <CardIcon
             height={60}
             src={getOrderIcon(item)}


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1436
follow-up to: https://github.com/RedHatInsights/catalog-ui/pull/512

Changes introduced in the PR above allowed for cropping of product images when necessary, but also severely cropped them in the mobile layout where there's room. This PR excludes the "shrink" class from the mobile layout, resolving the issue.

Old (mobile)
<img width="690" alt="Screen Shot 2020-04-16 at 3 03 31 PM" src="https://user-images.githubusercontent.com/1287144/79495976-767e7180-7ff3-11ea-9484-364116320c4d.png">


New (mobile)

<img width="751" alt="Screen Shot 2020-04-16 at 3 00 41 PM" src="https://user-images.githubusercontent.com/1287144/79495772-20a9c980-7ff3-11ea-94ba-512e29273cad.png">


Old (desktop)

<img width="1070" alt="Screen Shot 2020-04-16 at 3 03 19 PM" src="https://user-images.githubusercontent.com/1287144/79495983-7bdbbc00-7ff3-11ea-87bb-38f4cfd2c7b9.png">

New (desktop)

<img width="1134" alt="Screen Shot 2020-04-16 at 3 00 10 PM" src="https://user-images.githubusercontent.com/1287144/79495779-22738d00-7ff3-11ea-9534-207ee878ba6a.png">

