### PR TITLE
Add insights request id to the error notification

### DIFF
--- a/src/helpers/shared/user-login.js
+++ b/src/helpers/shared/user-login.js
@@ -26,7 +26,10 @@ const axiosInstance = axios.create({
 
 const resolveInterceptor = (response) => response.data || response;
 const errorInterceptor = (error = {}) => {
-  throw { ...error.response };
+  const requestId = error.response?.headers['x-rh-insights-request-id'];
+  throw requestId
+    ? { ...error.response, sentryId: requestId }
+    : { ...error.response };
 };
 
 // check identity before each request. If the token is expired it will log out user


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1256

For this PR - using the existing sentryId parameter to display the x-rh-insights-request-id.
This will be changed after the requestId parameter is added to the platform nootifications.

![Screenshot from 2020-04-17 13-03-21](https://user-images.githubusercontent.com/12769982/79595304-97ef6400-80ac-11ea-9441-9f5f0ebe9c92.png)

