### PR TITLE
Detail screens text styling and responsiveness fix

### DIFF
--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -5,6 +5,13 @@ const GlobalStyle = createGlobalStyle`
   pointer-events: none
 }
 
+.font-14{
+  font-size: 14px;
+  color: var(--pf-global--Color--100);
+  font-weight: bold;
+  margin-bottom: 2px !important;
+}
+
 .orders-list {
   background-color: var(--pf-global--BackgroundColor--100)
 }

--- a/src/smart-components/platform/service-offering/service-offering-detail.js
+++ b/src/smart-components/platform/service-offering/service-offering-detail.js
@@ -5,6 +5,7 @@ import {
   GridItem,
   TextContent,
   Text,
+  TextVariants,
   Level
 } from '@patternfly/react-core';
 import ReactJsonView from 'react-json-view';
@@ -16,7 +17,6 @@ import { fetchServiceOffering } from '../../../redux/actions/platform-actions';
 import { ProductLoaderPlaceholder } from '../../../presentational-components/shared/loader-placeholders';
 import CardIcon from '../../../presentational-components/shared/card-icon';
 import CatalogBreadcrumbs from '../../common/catalog-breadcrumbs';
-import EllipsisTextContainer from '../../../presentational-components/styled-components/ellipsis-text-container';
 import { StyledLevelItem } from '../../../presentational-components/styled-components/level';
 
 const requiredParams = ['service', 'platform'];
@@ -60,32 +60,26 @@ const ServiceOfferingDetail = () => {
             </StyledLevelItem>
           </Level>
         </GridItem>
-        <GridItem md={2}>
-          <TextContent>
-            <Text id="source" component="h6">
-              <span>Platform</span>
-              <br />
-              <EllipsisTextContainer>
-                <span>{source.name}</span>
-              </EllipsisTextContainer>
+        <GridItem md={3} lg={2}>
+          <TextContent className="pf-u-mb-md">
+            <Text className="font-14">Platform</Text>
+            <Text id="source" component={TextVariants.p}>
+              {source.name}
             </Text>
-            <Text id="created_at" component="h6">
-              <span>Created</span>
-              <br />
-              <EllipsisTextContainer>
-                <DateFormat type="relative" date={service.created_at} />
-              </EllipsisTextContainer>
+            <Text className="font-14">Created</Text>
+            <Text id="created_at" component={TextVariants.p}>
+              <DateFormat type="relative" date={service.created_at} />
             </Text>
           </TextContent>
         </GridItem>
-        <GridItem md={10}>
+        <GridItem md={9} lg={10}>
           <TextContent>
-            <Text component="h6">Name</Text>
-            <Text id="description" component="p">
+            <Text className="font-14">Name</Text>
+            <Text id="description" component={TextVariants.p}>
               {service.name}
             </Text>
-            <Text component="h6">Description</Text>
-            <Text id="long_description" component="p">
+            <Text className="font-14">Description</Text>
+            <Text id="long_description" component={TextVariants.p}>
               {service.description}
             </Text>
             <hr className="pf-c-divider" />

--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
@@ -2,39 +2,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/DateFormat';
-import EllipsisTextContainer from '../../../presentational-components/styled-components/ellipsis-text-container';
 
 const ItemDetailInfoBar = ({ product, source, portfolio }) => (
-  <TextContent>
-    <Text id="source-name" component={TextVariants.h6}>
-      <span>Platform</span>
-      <br />
-      <EllipsisTextContainer>
-        <span>{source.name}</span>
-      </EllipsisTextContainer>
+  <TextContent className="pf-u-mb-md">
+    <Text className="font-14">Platform</Text>
+    <Text id="source-name" component={TextVariants.p}>
+      {source.name}
     </Text>
-    <Text id="portfolio-name" component={TextVariants.h6}>
-      <span>Portfolio</span>
-      <br />
-      <EllipsisTextContainer>
-        <span>{portfolio.name}</span>
-      </EllipsisTextContainer>
+    <Text className="font-14">Portfolio</Text>
+    <Text id="portfolio-name" component={TextVariants.p}>
+      {portfolio.name}
     </Text>
     {product.distributor && (
-      <Text id="distributor" component={TextVariants.h6}>
-        <span>Vendor</span>
-        <br />
-        <EllipsisTextContainer>
-          <span>{product.distributor}</span>
-        </EllipsisTextContainer>
-      </Text>
+      <span id="distributor">
+        <Text className="font-14">Vendor</Text>
+        <Text component={TextVariants.p}>{product.distributor}</Text>
+      </span>
     )}
-    <Text id="created_at" component={TextVariants.h6}>
-      <span>Created</span>
-      <br />
-      <EllipsisTextContainer>
-        <DateFormat variant="relative" date={product.created_at} />
-      </EllipsisTextContainer>
+    <Text className="font-14">Created</Text>
+    <Text id="created_at" component={TextVariants.p}>
+      <DateFormat variant="relative" date={product.created_at} />
     </Text>
   </TextContent>
 );

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -123,14 +123,14 @@ const PortfolioItemDetail = () => {
               />
             )}
             <Grid className="pf-u-p-lg">
-              <GridItem md={2}>
+              <GridItem md={3} lg={2}>
                 <ItemDetailInfoBar
                   product={portfolioItem}
                   portfolio={portfolio}
                   source={source}
                 />
               </GridItem>
-              <GridItem md={10}>
+              <GridItem md={9} lg={10}>
                 <Route path={`${url}/order`}>
                   <OrderModal closeUrl={url} />
                 </Route>

--- a/src/test/smart-components/platform/service-offering/service-offering-detail.test.js
+++ b/src/test/smart-components/platform/service-offering/service-offering-detail.test.js
@@ -110,7 +110,7 @@ describe('<ServiceOfferingDetail />', () => {
     });
     wrapper.update();
     expect(wrapper.find(ReactJsonView)).toHaveLength(1);
-    expect(wrapper.find(Text)).toHaveLength(9);
+    expect(wrapper.find(Text)).toHaveLength(11);
     expect(wrapper.find(Breadcrumb)).toHaveLength(1);
   });
 });

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-info-bar.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-info-bar.test.js.snap
@@ -23,247 +23,245 @@ exports[`<ItemDetailInfoBar /> should render correctly 1`] = `
     }
   }
 >
-  <TextContent>
+  <TextContent
+    className="pf-u-mb-md"
+  >
     <div
-      className="pf-c-content"
+      className="pf-c-content pf-u-mb-md"
     >
       <Text
-        component="h6"
+        className="font-14"
+      >
+        <p
+          className="font-14"
+          data-pf-content={true}
+        >
+          Platform
+        </p>
+      </Text>
+      <Text
+        component="p"
         id="source-name"
       >
-        <h6
+        <p
           className=""
           data-pf-content={true}
           id="source-name"
         >
-          <span>
-            Platform
-          </span>
-          <br />
-          <styled.div>
-            <div
-              className="sc-AxjAm fkKIGI"
-            >
-              <span>
-                bar
-              </span>
-            </div>
-          </styled.div>
-        </h6>
+          bar
+        </p>
       </Text>
       <Text
-        component="h6"
+        className="font-14"
+      >
+        <p
+          className="font-14"
+          data-pf-content={true}
+        >
+          Portfolio
+        </p>
+      </Text>
+      <Text
+        component="p"
         id="portfolio-name"
       >
-        <h6
+        <p
           className=""
           data-pf-content={true}
           id="portfolio-name"
         >
-          <span>
-            Portfolio
-          </span>
-          <br />
-          <styled.div>
-            <div
-              className="sc-AxjAm fkKIGI"
-            >
-              <span>
-                quux
-              </span>
-            </div>
-          </styled.div>
-        </h6>
+          quux
+        </p>
       </Text>
-      <Text
-        component="h6"
+      <span
         id="distributor"
       >
-        <h6
-          className=""
-          data-pf-content={true}
-          id="distributor"
+        <Text
+          className="font-14"
         >
-          <span>
+          <p
+            className="font-14"
+            data-pf-content={true}
+          >
             Vendor
-          </span>
-          <br />
-          <styled.div>
-            <div
-              className="sc-AxjAm fkKIGI"
-            >
-              <span>
-                foo
-              </span>
-            </div>
-          </styled.div>
-        </h6>
+          </p>
+        </Text>
+        <Text
+          component="p"
+        >
+          <p
+            className=""
+            data-pf-content={true}
+          >
+            foo
+          </p>
+        </Text>
+      </span>
+      <Text
+        className="font-14"
+      >
+        <p
+          className="font-14"
+          data-pf-content={true}
+        >
+          Created
+        </p>
       </Text>
       <Text
-        component="h6"
+        component="p"
         id="created_at"
       >
-        <h6
+        <p
           className=""
           data-pf-content={true}
           id="created_at"
         >
-          <span>
-            Created
-          </span>
-          <br />
-          <styled.div>
-            <div
-              className="sc-AxjAm fkKIGI"
+          <DateFormat
+            date="Fri Mar 22 2019 08:36:57 GMT+0100 (Central European Standard Time)"
+            variant="relative"
+          >
+            <Tooltip
+              appendTo={[Function]}
+              aria="describedby"
+              boundary="window"
+              className=""
+              content={
+                <div>
+                  
+                  22 Mar 2019 07:36 UTC
+                </div>
+              }
+              distance={15}
+              enableFlip={true}
+              entryDelay={500}
+              exitDelay={500}
+              flipBehavior={
+                Array [
+                  "top",
+                  "right",
+                  "bottom",
+                  "left",
+                  "top",
+                  "right",
+                  "bottom",
+                ]
+              }
+              id=""
+              isAppLauncher={false}
+              isContentLeftAligned={false}
+              isVisible={false}
+              maxWidth="18.75rem"
+              position="top"
+              tippyProps={Object {}}
+              trigger="mouseenter focus"
+              zIndex={9999}
             >
-              <DateFormat
-                date="Fri Mar 22 2019 08:36:57 GMT+0100 (Central European Standard Time)"
-                variant="relative"
+              <PopoverBase
+                appendTo={[Function]}
+                aria="describedby"
+                arrow={true}
+                boundary="window"
+                content={
+                  <div
+                    className=""
+                    id=""
+                    role="tooltip"
+                  >
+                    <TooltipContent
+                      isLeftAligned={false}
+                    >
+                      <div>
+                        
+                        22 Mar 2019 07:36 UTC
+                      </div>
+                    </TooltipContent>
+                  </div>
+                }
+                delay={
+                  Array [
+                    500,
+                    500,
+                  ]
+                }
+                distance={15}
+                flip={true}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                isVisible={false}
+                lazy={true}
+                maxWidth="18.75rem"
+                onCreate={[Function]}
+                placement="top"
+                popperOptions={
+                  Object {
+                    "modifiers": Object {
+                      "hide": Object {
+                        "enabled": true,
+                      },
+                      "preventOverflow": Object {
+                        "enabled": true,
+                      },
+                    },
+                  }
+                }
+                theme="pf-tooltip"
+                trigger="mouseenter focus"
+                zIndex={9999}
               >
-                <Tooltip
-                  appendTo={[Function]}
-                  aria="describedby"
-                  boundary="window"
-                  className=""
-                  content={
+                <span>
+                  Just now
+                </span>
+                <Portal
+                  containerInfo={
                     <div>
-                      
-                      22 Mar 2019 07:36 UTC
-                    </div>
-                  }
-                  distance={15}
-                  enableFlip={true}
-                  entryDelay={500}
-                  exitDelay={500}
-                  flipBehavior={
-                    Array [
-                      "top",
-                      "right",
-                      "bottom",
-                      "left",
-                      "top",
-                      "right",
-                      "bottom",
-                    ]
-                  }
-                  id=""
-                  isAppLauncher={false}
-                  isContentLeftAligned={false}
-                  isVisible={false}
-                  maxWidth="18.75rem"
-                  position="top"
-                  tippyProps={Object {}}
-                  trigger="mouseenter focus"
-                  zIndex={9999}
-                >
-                  <PopoverBase
-                    appendTo={[Function]}
-                    aria="describedby"
-                    arrow={true}
-                    boundary="window"
-                    content={
                       <div
-                        className=""
+                        class=""
                         id=""
                         role="tooltip"
                       >
-                        <TooltipContent
-                          isLeftAligned={false}
+                        <div
+                          class="pf-c-tooltip__content"
                         >
                           <div>
                             
                             22 Mar 2019 07:36 UTC
                           </div>
-                        </TooltipContent>
-                      </div>
-                    }
-                    delay={
-                      Array [
-                        500,
-                        500,
-                      ]
-                    }
-                    distance={15}
-                    flip={true}
-                    flipBehavior={
-                      Array [
-                        "top",
-                        "right",
-                        "bottom",
-                        "left",
-                        "top",
-                        "right",
-                        "bottom",
-                      ]
-                    }
-                    isVisible={false}
-                    lazy={true}
-                    maxWidth="18.75rem"
-                    onCreate={[Function]}
-                    placement="top"
-                    popperOptions={
-                      Object {
-                        "modifiers": Object {
-                          "hide": Object {
-                            "enabled": true,
-                          },
-                          "preventOverflow": Object {
-                            "enabled": true,
-                          },
-                        },
-                      }
-                    }
-                    theme="pf-tooltip"
-                    trigger="mouseenter focus"
-                    zIndex={9999}
-                  >
-                    <span>
-                      Just now
-                    </span>
-                    <Portal
-                      containerInfo={
-                        <div>
-                          <div
-                            class=""
-                            id=""
-                            role="tooltip"
-                          >
-                            <div
-                              class="pf-c-tooltip__content"
-                            >
-                              <div>
-                                
-                                22 Mar 2019 07:36 UTC
-                              </div>
-                            </div>
-                          </div>
                         </div>
-                      }
+                      </div>
+                    </div>
+                  }
+                >
+                  <div
+                    className=""
+                    id=""
+                    role="tooltip"
+                  >
+                    <TooltipContent
+                      isLeftAligned={false}
                     >
                       <div
-                        className=""
-                        id=""
-                        role="tooltip"
+                        className="pf-c-tooltip__content"
                       >
-                        <TooltipContent
-                          isLeftAligned={false}
-                        >
-                          <div
-                            className="pf-c-tooltip__content"
-                          >
-                            <div>
-                              22 Mar 2019 07:36 UTC
-                            </div>
-                          </div>
-                        </TooltipContent>
+                        <div>
+                          22 Mar 2019 07:36 UTC
+                        </div>
                       </div>
-                    </Portal>
-                  </PopoverBase>
-                </Tooltip>
-              </DateFormat>
-            </div>
-          </styled.div>
-        </h6>
+                    </TooltipContent>
+                  </div>
+                </Portal>
+              </PopoverBase>
+            </Tooltip>
+          </DateFormat>
+        </p>
       </Text>
     </div>
   </TextContent>
@@ -290,223 +288,221 @@ exports[`<ItemDetailInfoBar /> should render correctly with fallback values with
     }
   }
 >
-  <TextContent>
+  <TextContent
+    className="pf-u-mb-md"
+  >
     <div
-      className="pf-c-content"
+      className="pf-c-content pf-u-mb-md"
     >
       <Text
-        component="h6"
+        className="font-14"
+      >
+        <p
+          className="font-14"
+          data-pf-content={true}
+        >
+          Platform
+        </p>
+      </Text>
+      <Text
+        component="p"
         id="source-name"
       >
-        <h6
+        <p
           className=""
           data-pf-content={true}
           id="source-name"
         >
-          <span>
-            Platform
-          </span>
-          <br />
-          <styled.div>
-            <div
-              className="sc-AxjAm fkKIGI"
-            >
-              <span>
-                bar
-              </span>
-            </div>
-          </styled.div>
-        </h6>
+          bar
+        </p>
       </Text>
       <Text
-        component="h6"
+        className="font-14"
+      >
+        <p
+          className="font-14"
+          data-pf-content={true}
+        >
+          Portfolio
+        </p>
+      </Text>
+      <Text
+        component="p"
         id="portfolio-name"
       >
-        <h6
+        <p
           className=""
           data-pf-content={true}
           id="portfolio-name"
         >
-          <span>
-            Portfolio
-          </span>
-          <br />
-          <styled.div>
-            <div
-              className="sc-AxjAm fkKIGI"
-            >
-              <span>
-                quux
-              </span>
-            </div>
-          </styled.div>
-        </h6>
+          quux
+        </p>
       </Text>
       <Text
-        component="h6"
+        className="font-14"
+      >
+        <p
+          className="font-14"
+          data-pf-content={true}
+        >
+          Created
+        </p>
+      </Text>
+      <Text
+        component="p"
         id="created_at"
       >
-        <h6
+        <p
           className=""
           data-pf-content={true}
           id="created_at"
         >
-          <span>
-            Created
-          </span>
-          <br />
-          <styled.div>
-            <div
-              className="sc-AxjAm fkKIGI"
+          <DateFormat
+            date="Fri Mar 22 2019 08:36:57 GMT+0100 (Central European Standard Time)"
+            variant="relative"
+          >
+            <Tooltip
+              appendTo={[Function]}
+              aria="describedby"
+              boundary="window"
+              className=""
+              content={
+                <div>
+                  
+                  22 Mar 2019 07:36 UTC
+                </div>
+              }
+              distance={15}
+              enableFlip={true}
+              entryDelay={500}
+              exitDelay={500}
+              flipBehavior={
+                Array [
+                  "top",
+                  "right",
+                  "bottom",
+                  "left",
+                  "top",
+                  "right",
+                  "bottom",
+                ]
+              }
+              id=""
+              isAppLauncher={false}
+              isContentLeftAligned={false}
+              isVisible={false}
+              maxWidth="18.75rem"
+              position="top"
+              tippyProps={Object {}}
+              trigger="mouseenter focus"
+              zIndex={9999}
             >
-              <DateFormat
-                date="Fri Mar 22 2019 08:36:57 GMT+0100 (Central European Standard Time)"
-                variant="relative"
+              <PopoverBase
+                appendTo={[Function]}
+                aria="describedby"
+                arrow={true}
+                boundary="window"
+                content={
+                  <div
+                    className=""
+                    id=""
+                    role="tooltip"
+                  >
+                    <TooltipContent
+                      isLeftAligned={false}
+                    >
+                      <div>
+                        
+                        22 Mar 2019 07:36 UTC
+                      </div>
+                    </TooltipContent>
+                  </div>
+                }
+                delay={
+                  Array [
+                    500,
+                    500,
+                  ]
+                }
+                distance={15}
+                flip={true}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                isVisible={false}
+                lazy={true}
+                maxWidth="18.75rem"
+                onCreate={[Function]}
+                placement="top"
+                popperOptions={
+                  Object {
+                    "modifiers": Object {
+                      "hide": Object {
+                        "enabled": true,
+                      },
+                      "preventOverflow": Object {
+                        "enabled": true,
+                      },
+                    },
+                  }
+                }
+                theme="pf-tooltip"
+                trigger="mouseenter focus"
+                zIndex={9999}
               >
-                <Tooltip
-                  appendTo={[Function]}
-                  aria="describedby"
-                  boundary="window"
-                  className=""
-                  content={
+                <span>
+                  Just now
+                </span>
+                <Portal
+                  containerInfo={
                     <div>
-                      
-                      22 Mar 2019 07:36 UTC
-                    </div>
-                  }
-                  distance={15}
-                  enableFlip={true}
-                  entryDelay={500}
-                  exitDelay={500}
-                  flipBehavior={
-                    Array [
-                      "top",
-                      "right",
-                      "bottom",
-                      "left",
-                      "top",
-                      "right",
-                      "bottom",
-                    ]
-                  }
-                  id=""
-                  isAppLauncher={false}
-                  isContentLeftAligned={false}
-                  isVisible={false}
-                  maxWidth="18.75rem"
-                  position="top"
-                  tippyProps={Object {}}
-                  trigger="mouseenter focus"
-                  zIndex={9999}
-                >
-                  <PopoverBase
-                    appendTo={[Function]}
-                    aria="describedby"
-                    arrow={true}
-                    boundary="window"
-                    content={
                       <div
-                        className=""
+                        class=""
                         id=""
                         role="tooltip"
                       >
-                        <TooltipContent
-                          isLeftAligned={false}
+                        <div
+                          class="pf-c-tooltip__content"
                         >
                           <div>
                             
                             22 Mar 2019 07:36 UTC
                           </div>
-                        </TooltipContent>
-                      </div>
-                    }
-                    delay={
-                      Array [
-                        500,
-                        500,
-                      ]
-                    }
-                    distance={15}
-                    flip={true}
-                    flipBehavior={
-                      Array [
-                        "top",
-                        "right",
-                        "bottom",
-                        "left",
-                        "top",
-                        "right",
-                        "bottom",
-                      ]
-                    }
-                    isVisible={false}
-                    lazy={true}
-                    maxWidth="18.75rem"
-                    onCreate={[Function]}
-                    placement="top"
-                    popperOptions={
-                      Object {
-                        "modifiers": Object {
-                          "hide": Object {
-                            "enabled": true,
-                          },
-                          "preventOverflow": Object {
-                            "enabled": true,
-                          },
-                        },
-                      }
-                    }
-                    theme="pf-tooltip"
-                    trigger="mouseenter focus"
-                    zIndex={9999}
-                  >
-                    <span>
-                      Just now
-                    </span>
-                    <Portal
-                      containerInfo={
-                        <div>
-                          <div
-                            class=""
-                            id=""
-                            role="tooltip"
-                          >
-                            <div
-                              class="pf-c-tooltip__content"
-                            >
-                              <div>
-                                
-                                22 Mar 2019 07:36 UTC
-                              </div>
-                            </div>
-                          </div>
                         </div>
-                      }
+                      </div>
+                    </div>
+                  }
+                >
+                  <div
+                    className=""
+                    id=""
+                    role="tooltip"
+                  >
+                    <TooltipContent
+                      isLeftAligned={false}
                     >
                       <div
-                        className=""
-                        id=""
-                        role="tooltip"
+                        className="pf-c-tooltip__content"
                       >
-                        <TooltipContent
-                          isLeftAligned={false}
-                        >
-                          <div
-                            className="pf-c-tooltip__content"
-                          >
-                            <div>
-                              22 Mar 2019 07:36 UTC
-                            </div>
-                          </div>
-                        </TooltipContent>
+                        <div>
+                          22 Mar 2019 07:36 UTC
+                        </div>
                       </div>
-                    </Portal>
-                  </PopoverBase>
-                </Tooltip>
-              </DateFormat>
-            </div>
-          </styled.div>
-        </h6>
+                    </TooltipContent>
+                  </div>
+                </Portal>
+              </PopoverBase>
+            </Tooltip>
+          </DateFormat>
+        </p>
       </Text>
     </div>
   </TextContent>
@@ -537,247 +533,245 @@ exports[`<ItemDetailInfoBar /> should render correctly with vendor 1`] = `
     }
   }
 >
-  <TextContent>
+  <TextContent
+    className="pf-u-mb-md"
+  >
     <div
-      className="pf-c-content"
+      className="pf-c-content pf-u-mb-md"
     >
       <Text
-        component="h6"
+        className="font-14"
+      >
+        <p
+          className="font-14"
+          data-pf-content={true}
+        >
+          Platform
+        </p>
+      </Text>
+      <Text
+        component="p"
         id="source-name"
       >
-        <h6
+        <p
           className=""
           data-pf-content={true}
           id="source-name"
         >
-          <span>
-            Platform
-          </span>
-          <br />
-          <styled.div>
-            <div
-              className="sc-AxjAm fkKIGI"
-            >
-              <span>
-                bar
-              </span>
-            </div>
-          </styled.div>
-        </h6>
+          bar
+        </p>
       </Text>
       <Text
-        component="h6"
+        className="font-14"
+      >
+        <p
+          className="font-14"
+          data-pf-content={true}
+        >
+          Portfolio
+        </p>
+      </Text>
+      <Text
+        component="p"
         id="portfolio-name"
       >
-        <h6
+        <p
           className=""
           data-pf-content={true}
           id="portfolio-name"
         >
-          <span>
-            Portfolio
-          </span>
-          <br />
-          <styled.div>
-            <div
-              className="sc-AxjAm fkKIGI"
-            >
-              <span>
-                quux
-              </span>
-            </div>
-          </styled.div>
-        </h6>
+          quux
+        </p>
       </Text>
-      <Text
-        component="h6"
+      <span
         id="distributor"
       >
-        <h6
-          className=""
-          data-pf-content={true}
-          id="distributor"
+        <Text
+          className="font-14"
         >
-          <span>
+          <p
+            className="font-14"
+            data-pf-content={true}
+          >
             Vendor
-          </span>
-          <br />
-          <styled.div>
-            <div
-              className="sc-AxjAm fkKIGI"
-            >
-              <span>
-                foo
-              </span>
-            </div>
-          </styled.div>
-        </h6>
+          </p>
+        </Text>
+        <Text
+          component="p"
+        >
+          <p
+            className=""
+            data-pf-content={true}
+          >
+            foo
+          </p>
+        </Text>
+      </span>
+      <Text
+        className="font-14"
+      >
+        <p
+          className="font-14"
+          data-pf-content={true}
+        >
+          Created
+        </p>
       </Text>
       <Text
-        component="h6"
+        component="p"
         id="created_at"
       >
-        <h6
+        <p
           className=""
           data-pf-content={true}
           id="created_at"
         >
-          <span>
-            Created
-          </span>
-          <br />
-          <styled.div>
-            <div
-              className="sc-AxjAm fkKIGI"
+          <DateFormat
+            date="Fri Mar 22 2019 08:36:57 GMT+0100 (Central European Standard Time)"
+            variant="relative"
+          >
+            <Tooltip
+              appendTo={[Function]}
+              aria="describedby"
+              boundary="window"
+              className=""
+              content={
+                <div>
+                  
+                  22 Mar 2019 07:36 UTC
+                </div>
+              }
+              distance={15}
+              enableFlip={true}
+              entryDelay={500}
+              exitDelay={500}
+              flipBehavior={
+                Array [
+                  "top",
+                  "right",
+                  "bottom",
+                  "left",
+                  "top",
+                  "right",
+                  "bottom",
+                ]
+              }
+              id=""
+              isAppLauncher={false}
+              isContentLeftAligned={false}
+              isVisible={false}
+              maxWidth="18.75rem"
+              position="top"
+              tippyProps={Object {}}
+              trigger="mouseenter focus"
+              zIndex={9999}
             >
-              <DateFormat
-                date="Fri Mar 22 2019 08:36:57 GMT+0100 (Central European Standard Time)"
-                variant="relative"
+              <PopoverBase
+                appendTo={[Function]}
+                aria="describedby"
+                arrow={true}
+                boundary="window"
+                content={
+                  <div
+                    className=""
+                    id=""
+                    role="tooltip"
+                  >
+                    <TooltipContent
+                      isLeftAligned={false}
+                    >
+                      <div>
+                        
+                        22 Mar 2019 07:36 UTC
+                      </div>
+                    </TooltipContent>
+                  </div>
+                }
+                delay={
+                  Array [
+                    500,
+                    500,
+                  ]
+                }
+                distance={15}
+                flip={true}
+                flipBehavior={
+                  Array [
+                    "top",
+                    "right",
+                    "bottom",
+                    "left",
+                    "top",
+                    "right",
+                    "bottom",
+                  ]
+                }
+                isVisible={false}
+                lazy={true}
+                maxWidth="18.75rem"
+                onCreate={[Function]}
+                placement="top"
+                popperOptions={
+                  Object {
+                    "modifiers": Object {
+                      "hide": Object {
+                        "enabled": true,
+                      },
+                      "preventOverflow": Object {
+                        "enabled": true,
+                      },
+                    },
+                  }
+                }
+                theme="pf-tooltip"
+                trigger="mouseenter focus"
+                zIndex={9999}
               >
-                <Tooltip
-                  appendTo={[Function]}
-                  aria="describedby"
-                  boundary="window"
-                  className=""
-                  content={
+                <span>
+                  Just now
+                </span>
+                <Portal
+                  containerInfo={
                     <div>
-                      
-                      22 Mar 2019 07:36 UTC
-                    </div>
-                  }
-                  distance={15}
-                  enableFlip={true}
-                  entryDelay={500}
-                  exitDelay={500}
-                  flipBehavior={
-                    Array [
-                      "top",
-                      "right",
-                      "bottom",
-                      "left",
-                      "top",
-                      "right",
-                      "bottom",
-                    ]
-                  }
-                  id=""
-                  isAppLauncher={false}
-                  isContentLeftAligned={false}
-                  isVisible={false}
-                  maxWidth="18.75rem"
-                  position="top"
-                  tippyProps={Object {}}
-                  trigger="mouseenter focus"
-                  zIndex={9999}
-                >
-                  <PopoverBase
-                    appendTo={[Function]}
-                    aria="describedby"
-                    arrow={true}
-                    boundary="window"
-                    content={
                       <div
-                        className=""
+                        class=""
                         id=""
                         role="tooltip"
                       >
-                        <TooltipContent
-                          isLeftAligned={false}
+                        <div
+                          class="pf-c-tooltip__content"
                         >
                           <div>
                             
                             22 Mar 2019 07:36 UTC
                           </div>
-                        </TooltipContent>
-                      </div>
-                    }
-                    delay={
-                      Array [
-                        500,
-                        500,
-                      ]
-                    }
-                    distance={15}
-                    flip={true}
-                    flipBehavior={
-                      Array [
-                        "top",
-                        "right",
-                        "bottom",
-                        "left",
-                        "top",
-                        "right",
-                        "bottom",
-                      ]
-                    }
-                    isVisible={false}
-                    lazy={true}
-                    maxWidth="18.75rem"
-                    onCreate={[Function]}
-                    placement="top"
-                    popperOptions={
-                      Object {
-                        "modifiers": Object {
-                          "hide": Object {
-                            "enabled": true,
-                          },
-                          "preventOverflow": Object {
-                            "enabled": true,
-                          },
-                        },
-                      }
-                    }
-                    theme="pf-tooltip"
-                    trigger="mouseenter focus"
-                    zIndex={9999}
-                  >
-                    <span>
-                      Just now
-                    </span>
-                    <Portal
-                      containerInfo={
-                        <div>
-                          <div
-                            class=""
-                            id=""
-                            role="tooltip"
-                          >
-                            <div
-                              class="pf-c-tooltip__content"
-                            >
-                              <div>
-                                
-                                22 Mar 2019 07:36 UTC
-                              </div>
-                            </div>
-                          </div>
                         </div>
-                      }
+                      </div>
+                    </div>
+                  }
+                >
+                  <div
+                    className=""
+                    id=""
+                    role="tooltip"
+                  >
+                    <TooltipContent
+                      isLeftAligned={false}
                     >
                       <div
-                        className=""
-                        id=""
-                        role="tooltip"
+                        className="pf-c-tooltip__content"
                       >
-                        <TooltipContent
-                          isLeftAligned={false}
-                        >
-                          <div
-                            className="pf-c-tooltip__content"
-                          >
-                            <div>
-                              22 Mar 2019 07:36 UTC
-                            </div>
-                          </div>
-                        </TooltipContent>
+                        <div>
+                          22 Mar 2019 07:36 UTC
+                        </div>
                       </div>
-                    </Portal>
-                  </PopoverBase>
-                </Tooltip>
-              </DateFormat>
-            </div>
-          </styled.div>
-        </h6>
+                    </TooltipContent>
+                  </div>
+                </Portal>
+              </PopoverBase>
+            </Tooltip>
+          </DateFormat>
+        </p>
       </Text>
     </div>
   </TextContent>


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1457

This PR updates the styling of fonts used for labels and values in the left column of the Service Offering & Portfolio Item Detail screens

It also makes the left column  responsive, eliminating the need for ellipsis to truncate text.

I'll follow-up with a styled-component later.

Old (desktop)
![Screen Shot 2020-04-22 at 9 02 59 AM](https://user-images.githubusercontent.com/1287144/79985249-4feb8b00-8478-11ea-8c23-545407557ed2.png)

![Screen Shot 2020-04-22 at 9 03 43 AM](https://user-images.githubusercontent.com/1287144/79985251-50842180-8478-11ea-8aec-81ac416f50d4.png)


New (desktop)

![Screen Shot 2020-04-22 at 9 10 21 AM](https://user-images.githubusercontent.com/1287144/79985853-33038780-8479-11ea-807d-ab54b07bb168.png)

![Screen Shot 2020-04-22 at 9 12 23 AM](https://user-images.githubusercontent.com/1287144/79986014-6cd48e00-8479-11ea-8090-15406693ddac.png)

Old (mobile)

![Screen Shot 2020-04-22 at 9 03 54 AM](https://user-images.githubusercontent.com/1287144/79985250-50842180-8478-11ea-91b5-64f0923539a2.png)

![Screen Shot 2020-04-22 at 9 03 13 AM](https://user-images.githubusercontent.com/1287144/79985253-50842180-8478-11ea-8034-da12a1c54196.png)

New (mobile)

![Screen Shot 2020-04-22 at 9 10 38 AM](https://user-images.githubusercontent.com/1287144/79985864-38f96880-8479-11ea-9e42-977bc8a94f71.png)

![Screen Shot 2020-04-22 at 9 12 32 AM](https://user-images.githubusercontent.com/1287144/79986040-74943280-8479-11ea-8313-a94856b80f15.png)

