### PR TITLE
Long Portfolio name breaks the layout

### DIFF
--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -59,12 +59,16 @@ const GlobalStyle = createGlobalStyle`
   flex-grow: 1;
 }
 
-a.pf-c-breadcrumb__item {
-  cursor: pointer;
-  >* {
+.pf-c-breadcrumb__list {
+  overflow-wrap: anywhere;
+  a.pf-c-breadcrumb__item {
     cursor: pointer;
+    >* {
+      cursor: pointer;
+    }
   }
 }
+
 .pf4-hidefield-overlay{
   .hide-indicator {
     z-index: 1;

--- a/src/presentational-components/styled-components/toolbars.js
+++ b/src/presentational-components/styled-components/toolbars.js
@@ -21,6 +21,7 @@ export const TopToolbarWrapper = styled.div`
   }
   h2 {
     margin-bottom: 0 !important;
+    overflow-wrap: anywhere;
   }
   .top-toolbar-title {
     min-width: 200px;


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1455

Extremely long names (without spaces) cause screen elements on the right to be pushed out of the viewport. Here, I used "overflow-wrap: anywhere", which will first attempt to wrap at a word break, failing that, it will break extremely long words where needed.  Since the breadcrumb and title are able to accommodate wrapping, it seemed like a better  approach than using an ellipsis.

/cc @sbuenafe-rh

Old
<img width="1136" alt="Screen Shot 2020-04-23 at 3 44 09 PM" src="https://user-images.githubusercontent.com/1287144/80143106-49453c80-857a-11ea-95d7-528c1d0596dd.png">

New
<img width="1134" alt="Screen Shot 2020-04-23 at 3 43 25 PM" src="https://user-images.githubusercontent.com/1287144/80143103-48aca600-857a-11ea-8efa-f1661cc3282d.png">
<img width="1884" alt="Screen Shot 2020-04-23 at 4 14 37 PM" src="https://user-images.githubusercontent.com/1287144/80145061-94148380-857d-11ea-9e31-7d9828e54514.png">

