### PR TITLE
Fixed missing add products to portfolio button.

### DIFF
--- a/src/smart-components/portfolio/portfolio-empty-state.js
+++ b/src/smart-components/portfolio/portfolio-empty-state.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { SearchIcon, WrenchIcon } from '@patternfly/react-icons';
 
@@ -6,19 +6,19 @@ import ContentGalleryEmptyState, {
   EmptyStatePrimaryAction
 } from '../../presentational-components/shared/content-gallery-empty-state';
 import { Button } from '@patternfly/react-core';
-import UserContext from '../../user-context';
-import { hasPermission } from '../../helpers/shared/helpers';
 
-const PortfolioEmptyState = ({ url, handleFilterChange, meta }) => {
-  const { permissions } = useContext(UserContext);
+const PortfolioEmptyState = ({
+  url,
+  handleFilterChange,
+  meta,
+  userCapabilities: { update }
+}) => {
   const NoDataAction = () => (
     <EmptyStatePrimaryAction
       url={url}
       label="Add products"
       id="add-products-to-portfolio"
-      hasPermission={hasPermission(permissions, [
-        'catalog:portfolio_items:create'
-      ])}
+      hasPermission={update}
     />
   );
 
@@ -48,6 +48,9 @@ PortfolioEmptyState.propTypes = {
   handleFilterChange: PropTypes.func.isRequired,
   meta: PropTypes.shape({
     noData: PropTypes.bool
+  }).isRequired,
+  userCapabilities: PropTypes.shape({
+    update: PropTypes.bool
   }).isRequired
 };
 

--- a/src/smart-components/portfolio/portfolio-items.js
+++ b/src/smart-components/portfolio/portfolio-items.js
@@ -166,6 +166,7 @@ const PortfolioItems = ({
           <PortfolioEmptyState
             handleFilterChange={handleFilterChange}
             meta={meta}
+            userCapabilities={userCapabilities}
             url={routes.addProductsRoute}
           />
         )}

--- a/src/test/smart-components/portfolio/portfolio-empty-state.test.js
+++ b/src/test/smart-components/portfolio/portfolio-empty-state.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, render } from 'enzyme';
 import PortfolioEmptyState from '../../../smart-components/portfolio/portfolio-empty-state';
-import UserContext from '../../../user-context';
 import CatalogLink from '../../../smart-components/common/catalog-link';
 import { MemoryRouter } from 'react-router-dom';
+import UserContext from '../../../user-context';
 
 describe('<PortfolioEmptyState />', () => {
   const initialProps = {
@@ -12,12 +12,12 @@ describe('<PortfolioEmptyState />', () => {
   };
 
   it('should render empty state for noData and no permissions', () => {
-    const wrapper = mount(
-      <UserContext.Provider
-        value={{ permissions: [{ permission: 'wrong:permission:rule' }] }}
-      >
-        <PortfolioEmptyState {...initialProps} meta={{ noData: true }} />
-      </UserContext.Provider>
+    const wrapper = render(
+      <PortfolioEmptyState
+        {...initialProps}
+        meta={{ noData: true }}
+        userCapabilities={{}}
+      />
     );
 
     expect(wrapper.find(CatalogLink)).toHaveLength(0);
@@ -31,7 +31,11 @@ describe('<PortfolioEmptyState />', () => {
             permissions: [{ permission: 'catalog:portfolio_items:create' }]
           }}
         >
-          <PortfolioEmptyState {...initialProps} meta={{ noData: true }} />
+          <PortfolioEmptyState
+            {...initialProps}
+            meta={{ noData: true }}
+            userCapabilities={{ update: true }}
+          />
         </UserContext.Provider>
       </MemoryRouter>
     );
@@ -42,15 +46,12 @@ describe('<PortfolioEmptyState />', () => {
   it('should render empty state for no filter result with clear filters action', () => {
     const handleFilterChange = jest.fn();
     const wrapper = mount(
-      <UserContext.Provider
-        value={{ permissions: [{ permission: 'wrong:permission:rule' }] }}
-      >
-        <PortfolioEmptyState
-          {...initialProps}
-          handleFilterChange={handleFilterChange}
-          meta={{ noData: false }}
-        />
-      </UserContext.Provider>
+      <PortfolioEmptyState
+        {...initialProps}
+        handleFilterChange={handleFilterChange}
+        userCapabilities={{ update: true }}
+        meta={{ noData: false }}
+      />
     );
 
     expect(wrapper.find('button#clear-portfolio-filter')).toHaveLength(1);


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1451

### Changes
- use user capabilities instead of rbac permissions to show/hide add products to the portfolio in empty portfolio

### Before
![screenshot-qa cloud redhat com-2020 04 27-15_23_11](https://user-images.githubusercontent.com/22619452/80377134-22994580-889b-11ea-8a3a-8220524ebdf9.png)

### After
![screenshot-qa foo redhat com_1337-2020 04 27-15_23_22](https://user-images.githubusercontent.com/22619452/80377155-27f69000-889b-11ea-9530-758369d964d4.png)
