### PR TITLE
Long names cause page elements to drop a line

### DIFF
--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -84,6 +84,13 @@ a.pf-c-breadcrumb__item {
   }
 
 }
+
+@media screen and (min-width: 768px) { /* missing from patternfly-react */
+  .pf-u-text-align-right-on-md {
+    text-align:right !important
+  }
+}
+
 /**
 * End of PF4 fixes
 */

--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -12,6 +12,16 @@ const GlobalStyle = createGlobalStyle`
   margin-bottom: 2px !important;
 }
 
+.flex-no-wrap {
+  flex-wrap: nowrap !important;
+  .flex-item-no-wrap {
+    align-self: flex-start;
+    white-space: nowrap;
+  .pf-c-form__actions {
+    flex-wrap: nowrap !important;
+  }
+}
+
 .orders-list {
   background-color: var(--pf-global--BackgroundColor--100)
 }
@@ -82,15 +92,7 @@ a.pf-c-breadcrumb__item {
   &::before {
     z-index: 1;
   }
-
 }
-
-@media screen and (min-width: 768px) { /* missing from patternfly-react */
-  .pf-u-text-align-right-on-md {
-    text-align:right !important
-  }
-}
-
 /**
 * End of PF4 fixes
 */

--- a/src/presentational-components/shared/top-toolbar.js
+++ b/src/presentational-components/shared/top-toolbar.js
@@ -63,9 +63,7 @@ export const TopToolbarTitle = ({
 }) => (
   <Fragment>
     <TopToolbarTitleContainer
-      className={clsx({
-        'pf-u-mb-lg': !noData
-      })}
+      className={clsx({ 'pf-u-mb-lg': !noData, 'flex-no-wrap': true })}
       {...rest}
     >
       <LevelItem>
@@ -83,7 +81,7 @@ export const TopToolbarTitle = ({
           )}
         </TextContent>
       </LevelItem>
-      {children}
+      <LevelItem className="flex-item-no-wrap">{children}</LevelItem>
     </TopToolbarTitleContainer>
   </Fragment>
 );

--- a/src/presentational-components/styled-components/toolbars.js
+++ b/src/presentational-components/styled-components/toolbars.js
@@ -19,6 +19,7 @@ export const TopToolbarWrapper = styled.div`
       pointer-events: none;
     }
   }
+  h1,
   h2 {
     margin-bottom: 0 !important;
     @supports not (overflow-wrap: anywhere) {

--- a/src/smart-components/order/order-detail/order-detail.js
+++ b/src/smart-components/order/order-detail/order-detail.js
@@ -93,7 +93,7 @@ const OrderDetail = () => {
             <Level className="pf-u-mb-md">
               <CatalogBreadcrumbs />
             </Level>
-            <Level>
+            <Level className="flex-no-wrap">
               {unAvailable.length > 0 ? (
                 <UnAvailableAlertContainer>
                   {unAvailable}
@@ -106,7 +106,7 @@ const OrderDetail = () => {
                       orderId={order.id}
                     />
                   </LevelItem>
-                  <LevelItem>
+                  <LevelItem className="flex-item-no-wrap">
                     <OrderToolbarActions
                       portfolioItemName={portfolioItem.name}
                       orderId={order.id}

--- a/src/smart-components/order/order-item.js
+++ b/src/smart-components/order/order-item.js
@@ -74,29 +74,30 @@ const OrderItem = memo(
         <TableCell>
           <TextContent>
             <Grid gutter="sm" className="pf-u-gg-md">
-              <GridItem className="pf-m-9-col-on-md pf-m-10-col-on-lg">
-                <Text
-                  className="pf-u-mb-0 overflow-wrap"
-                  component={TextVariants.h5}
-                >
-                  <CatalogLink
-                    pathname={ORDER_ROUTE}
-                    searchParams={searchParams}
-                  >
-                    {orderName} - Order # {item.id}
-                  </CatalogLink>
-                </Text>
-              </GridItem>
-              <GridItem className="pf-m-3-col-on-md pf-m-2-col-on-lg pf-u-text-align-right-on-md">
-                <CatalogLink
-                  pathname={routeMapper[item.state] || ORDER_ROUTE}
-                  searchParams={searchParams}
-                >
-                  {item.state === 'Failed' && (
-                    <ExclamationCircleIcon className="pf-u-mr-sm icon-danger-fill" />
-                  )}
-                  {item.state}
-                </CatalogLink>
+              <GridItem>
+                <Level className="flex-no-wrap">
+                  <LevelItem>
+                    <Text className="pf-u-mb-0" component={TextVariants.h5}>
+                      <CatalogLink
+                        pathname={ORDER_ROUTE}
+                        searchParams={searchParams}
+                      >
+                        {orderName} - Order # {item.id}
+                      </CatalogLink>
+                    </Text>
+                  </LevelItem>
+                  <LevelItem className="flex-item-no-wrap">
+                    <CatalogLink
+                      pathname={routeMapper[item.state] || ORDER_ROUTE}
+                      searchParams={searchParams}
+                    >
+                      {item.state === 'Failed' && (
+                        <ExclamationCircleIcon className="pf-u-mr-sm icon-danger-fill" />
+                      )}
+                      {item.state}
+                    </CatalogLink>
+                  </LevelItem>
+                </Level>
               </GridItem>
               <GridItem>
                 <Level>

--- a/src/smart-components/order/order-item.js
+++ b/src/smart-components/order/order-item.js
@@ -74,30 +74,29 @@ const OrderItem = memo(
         <TableCell>
           <TextContent>
             <Grid gutter="sm" className="pf-u-gg-md">
-              <GridItem>
-                <Level>
-                  <LevelItem>
-                    <Text className="pf-u-mb-0" component={TextVariants.h5}>
-                      <CatalogLink
-                        pathname={ORDER_ROUTE}
-                        searchParams={searchParams}
-                      >
-                        {orderName} - Order # {item.id}
-                      </CatalogLink>
-                    </Text>
-                  </LevelItem>
-                  <LevelItem>
-                    <CatalogLink
-                      pathname={routeMapper[item.state] || ORDER_ROUTE}
-                      searchParams={searchParams}
-                    >
-                      {item.state === 'Failed' && (
-                        <ExclamationCircleIcon className="pf-u-mr-sm icon-danger-fill" />
-                      )}
-                      {item.state}
-                    </CatalogLink>
-                  </LevelItem>
-                </Level>
+              <GridItem className="pf-m-9-col-on-md pf-m-10-col-on-lg">
+                <Text
+                  className="pf-u-mb-0 overflow-wrap"
+                  component={TextVariants.h5}
+                >
+                  <CatalogLink
+                    pathname={ORDER_ROUTE}
+                    searchParams={searchParams}
+                  >
+                    {orderName} - Order # {item.id}
+                  </CatalogLink>
+                </Text>
+              </GridItem>
+              <GridItem className="pf-m-3-col-on-md pf-m-2-col-on-lg pf-u-text-align-right-on-md">
+                <CatalogLink
+                  pathname={routeMapper[item.state] || ORDER_ROUTE}
+                  searchParams={searchParams}
+                >
+                  {item.state === 'Failed' && (
+                    <ExclamationCircleIcon className="pf-u-mr-sm icon-danger-fill" />
+                  )}
+                  {item.state}
+                </CatalogLink>
               </GridItem>
               <GridItem>
                 <Level>

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
@@ -49,7 +49,7 @@ export const PortfolioItemDetailToolbar = ({
   userCapabilities
 }) => (
   <TopToolbar breadcrumbsSpacing={false}>
-    <Level>
+    <Level className="flex-no-wrap">
       <StyledLevelItem alignStart className="pf-l-flex">
         {userCapabilities.update ? (
           <PortfolioItemIconItem
@@ -68,8 +68,8 @@ export const PortfolioItemDetailToolbar = ({
           <Text component={TextVariants.h1}>{product.name}</Text>
         </TextContent>
       </StyledLevelItem>
-      <LevelItem style={{ minHeight: 36 }}>
-        <Level>
+      <LevelItem style={{ minHeight: 36 }} className="flex-item-no-wrap">
+        <Level className="flex-no-wrap">
           <Route
             exact
             path={url}


### PR DESCRIPTION
Jira:  https://projects.engineering.redhat.com/browse/SSP-1456

This PR fixes an issue on many of the screens where a long name causes buttons, kebabs and text links (on the right) to drop a line. It also insures that those elements are vertically aligned to the top.

Before
![Screen Shot 2020-05-08 at 2 58 09 PM](https://user-images.githubusercontent.com/1287144/81439482-737f2880-913c-11ea-89fd-7b989da12ee8.png)

After
![Screen Shot 2020-05-08 at 2 58 35 PM](https://user-images.githubusercontent.com/1287144/81439481-72e69200-913c-11ea-9035-917462c4a69c.png)


Before
![Screen Shot 2020-05-08 at 3 05 34 PM](https://user-images.githubusercontent.com/1287144/81440042-69a9f500-913d-11ea-851c-177ea4a37a8d.png)

After
![Screen Shot 2020-05-08 at 3 03 58 PM](https://user-images.githubusercontent.com/1287144/81440046-6adb2200-913d-11ea-86e5-d11dd77b90f2.png)


Before
![Screen Shot 2020-05-08 at 2 45 39 PM](https://user-images.githubusercontent.com/1287144/81438373-acb69900-913a-11ea-9744-924ea079b9d8.png)

After
![Screen Shot 2020-05-08 at 2 45 00 PM](https://user-images.githubusercontent.com/1287144/81438375-acb69900-913a-11ea-8059-5fe1e5cad462.png)


Before
![Screen Shot 2020-05-08 at 3 32 31 PM](https://user-images.githubusercontent.com/1287144/81442211-2fdaed80-9141-11ea-9102-4672e4b089ea.png)

After
![Screen Shot 2020-05-08 at 3 31 39 PM](https://user-images.githubusercontent.com/1287144/81442213-2fdaed80-9141-11ea-9ff5-17b27435ce59.png)




