### PR TITLE
Update order detail messages for deleted porfolio items

### DIFF
--- a/src/helpers/order/order-helper.js
+++ b/src/helpers/order/order-helper.js
@@ -81,7 +81,7 @@ export function getOrderApprovalRequests(orderItemId) {
 }
 
 export const getOrderDetail = (params) => {
-  return Promise.all([
+  let detailPromises = [
     axiosInstance.get(`${CATALOG_API_BASE}/orders/${params.order}`),
     axiosInstance.get(
       `${CATALOG_API_BASE}/order_items/${params['order-item']}`
@@ -91,34 +91,7 @@ export const getOrderDetail = (params) => {
       .catch((error) => {
         if (error.status === 404) {
           return {
-            object: 'Portfolio item',
-            notFound: true
-          };
-        }
-
-        throw error;
-      }),
-    axiosInstance
-      .get(`${SOURCES_API_BASE}/sources/${params.platform}`)
-      .catch((error) => {
-        if (error.status === 404 || error.status === 400) {
-          return {
-            object: 'Platform',
-            notFound: true
-          };
-        }
-
-        throw error;
-      }),
-    axiosInstance.get(
-      `${CATALOG_API_BASE}/order_items/${params['order-item']}/progress_messages`
-    ),
-    axiosInstance
-      .get(`${CATALOG_API_BASE}/portfolios/${params.portfolio}`)
-      .catch((error) => {
-        if (error.status === 404 || error.status === 400) {
-          return {
-            object: 'Portfolio',
+            object: 'Product',
             notFound: true
           };
         }
@@ -127,8 +100,47 @@ export const getOrderDetail = (params) => {
       }),
     axiosInstance.get(
       `${CATALOG_API_BASE}/order_items/${params['order-item']}/approval_requests`
+    ),
+    axiosInstance.get(
+      `${CATALOG_API_BASE}/order_items/${params['order-item']}/progress_messages`
     )
-  ]);
+  ];
+
+  if (params && params.platform && params.platform !== 'undefined') {
+    detailPromises.push(
+      axiosInstance
+        .get(`${SOURCES_API_BASE}/sources/${params.platform}`)
+        .catch((error) => {
+          if (error.status === 404 || error.status === 400) {
+            return {
+              object: 'Platform',
+              notFound: true
+            };
+          }
+
+          throw error;
+        })
+    );
+  }
+
+  if (params && params.portfolio && params.portfolio !== 'undefined') {
+    detailPromises.push(
+      axiosInstance
+        .get(`${CATALOG_API_BASE}/portfolios/${params.portfolio}`)
+        .catch((error) => {
+          if (error.status === 404 || error.status === 400) {
+            return {
+              object: 'Portfolio',
+              notFound: true
+            };
+          }
+
+          throw error;
+        })
+    );
+  }
+
+  return Promise.all(detailPromises);
 };
 
 export const getApprovalRequests = (orderItemId) =>

--- a/src/smart-components/order/order-detail/order-detail.js
+++ b/src/smart-components/order/order-detail/order-detail.js
@@ -44,7 +44,7 @@ const OrderDetail = () => {
   const [isFetching, setIsFetching] = useState(true);
   const [queryValues] = useQuery(requiredParams);
   const orderDetailData = useSelector(
-    ({ orderReducer: { orderDetail } }) => orderDetail || {}
+    ({ orderReducer: { orderDetail } }) => orderDetail
   );
   const match = useRouteMatch(ORDER_ROUTE);
   const dispatch = useDispatch();
@@ -72,7 +72,7 @@ const OrderDetail = () => {
     portfolio
   } = orderDetailData;
 
-  const unAvailable = [portfolioItem, platform, portfolio]
+  const unAvailable = [portfolioItem, platform, portfolio || {}]
     .filter(({ notFound }) => notFound)
     .map(({ object }) => (
       <Alert

--- a/src/smart-components/order/order-detail/order-details.js
+++ b/src/smart-components/order/order-detail/order-details.js
@@ -40,13 +40,13 @@ const OrderDetails = () => {
           Portfolio
         </TextListItem>
         <TextListItem component={TextListItemVariants.dd}>
-          {portfolio.name}
+          {portfolio?.name}
         </TextListItem>
         <TextListItem component={TextListItemVariants.dt}>
           Platform
         </TextListItem>
         <TextListItem component={TextListItemVariants.dd}>
-          {platform.name}
+          {platform?.name || undefined}
         </TextListItem>
       </TextList>
       <hr className="pf-c-divider" />

--- a/src/test/smart-components/order/orders.test.js
+++ b/src/test/smart-components/order/orders.test.js
@@ -385,7 +385,7 @@ describe('<Orders />', () => {
         orderDetail: {
           ...orderReducer.orderDetail,
           platform: { notFound: true, object: 'Platform' },
-          portfolioItem: { notFound: true, object: 'Portfolio item' }
+          portfolioItem: { notFound: true, object: 'Product' }
         }
       }
     });


### PR DESCRIPTION
Update order detail messages for deleted porfolio items

Fixes https://projects.engineering.redhat.com/browse/SSP-1409

Only display missing resource message for order detail resources we have the id of.

Before:
![Screenshot from 2020-04-29 18-44-22](https://user-images.githubusercontent.com/12769982/80743833-af3a4280-8aeb-11ea-8381-1a4cf15e9be4.png)


After:
![Screenshot from 2020-04-30 13-55-34](https://user-images.githubusercontent.com/12769982/80743819-aa758e80-8aeb-11ea-97bd-78053a2c1fbf.png)

