### PR TITLE
Details screens responsiveness follow-up

### DIFF
--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -12,6 +12,10 @@ const GlobalStyle = createGlobalStyle`
   margin-bottom: 2px !important;
 }
 
+.overflow-wrap {
+  overflow-wrap: anywhere;
+}
+
 .orders-list {
   background-color: var(--pf-global--BackgroundColor--100)
 }

--- a/src/smart-components/platform/service-offering/service-offering-detail.js
+++ b/src/smart-components/platform/service-offering/service-offering-detail.js
@@ -45,7 +45,7 @@ const ServiceOfferingDetail = () => {
 
   return (
     <Section className="global-primary-background full-height">
-      <Grid className="pf-u-p-lg">
+      <Grid gutter="md" className="pf-u-p-lg">
         <div className="pf-u-mb-sm">
           <CatalogBreadcrumbs />
         </div>
@@ -61,13 +61,21 @@ const ServiceOfferingDetail = () => {
           </Level>
         </GridItem>
         <GridItem md={3} lg={2}>
-          <TextContent className="pf-u-mb-md">
+          <TextContent>
             <Text className="font-14">Platform</Text>
-            <Text id="source" component={TextVariants.p}>
+            <Text
+              id="source"
+              className="overflow-wrap"
+              component={TextVariants.p}
+            >
               {source.name}
             </Text>
             <Text className="font-14">Created</Text>
-            <Text id="created_at" component={TextVariants.p}>
+            <Text
+              id="created_at"
+              className="overflow-wrap"
+              component={TextVariants.p}
+            >
               <DateFormat type="relative" date={service.created_at} />
             </Text>
           </TextContent>

--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
@@ -6,17 +6,23 @@ import { DateFormat } from '@redhat-cloud-services/frontend-components/component
 const ItemDetailInfoBar = ({ product, source, portfolio }) => (
   <TextContent className="pf-u-mb-md">
     <Text className="font-14">Platform</Text>
-    <Text id="source-name" component={TextVariants.p}>
+    <Text id="source-name" className="overflow-wrap" component={TextVariants.p}>
       {source.name}
     </Text>
     <Text className="font-14">Portfolio</Text>
-    <Text id="portfolio-name" component={TextVariants.p}>
+    <Text
+      id="portfolio-name"
+      className="overflow-wrap"
+      component={TextVariants.p}
+    >
       {portfolio.name}
     </Text>
     {product.distributor && (
       <span id="distributor">
         <Text className="font-14">Vendor</Text>
-        <Text component={TextVariants.p}>{product.distributor}</Text>
+        <Text className="overflow-wrap" component={TextVariants.p}>
+          {product.distributor}
+        </Text>
       </span>
     )}
     <Text className="font-14">Created</Text>

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -122,7 +122,7 @@ const PortfolioItemDetail = () => {
                 title="The platform for this product is unavailable"
               />
             )}
-            <Grid className="pf-u-p-lg">
+            <Grid gutter="md" className="pf-u-p-lg">
               <GridItem md={3} lg={2}>
                 <ItemDetailInfoBar
                   product={portfolioItem}

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-info-bar.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/item-detail-info-bar.test.js.snap
@@ -40,11 +40,12 @@ exports[`<ItemDetailInfoBar /> should render correctly 1`] = `
         </p>
       </Text>
       <Text
+        className="overflow-wrap"
         component="p"
         id="source-name"
       >
         <p
-          className=""
+          className="overflow-wrap"
           data-pf-content={true}
           id="source-name"
         >
@@ -62,11 +63,12 @@ exports[`<ItemDetailInfoBar /> should render correctly 1`] = `
         </p>
       </Text>
       <Text
+        className="overflow-wrap"
         component="p"
         id="portfolio-name"
       >
         <p
-          className=""
+          className="overflow-wrap"
           data-pf-content={true}
           id="portfolio-name"
         >
@@ -87,10 +89,11 @@ exports[`<ItemDetailInfoBar /> should render correctly 1`] = `
           </p>
         </Text>
         <Text
+          className="overflow-wrap"
           component="p"
         >
           <p
-            className=""
+            className="overflow-wrap"
             data-pf-content={true}
           >
             foo
@@ -305,11 +308,12 @@ exports[`<ItemDetailInfoBar /> should render correctly with fallback values with
         </p>
       </Text>
       <Text
+        className="overflow-wrap"
         component="p"
         id="source-name"
       >
         <p
-          className=""
+          className="overflow-wrap"
           data-pf-content={true}
           id="source-name"
         >
@@ -327,11 +331,12 @@ exports[`<ItemDetailInfoBar /> should render correctly with fallback values with
         </p>
       </Text>
       <Text
+        className="overflow-wrap"
         component="p"
         id="portfolio-name"
       >
         <p
-          className=""
+          className="overflow-wrap"
           data-pf-content={true}
           id="portfolio-name"
         >
@@ -550,11 +555,12 @@ exports[`<ItemDetailInfoBar /> should render correctly with vendor 1`] = `
         </p>
       </Text>
       <Text
+        className="overflow-wrap"
         component="p"
         id="source-name"
       >
         <p
-          className=""
+          className="overflow-wrap"
           data-pf-content={true}
           id="source-name"
         >
@@ -572,11 +578,12 @@ exports[`<ItemDetailInfoBar /> should render correctly with vendor 1`] = `
         </p>
       </Text>
       <Text
+        className="overflow-wrap"
         component="p"
         id="portfolio-name"
       >
         <p
-          className=""
+          className="overflow-wrap"
           data-pf-content={true}
           id="portfolio-name"
         >
@@ -597,10 +604,11 @@ exports[`<ItemDetailInfoBar /> should render correctly with vendor 1`] = `
           </p>
         </Text>
         <Text
+          className="overflow-wrap"
           component="p"
         >
           <p
-            className=""
+            className="overflow-wrap"
             data-pf-content={true}
           >
             foo


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1457
follow-up to: https://github.com/RedHatInsights/catalog-ui/pull/531

The last PR (https://github.com/RedHatInsights/catalog-ui/pull/531)  made adjustments to the left column on the Service Offering & Portfolio screens to make them responsive and removed the ellipses, allowing wrapping at word breaks.

This PR forces long names without spaces to break where needed and adds proper padding between columns.

Before:
![Screen Shot 2020-04-30 at 11 05 47 AM](https://user-images.githubusercontent.com/1287144/80728276-c1f54d00-8ad4-11ea-86b3-15f84c9353ed.png)

After:
![Screen Shot 2020-04-30 at 11 22 39 AM](https://user-images.githubusercontent.com/1287144/80728451-efda9180-8ad4-11ea-9280-a852691d9a3f.png)

 