### PR TITLE
overflow-wrap fallback support for Safari

### DIFF
--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -12,10 +12,6 @@ const GlobalStyle = createGlobalStyle`
   margin-bottom: 2px !important;
 }
 
-.overflow-wrap {
-  overflow-wrap: anywhere;
-}
-
 .orders-list {
   background-color: var(--pf-global--BackgroundColor--100)
 }
@@ -63,13 +59,19 @@ const GlobalStyle = createGlobalStyle`
   flex-grow: 1;
 }
 
-.pf-c-breadcrumb__list {
-  overflow-wrap: anywhere;
-  a.pf-c-breadcrumb__item {
+.pf-c-breadcrumb__list, .overflow-wrap {
+  @supports not (overflow-wrap: anywhere) {
+    word-break: break-all;
+  }
+  @supports (overflow-wrap: anywhere) {
+    overflow-wrap: anywhere;
+  }
+}
+
+a.pf-c-breadcrumb__item {
+  cursor: pointer;
+  >* {
     cursor: pointer;
-    >* {
-      cursor: pointer;
-    }
   }
 }
 

--- a/src/presentational-components/styled-components/toolbars.js
+++ b/src/presentational-components/styled-components/toolbars.js
@@ -21,7 +21,12 @@ export const TopToolbarWrapper = styled.div`
   }
   h2 {
     margin-bottom: 0 !important;
-    overflow-wrap: anywhere;
+    @supports not (overflow-wrap: anywhere) {
+      word-break: break-all;
+    }
+    @supports (overflow-wrap: anywhere) {
+      overflow-wrap: anywhere;
+    }
   }
   .top-toolbar-title {
     min-width: 200px;


### PR DESCRIPTION
This PR adds a fallback for browsers that don't support the css property/value combination: "overflow-wrap: anywhere."

 Instead of only creating a break if an entire word cannot be placed on its own line without overflowing, the fallback will break text anywhere neccessary.

Follow-up to: https://github.com/RedHatInsights/catalog-ui/pull/550
 jira: https://projects.engineering.redhat.com/browse/SSP-1457

Most browsers
<img width="1098" alt="Screen Shot 2020-04-30 at 2 41 03 PM" src="https://user-images.githubusercontent.com/1287144/80747191-0a226880-8af1-11ea-8902-834c20532e4e.png">

Safari
<img width="1090" alt="Screen Shot 2020-04-30 at 2 40 29 PM" src="https://user-images.githubusercontent.com/1287144/80747195-0abaff00-8af1-11ea-913b-74d5fbe29b29.png">
