### PR TITLE
Added "Ordered" to the list of Order state filter options

### DIFF
--- a/src/smart-components/order/orders-list.js
+++ b/src/smart-components/order/orders-list.js
@@ -176,14 +176,6 @@ const OrdersList = () => {
                     filterValues: {
                       items: [
                         {
-                          value: 'Failed',
-                          label: 'Failed'
-                        },
-                        {
-                          value: 'Completed',
-                          label: 'Completed'
-                        },
-                        {
                           value: 'Approval Pending',
                           label: 'Approval Pending'
                         },
@@ -192,8 +184,20 @@ const OrdersList = () => {
                           label: 'Canceled'
                         },
                         {
+                          value: 'Completed',
+                          label: 'Completed'
+                        },
+                        {
                           value: 'Created',
                           label: 'Created'
+                        },
+                        {
+                          value: 'Failed',
+                          label: 'Failed'
+                        },
+                        {
+                          value: 'Ordered',
+                          label: 'Ordered'
                         }
                       ],
                       value: filters.state,


### PR DESCRIPTION
Added "Ordered" to the filter list and sorted the list alphabetically.

https://projects.engineering.redhat.com/browse/SSP-1485

Before:
![image](https://user-images.githubusercontent.com/2591569/80846169-6cef2f00-8bd9-11ea-99ff-2be63a8c69c3.png)

After:
<help>  🙂 