### PR TITLE
Fixed portfolio card link text color.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3422,7 +3422,7 @@
     "@emotion/babel-utils": {
       "version": "0.6.10",
       "resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.10.tgz",
-      "integrity": "sha1-g9vz36kz+un8Vm5U+7RfFGdMbMw=",
+      "integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
       "requires": {
         "@emotion/hash": "^0.6.6",
         "@emotion/memoize": "^0.6.6",
@@ -3435,7 +3435,7 @@
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M="
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
     },
@@ -3586,7 +3586,7 @@
     "@emotion/hash": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
-      "integrity": "sha1-YiZsXw6saUH+zjAqutafLufiXkQ="
+      "integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
     },
     "@emotion/is-prop-valid": {
       "version": "0.8.6",
@@ -3606,12 +3606,12 @@
     "@emotion/memoize": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
-      "integrity": "sha1-AEuYKY0Ex8o7T1DKIDXU9g0u7Rs="
+      "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
     },
     "@emotion/serialize": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
-      "integrity": "sha1-pJSYKmkgcw26YwPrAYIgorYpwUU=",
+      "integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
       "requires": {
         "@emotion/hash": "^0.6.6",
         "@emotion/memoize": "^0.6.6",
@@ -3627,17 +3627,17 @@
     "@emotion/stylis": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
-      "integrity": "sha1-UPYyJecS2Z4rKznBnHD/8CN5PKU="
+      "integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ=="
     },
     "@emotion/unitless": {
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
-      "integrity": "sha1-U+nxiS9yWxlNXmoWhKezlN9ZI5c="
+      "integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
     },
     "@emotion/utils": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
-      "integrity": "sha1-V2/3+xIwGFthmnXSWMvJjwhnqNw="
+      "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
     },
     "@emotion/weak-memoize": {
       "version": "0.2.5",
@@ -7141,7 +7141,7 @@
     "babel-plugin-emotion": {
       "version": "9.2.11",
       "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz",
-      "integrity": "sha1-MZwAWp7h0Vu0R/Wf5QTDX9WAdyg=",
+      "integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/babel-utils": "^0.6.4",
@@ -7633,7 +7633,7 @@
     "buffer-from": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-      "integrity": "sha1-FfS5vO8BIETfMRQsFDM8r24CYNA="
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -8410,7 +8410,7 @@
     "create-emotion": {
       "version": "9.2.12",
       "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
-      "integrity": "sha1-D8jn+SxPi7kksP72eB9msdB8sm8=",
+      "integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
       "requires": {
         "@emotion/hash": "^0.6.2",
         "@emotion/memoize": "^0.6.1",
@@ -8424,7 +8424,7 @@
     "create-emotion-server": {
       "version": "9.2.12",
       "resolved": "https://registry.npmjs.org/create-emotion-server/-/create-emotion-server-9.2.12.tgz",
-      "integrity": "sha1-MNglB7/kQL+z3WybXI+vJFl+6VQ=",
+      "integrity": "sha512-ET+E6A5MkQTEBNDYAnjh6+0cB33qStFXhtflkZNPEaOmvzYlB/xcPnpUk4J7ul3MVa8PCQx2Ei5g2MGY/y1n+g==",
       "requires": {
         "html-tokenize": "^2.0.0",
         "multipipe": "^1.0.2",
@@ -8523,7 +8523,7 @@
     "css": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
       "requires": {
         "inherits": "^2.0.3",
         "source-map": "^0.6.1",
@@ -8534,7 +8534,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -8643,7 +8643,7 @@
     "cssstyle": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
-      "integrity": "sha1-bam0z/G8XXFubl/o4E/LG1Ckmt8=",
+      "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
       "requires": {
         "cssom": "0.3.x"
       }
@@ -9136,7 +9136,7 @@
     "emotion": {
       "version": "9.2.12",
       "resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.12.tgz",
-      "integrity": "sha1-U5JaqgBWFOZcbkPbgkPIQ1dNHqk=",
+      "integrity": "sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==",
       "requires": {
         "babel-plugin-emotion": "^9.2.11",
         "create-emotion": "^9.2.12"
@@ -9145,7 +9145,7 @@
     "emotion-server": {
       "version": "9.2.12",
       "resolved": "https://registry.npmjs.org/emotion-server/-/emotion-server-9.2.12.tgz",
-      "integrity": "sha1-qqqgSEMQiUPRzlp5bgvECwajIj4=",
+      "integrity": "sha512-Bhjdl7eNoIeiAVa2QPP5d+1nP/31SiO/K1P/qI9cdXCydg91NwGYmteqhhge8u7PF8fLGTEVQfcPwj21815eBw==",
       "requires": {
         "create-emotion-server": "^9.2.12"
       }
@@ -15202,7 +15202,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash-webpack-plugin": {
       "version": "0.11.5",
@@ -20428,12 +20428,12 @@
     "stylis": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha1-9mXyX14pnPPWRlSrlJpXx2i3P74="
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
     },
     "stylis-rule-sheet": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha1-ROZKKwdmQ/S1Ll/3HvwE2MPEpDA="
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
     },
     "sugarss": {
       "version": "2.0.0",
@@ -20505,7 +20505,7 @@
     "tabbable": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
-      "integrity": "sha1-8tFszNAfQA44Y1xxga3+CtllpKI="
+      "integrity": "sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ=="
     },
     "table": {
       "version": "5.4.6",
@@ -20743,7 +20743,7 @@
     "tippy.js": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.1.2.tgz",
-      "integrity": "sha1-WskSM8WatILvWYjP/m4IvSZSjmY=",
+      "integrity": "sha512-Qtrv2wqbRbaKMUb6bWWBQWPayvcDKNrGlvihxtsyowhT7RLGEh1STWuy6EMXC6QLkfKPB2MLnf8W2mzql9VDAw==",
       "requires": {
         "popper.js": "^1.16.0"
       }
@@ -20852,7 +20852,7 @@
     "touch": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/touch/-/touch-2.0.2.tgz",
-      "integrity": "sha1-ygsqOuMhEkamGxa6nmy/FZYocWQ=",
+      "integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
       "requires": {
         "nopt": "~1.0.10"
       }

--- a/src/presentational-components/portfolio/portfolio-card-header.js
+++ b/src/presentational-components/portfolio/portfolio-card-header.js
@@ -18,8 +18,8 @@ const HeaderTitle = styled(LevelItem)`
 const PortfolioCardHeader = ({ id, to, portfolioName, headerActions }) => (
   <Level>
     <HeaderTitle className="pf-m-grow">
-      <Link to={to} id={`portfolio-link-${id}`}>
-        <TextContent>
+      <TextContent>
+        <Link to={to} id={`portfolio-link-${id}`}>
           <Text
             title={portfolioName}
             className="pf-u-mb-0"
@@ -27,8 +27,8 @@ const PortfolioCardHeader = ({ id, to, portfolioName, headerActions }) => (
           >
             <EllipsisTextContainer>{portfolioName}</EllipsisTextContainer>
           </Text>
-        </TextContent>
-      </Link>
+        </Link>
+      </TextContent>
     </HeaderTitle>
     <LevelItem onClick={(event) => event.preventDefault()}>
       {headerActions}

--- a/src/test/presentational-components/portfolio/__snapshots__/portfolio-card-header.test.js.snap
+++ b/src/test/presentational-components/portfolio/__snapshots__/portfolio-card-header.test.js.snap
@@ -5,16 +5,16 @@ exports[`<PortfolioCardHeader /> should render correctly 1`] = `
   <Styled(LevelItem)
     className="pf-m-grow"
   >
-    <Link
-      id="portfolio-link-undefined"
-      to={
-        Object {
-          "pathname": "foo/bar",
-          "search": "?something=1",
+    <TextContent>
+      <Link
+        id="portfolio-link-undefined"
+        to={
+          Object {
+            "pathname": "foo/bar",
+            "search": "?something=1",
+          }
         }
-      }
-    >
-      <TextContent>
+      >
         <Text
           className="pf-u-mb-0"
           component="h3"
@@ -24,8 +24,8 @@ exports[`<PortfolioCardHeader /> should render correctly 1`] = `
             foo
           </styled.div>
         </Text>
-      </TextContent>
-    </Link>
+      </Link>
+    </TextContent>
   </Styled(LevelItem)>
   <LevelItem
     onClick={[Function]}


### PR DESCRIPTION
Links on portfolio cards now have the actual PF link color like the rest of the cards in UI.

### Before
![screenshot-ci cloud redhat com-2020 05 05-13_52_48](https://user-images.githubusercontent.com/22619452/81063238-bc827300-8ed7-11ea-835e-38f9a0200818.png)

### After
![screenshot-ci foo redhat com_1337-2020 05 05-13_52_06](https://user-images.githubusercontent.com/22619452/81063242-bf7d6380-8ed7-11ea-8bd4-dc65a7bc7cda.png)
