### PR TITLE
Fix for null approval request data 

### DIFF
--- a/src/smart-components/error-pages/common-api-error.js
+++ b/src/smart-components/error-pages/common-api-error.js
@@ -18,8 +18,8 @@ const TITLES = {
 };
 
 const MESSAGES = {
-  '/401': 'You are not auhtorized to access this section: ',
-  '/403': 'You are not auhtorized to access this section: '
+  '/401': 'You are not authorized to access this section: ',
+  '/403': 'You are not authorized to access this section: '
 };
 
 const SourceSpan = styled.span`

--- a/src/smart-components/order/order-detail/approval-request.js
+++ b/src/smart-components/order/order-detail/approval-request.js
@@ -38,12 +38,18 @@ const ApprovalRequests = () => {
   );
 
   useEffect(() => {
-    if (order.state !== 'Failed' && approvalRequest.data.length === 0) {
+    if (
+      order.state !== 'Failed' &&
+      (!approvalRequest.data || approvalRequest.data.length === 0)
+    ) {
       checkRequest(() => dispatch(fetchApprovalRequests(orderItem.id)));
     }
   }, []);
 
-  if (order.state === 'Failed' && approvalRequest.data.length === 0) {
+  if (
+    order.state === 'Failed' &&
+    (!approvalRequest.data || approvalRequest.data.length === 0)
+  ) {
     return (
       <Bullseye>
         <Flex breakpointMods={[{ modifier: 'column' }, { modifier: 'grow' }]}>
@@ -62,7 +68,7 @@ const ApprovalRequests = () => {
 
   return (
     <TextContent>
-      {approvalRequest.data.length === 0 ? (
+      {!approvalRequest.data || approvalRequest.data.length === 0 ? (
         <Bullseye>
           <Flex breakpointMods={[{ modifier: 'column' }, { modifier: 'grow' }]}>
             <Bullseye>


### PR DESCRIPTION
Also fix spelling for 'authorized' https://projects.engineering.redhat.com/browse/SSP-1495

Before: crash when approvalRequess.data was null, for both Fail and until data is returned.

After:
![Screenshot from 2020-05-05 09-37-27](https://user-images.githubusercontent.com/12769982/81072556-520c0b80-8eb4-11ea-86b0-922cdd3311ae.png)
![Screenshot from 2020-05-05 09-37-40](https://user-images.githubusercontent.com/12769982/81072580-59cbb000-8eb4-11ea-8ff3-2d258edbe3ba.png)


