### PR TITLE
Add copy option to portfolio card dropdown.

### DIFF
--- a/src/presentational-components/portfolio/porfolio-card.js
+++ b/src/presentational-components/portfolio/porfolio-card.js
@@ -33,7 +33,8 @@ const TO_DISPLAY = ['description'];
 
 const HeaderActions = ({
   portfolioId,
-  userCapabilities: { share, unshare, update, destroy, set_approval }
+  handleCopyPortfolio,
+  userCapabilities: { share, copy, unshare, update, destroy, set_approval }
 }) => {
   const [isOpen, setOpen] = useState(false);
   const dropdownItems = [];
@@ -52,6 +53,18 @@ const HeaderActions = ({
           </CatalogLink>
         }
       />
+    );
+  }
+
+  if (copy) {
+    dropdownItems.push(
+      <DropdownItem
+        key="copy-portfolio-action"
+        id="copy-portfolio-action"
+        onClick={() => handleCopyPortfolio(portfolioId)}
+      >
+        Copy
+      </DropdownItem>
     );
   }
 
@@ -135,8 +148,10 @@ HeaderActions.propTypes = {
     update: PropTypes.bool,
     share: PropTypes.bool,
     unshare: PropTypes.bool,
-    set_approval: PropTypes.bool
-  }).isRequired
+    set_approval: PropTypes.bool,
+    copy: PropTypes.bool
+  }).isRequired,
+  handleCopyPortfolio: PropTypes.func.isRequired
 };
 
 const PortfolioCard = ({
@@ -144,6 +159,7 @@ const PortfolioCard = ({
   isDisabled,
   name,
   id,
+  handleCopyPortfolio,
   metadata: { user_capabilities },
   ...props
 }) => {
@@ -163,6 +179,7 @@ const PortfolioCard = ({
               <HeaderActions
                 portfolioId={id}
                 userCapabilities={user_capabilities}
+                handleCopyPortfolio={handleCopyPortfolio}
               />
             }
           />
@@ -199,7 +216,8 @@ PortfolioCard.propTypes = {
   owner: PropTypes.string,
   isDisabled: PropTypes.bool,
   metadata: PropTypes.shape({ user_capabilities: PropTypes.object.isRequired })
-    .isRequired
+    .isRequired,
+  handleCopyPortfolio: PropTypes.func.isRequired
 };
 
 export default PortfolioCard;

--- a/src/smart-components/portfolio/portfolios.js
+++ b/src/smart-components/portfolio/portfolios.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useEffect, useReducer, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Route, useRouteMatch } from 'react-router-dom';
+import { Route, useRouteMatch, useHistory } from 'react-router-dom';
 import { SearchIcon, WrenchIcon } from '@patternfly/react-icons';
 import { Button } from '@patternfly/react-core';
 
@@ -12,7 +12,10 @@ import { scrollToTop } from '../../helpers/shared/helpers';
 import ToolbarRenderer from '../../toolbar/toolbar-renderer';
 import ContentGallery from '../content-gallery/content-gallery';
 import { defaultSettings } from '../../helpers/shared/pagination';
-import { fetchPortfoliosWithState } from '../../redux/actions/portfolio-actions';
+import {
+  fetchPortfoliosWithState,
+  copyPortfolio
+} from '../../redux/actions/portfolio-actions';
 import PortfolioCard from '../../presentational-components/portfolio/porfolio-card';
 import createPortfolioToolbarSchema from '../../toolbar/schemas/portfolios-toolbar.schema';
 import ContentGalleryEmptyState, {
@@ -28,7 +31,8 @@ import {
   EDIT_PORTFOLIO_ROUTE,
   REMOVE_PORTFOLIO_ROUTE,
   SHARE_PORTFOLIO_ROUTE,
-  WORKFLOW_PORTFOLIO_ROUTE
+  WORKFLOW_PORTFOLIO_ROUTE,
+  PORTFOLIO_ROUTE
 } from '../../constants/routes';
 import UserContext from '../../user-context';
 import { hasPermission } from '../../helpers/shared/helpers';
@@ -79,6 +83,7 @@ const Portfolios = () => {
   const match = useRouteMatch(PORTFOLIOS_ROUTE);
   const dispatch = useDispatch();
   const { permissions: userPermissions } = useContext(UserContext);
+  const history = useHistory();
 
   useEffect(() => {
     dispatch(fetchPortfoliosWithState(viewState?.portfolio)).then(() =>
@@ -104,6 +109,14 @@ const Portfolios = () => {
       }
     );
   };
+
+  const handleCopyPortfolio = (id) =>
+    dispatch(copyPortfolio(id)).then(({ id }) =>
+      history.push({
+        pathname: PORTFOLIO_ROUTE,
+        search: `?portfolio=${id}`
+      })
+    );
 
   const NoDataAction = () => (
     <EmptyStatePrimaryAction
@@ -132,7 +145,11 @@ const Portfolios = () => {
   };
 
   const galleryItems = data.map((item) => (
-    <PortfolioCard key={item.id} {...item} />
+    <PortfolioCard
+      key={item.id}
+      {...item}
+      handleCopyPortfolio={handleCopyPortfolio}
+    />
   ));
 
   return (

--- a/src/test/presentational-components/portfolio/__snapshots__/portfolio-card.test.js.snap
+++ b/src/test/presentational-components/portfolio/__snapshots__/portfolio-card.test.js.snap
@@ -7,9 +7,11 @@ exports[`<PortfolioCard /> should render correctly 1`] = `
       <PortfolioCardHeader
         headerActions={
           <HeaderActions
+            handleCopyPortfolio={[MockFunction]}
             portfolioId="123"
             userCapabilities={
               Object {
+                "copy": true,
                 "destroy": true,
                 "set_approval": true,
                 "share": true,

--- a/src/test/presentational-components/portfolio/portfolio-card.test.js
+++ b/src/test/presentational-components/portfolio/portfolio-card.test.js
@@ -33,8 +33,10 @@ describe('<PortfolioCard />', () => {
       id: '123',
       created_at: 'created',
       owner: 'Owner',
+      handleCopyPortfolio: jest.fn(),
       metadata: {
         user_capabilities: {
+          copy: true,
           destroy: true,
           update: true,
           share: true,
@@ -58,7 +60,7 @@ describe('<PortfolioCard />', () => {
     );
     expect(wrapper.find('button')).toHaveLength(1);
     wrapper.find('button#portfolio-123-toggle').simulate('click');
-    expect(wrapper.find('li')).toHaveLength(4);
+    expect(wrapper.find('li')).toHaveLength(5);
   });
 
   it('should show share dropdown option if only unshare is set to true', () => {
@@ -115,6 +117,20 @@ describe('<PortfolioCard />', () => {
     wrapper.find('button#portfolio-123-toggle').simulate('click');
     expect(wrapper.find('li')).toHaveLength(1);
     expect(wrapper.find('li#set-approval-portfolio-action'));
+  });
+
+  it('should have copy action in dropdown', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <PortfolioCard
+          {...initialProps}
+          metadata={prepareTruthyCapability('copy')}
+        />
+      </MemoryRouter>
+    );
+    wrapper.find('button#portfolio-123-toggle').simulate('click');
+    expect(wrapper.find('li')).toHaveLength(1);
+    expect(wrapper.find('li#copy-portfolio-action'));
   });
 
   it('should not render dropdown', () => {


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1483

A portfolio can now be copied from the card menu.

![copy-portfolio](https://user-images.githubusercontent.com/22619452/81159979-d7adbb00-8f89-11ea-9c00-aeb12c406c67.gif)
