### PR TITLE
Hide add source button for non org admins on producst page

### DIFF
--- a/src/test/smart-components/products/products.test.js
+++ b/src/test/smart-components/products/products.test.js
@@ -19,6 +19,7 @@ import {
   mockApi,
   mockGraphql
 } from '../../../helpers/shared/__mocks__/user-login';
+import UserContext from '../../../user-context';
 
 describe('<Products />', () => {
   let initialState;
@@ -28,7 +29,11 @@ describe('<Products />', () => {
 
   const ComponentWrapper = ({ store, initialEntries = ['/foo'], children }) => (
     <Provider store={store}>
-      <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+      <UserContext.Provider
+        value={{ userIdentity: { identity: { user: { is_org_admin: true } } } }}
+      >
+        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+      </UserContext.Provider>
     </Provider>
   );
 


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1377

The add source button in products page empty state is only visible for org admins.

### Org admin

![screenshot-prod foo redhat com_1337-2020 05 06-12_47_11](https://user-images.githubusercontent.com/22619452/81168965-4db91e80-8f98-11ea-91e8-7993661efa5c.png)

### Others
![screenshot-prod foo redhat com_1337-2020 05 06-12_54_35](https://user-images.githubusercontent.com/22619452/81169236-ccae5700-8f98-11ea-95cc-45fc706fcd46.png)
