### PR TITLE
Ignore all 400 and 404 responses in order detail.

### DIFF
--- a/src/helpers/order/order-helper.js
+++ b/src/helpers/order/order-helper.js
@@ -83,13 +83,22 @@ export function getOrderApprovalRequests(orderItemId) {
 export const getOrderDetail = (params) => {
   let detailPromises = [
     axiosInstance.get(`${CATALOG_API_BASE}/orders/${params.order}`),
-    axiosInstance.get(
-      `${CATALOG_API_BASE}/order_items/${params['order-item']}`
-    ),
+    axiosInstance
+      .get(`${CATALOG_API_BASE}/order_items/${params['order-item']}`)
+      .catch((error) => {
+        if (error.status === 404 || error.status === 400) {
+          return {
+            object: 'Order item',
+            notFound: true
+          };
+        }
+
+        throw error;
+      }),
     axiosInstance
       .get(`${CATALOG_API_BASE}/portfolio_items/${params['portfolio-item']}`)
       .catch((error) => {
-        if (error.status === 404) {
+        if (error.status === 404 || error.status === 400) {
           return {
             object: 'Product',
             notFound: true
@@ -98,12 +107,28 @@ export const getOrderDetail = (params) => {
 
         throw error;
       }),
-    axiosInstance.get(
-      `${CATALOG_API_BASE}/order_items/${params['order-item']}/approval_requests`
-    ),
-    axiosInstance.get(
-      `${CATALOG_API_BASE}/order_items/${params['order-item']}/progress_messages`
-    )
+    axiosInstance
+      .get(
+        `${CATALOG_API_BASE}/order_items/${params['order-item']}/approval_requests`
+      )
+      .catch((error) => {
+        if (error.status === 404 || error.status === 400) {
+          return {};
+        }
+
+        throw error;
+      }),
+    axiosInstance
+      .get(
+        `${CATALOG_API_BASE}/order_items/${params['order-item']}/progress_messages`
+      )
+      .catch((error) => {
+        if (error.status === 404 || error.status === 400) {
+          return {};
+        }
+
+        throw error;
+      })
   ];
 
   if (params && params.platform && params.platform !== 'undefined') {

--- a/src/smart-components/order/order-detail/approval-request.js
+++ b/src/smart-components/order/order-detail/approval-request.js
@@ -41,6 +41,7 @@ const ApprovalRequests = () => {
     if (
       approvalRequest &&
       order.state !== 'Failed' &&
+      orderItem?.id &&
       approvalRequest.data.length === 0
     ) {
       checkRequest(() => dispatch(fetchApprovalRequests(orderItem.id)));

--- a/src/smart-components/order/order-detail/order-detail.js
+++ b/src/smart-components/order/order-detail/order-detail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, Fragment } from 'react';
-import { Route, Switch, useRouteMatch, Redirect } from 'react-router-dom';
+import { Route, Switch, useRouteMatch } from 'react-router-dom';
 import {
   StackItem,
   Level,
@@ -25,7 +25,7 @@ import OrderLifecycle from './order-lifecycle';
 import CatalogBreadcrumbs from '../../common/catalog-breadcrumbs';
 import useBreadcrumbs from '../../../utilities/use-breadcrumbs';
 import { fetchPlatforms } from '../../../redux/actions/platform-actions';
-import { ORDER_ROUTE, ORDERS_ROUTE } from '../../../constants/routes';
+import { ORDER_ROUTE } from '../../../constants/routes';
 import {
   OrderDetailStack,
   OrderDetailStackItem
@@ -59,10 +59,6 @@ const OrderDetail = () => {
     ]).then(() => setIsFetching(false));
     return () => resetBreadcrumbs();
   }, []);
-
-  if (!isFetching && Object.keys(orderDetailData).length === 0) {
-    return <Redirect to={ORDERS_ROUTE} />;
-  }
 
   const {
     order,
@@ -124,7 +120,7 @@ const OrderDetail = () => {
                   state={order.state}
                   jobName={portfolioItem.name}
                   orderRequestDate={order.created_at}
-                  orderUpdateDate={orderItem.updated_at}
+                  orderUpdateDate={orderItem?.updated_at}
                   owner={order.owner}
                 />
               </Level>

--- a/src/smart-components/order/order-detail/order-details.js
+++ b/src/smart-components/order/order-detail/order-details.js
@@ -51,9 +51,11 @@ const OrderDetails = () => {
       </TextList>
       <hr className="pf-c-divider" />
       <Text component={TextVariants.h2}>Order parameters</Text>
-      <ReactJsonView src={orderItem.service_parameters} />
+      {orderItem?.service_parameters && (
+        <ReactJsonView src={orderItem.service_parameters} />
+      )}
       <Text component={TextVariants.h2}>Progress messages</Text>
-      <ReactJsonView src={progressMessages.data} />
+      {progressMessages?.data && <ReactJsonView src={progressMessages.data} />}
     </TextContent>
   );
 };


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1311

### Bug fixes
- of an order item were missing in the order detail, it was causing and crash in the UI 
  - all sub-requests for order detail page are now catching and ignoring 400 and 404 responses to avoid invoking the error notification
  - UI will display the missing product notification