### PR TITLE
Check for approval request data and a small spelling fix

### DIFF
--- a/src/smart-components/error-pages/common-api-error.js
+++ b/src/smart-components/error-pages/common-api-error.js
@@ -18,8 +18,8 @@ const TITLES = {
 };
 
 const MESSAGES = {
-  '/401': 'You are not auhtorized to access this section: ',
-  '/403': 'You are not auhtorized to access this section: '
+  '/401': 'You are not authorized to access this section: ',
+  '/403': 'You are not authorized to access this section: '
 };
 
 const SourceSpan = styled.span`

--- a/src/smart-components/order/order-detail/approval-request.js
+++ b/src/smart-components/order/order-detail/approval-request.js
@@ -31,6 +31,11 @@ const checkRequest = async (fetchRequests) => {
   }
 };
 
+const isEmpty = (approvalRequest) =>
+  !approvalRequest ||
+  !approvalRequest.data ||
+  approvalRequest.data.length === 0;
+
 const ApprovalRequests = () => {
   const dispatch = useDispatch();
   const { order, approvalRequest, orderItem } = useSelector(
@@ -38,20 +43,12 @@ const ApprovalRequests = () => {
   );
 
   useEffect(() => {
-    if (
-      approvalRequest &&
-      order.state !== 'Failed' &&
-      orderItem?.id &&
-      approvalRequest.data.length === 0
-    ) {
+    if (order.state !== 'Failed' && orderItem?.id && isEmpty(approvalRequest)) {
       checkRequest(() => dispatch(fetchApprovalRequests(orderItem.id)));
     }
   }, []);
 
-  if (
-    !approvalRequest ||
-    (order.state === 'Failed' && approvalRequest.data.length === 0)
-  ) {
+  if (order.state === 'Failed' && isEmpty(approvalRequest)) {
     return (
       <Bullseye id="no-approval-requests">
         <Flex breakpointMods={[{ modifier: 'column' }, { modifier: 'grow' }]}>
@@ -70,7 +67,7 @@ const ApprovalRequests = () => {
 
   return (
     <TextContent>
-      {approvalRequest.data && approvalRequest.data.length === 0 ? (
+      {isEmpty(approvalRequest) ? (
         <Bullseye>
           <Flex breakpointMods={[{ modifier: 'column' }, { modifier: 'grow' }]}>
             <Bullseye>

--- a/src/smart-components/order/order-detail/approval-request.js
+++ b/src/smart-components/order/order-detail/approval-request.js
@@ -70,7 +70,7 @@ const ApprovalRequests = () => {
       {isEmpty(approvalRequest) ? (
         <Bullseye>
           <Flex breakpointMods={[{ modifier: 'column' }, { modifier: 'grow' }]}>
-            <Bullseye>
+            <Bullseye id={'creating-approval-request'}>
               <Title>Creating approval request</Title>
             </Bullseye>
             <Bullseye>

--- a/src/test/smart-components/order/order-detail.test.js
+++ b/src/test/smart-components/order/order-detail.test.js
@@ -115,7 +115,7 @@ describe('<OrderDetail />', () => {
         wrapper.update();
       });
       wrapper.update();
-      expect(wrapper.find('div#no-approval-requests')).toHaveLength(1);
+      expect(wrapper.find('div#creating-approval-request')).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
Fix spelling for 'authorized' https://projects.engineering.redhat.com/browse/SSP-1495

Before:
![Screenshot from 2020-05-07 07-10-04](https://user-images.githubusercontent.com/12769982/81289975-4005a680-9035-11ea-8069-8002ec372d5a.png)

After:
![Screenshot from 2020-05-07 07-35-25](https://user-images.githubusercontent.com/12769982/81290028-557ad080-9035-11ea-9e59-e884a984b273.png)



