### PR TITLE
Add missing CSS

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import smoothscroll from 'smoothscroll-polyfill';
 // react-int eng locale data
 import { IntlProvider } from 'react-intl';
 
+import '@redhat-cloud-services/frontend-components/index.css';
 import '@redhat-cloud-services/frontend-components-notifications/index.css';
 import { getAxiosInstance } from './helpers/shared/user-login';
 import { CATALOG_API_BASE, SOURCES_API_BASE } from './utilities/constants';


### PR DESCRIPTION
Added missing CSS files to the catalog.
Turns out that we do need the frontend components CSS. It does work locally but not on proc.

Caused by last bundle size optimizations.

(I feel like I've done this before)