### PR TITLE
Adjust order screen image formatting

### DIFF
--- a/src/presentational-components/styled-components/table.js
+++ b/src/presentational-components/styled-components/table.js
@@ -32,10 +32,10 @@ export const TableCell = styled(({ shrink, children, ...props }) => (
   <td {...props}>{children}</td>
 ))`
   @media screen and (min-width: 768px) {
-    vertical-align: middle !important;
-    width: ${({ shrink }) => (shrink ? '10%' : 'initial')};
+    vertical-align: top !important;
+    width: ${({ shrink }) => (shrink ? '200px' : 'initial')};
     img {
-      object-fit: cover;
+      object-fit: contain;
     }
   }
 `;

--- a/src/smart-components/order/order-item.js
+++ b/src/smart-components/order/order-item.js
@@ -64,7 +64,7 @@ const OrderItem = memo(
         aria-labelledby={`${item.id}-expand`}
         className="data-list-expand-fix"
       >
-        <TableCell shrink className="pf-u-pl-xl">
+        <TableCell shrink className="pf-u-pl-xl-on-md">
           <CardIcon
             height={60}
             src={getOrderIcon(item)}


### PR DESCRIPTION
jira: 
https://projects.engineering.redhat.com/browse/SSP-1494
https://projects.engineering.redhat.com/browse/SSP-1500

In this PR, the left column of the order screen is fixed at 200 pixels (for desktop layout), rather than 10%. This resolved the scaling/cropping problems of images that are very wide (and unreadable when scaled down or cropped.)  I also removed the  left margin from the image in the mobile layout, which had been pushing the image too far right. 

![Screen Shot 2020-05-18 at 9 12 03 AM](https://user-images.githubusercontent.com/1287144/82221459-04e55c00-98ee-11ea-834e-036d9bbad3cc.png)
![Screen Shot 2020-05-18 at 9 12 14 AM](https://user-images.githubusercontent.com/1287144/82221460-057df280-98ee-11ea-9814-057097ae2a83.png)
![Screen Shot 2020-05-18 at 9 12 25 AM](https://user-images.githubusercontent.com/1287144/82221461-057df280-98ee-11ea-89ea-a3aa9a3bd61e.png)
