### PR TITLE
Fixed portfolio reload after copy product action.

### DIFF
--- a/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
@@ -15,13 +15,11 @@ import FormRenderer from '../../common/form-renderer';
 import { getPortfolioItemApi } from '../../../helpers/shared/user-login';
 import {
   copyPortfolioItem,
-  fetchPortfolioItemsWithPortfolio
+  fetchPortfolioItemsWithPortfolio,
+  fetchSelectedPortfolio
 } from '../../../redux/actions/portfolio-actions';
 import asyncFormValidator from '../../../utilities/async-form-validator';
-import {
-  listPortfolios,
-  getPortfolio
-} from '../../../helpers/portfolio/portfolio-helper';
+import { listPortfolios } from '../../../helpers/portfolio/portfolio-helper';
 import { PORTFOLIO_ITEM_ROUTE } from '../../../constants/routes';
 
 const loadPortfolios = (filter) =>
@@ -95,8 +93,14 @@ const CopyPortfolioItemModal = ({
   }, []);
   const onSubmit = async (values) => {
     setSubmitting(true);
-    const portfolio = await getPortfolio(values.portfolio_id);
-    dispatch(copyPortfolioItem(portfolioItemId, values, portfolio))
+    /**
+     * dispatch redux action to set selected portfolio in store
+     * this will ensure that correct portfolio data will be loaded after the redirect occurs
+     */
+    const { value: portfolio } = await dispatch(
+      fetchSelectedPortfolio(values.portfolio_id)
+    );
+    return dispatch(copyPortfolioItem(portfolioItemId, values, portfolio))
       .then(({ id, service_offering_source_ref }) =>
         push({
           pathname: PORTFOLIO_ITEM_ROUTE,
@@ -146,7 +150,7 @@ const CopyPortfolioItemModal = ({
         formContainer="modal"
         componentMapper={{ 'value-only': ValueOnly }}
         buttonsLabels={{ submitLabel: 'Save' }}
-        disableSubmit={submitting ? ['pristine', 'diry'] : []}
+        disableSubmit={submitting ? ['pristine', 'dirty'] : []}
       />
     </Modal>
   );


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1533

### Fixes
- The portfolio was correctly updated but not stored in the redux store. That caused the old data to be shown even though the URL had the correct redirect information
- Also fixed a typo in disabling submit prop on the form

![copy-redirect](https://user-images.githubusercontent.com/22619452/82021652-7f627180-968b-11ea-8d9d-4c1faa487c1a.gif)
