### PR TITLE
Update order for the getOrderDetail promises

### DIFF
--- a/src/helpers/order/order-helper.js
+++ b/src/helpers/order/order-helper.js
@@ -106,18 +106,30 @@ export const getOrderDetail = (params) => {
         }
 
         throw error;
-      }),
-    axiosInstance
-      .get(
-        `${CATALOG_API_BASE}/order_items/${params['order-item']}/approval_requests`
-      )
-      .catch((error) => {
-        if (error.status === 404 || error.status === 400) {
-          return {};
-        }
+      })
+  ];
 
-        throw error;
-      }),
+  detailPromises.push(
+    params.platform && params.platform !== 'undefined'
+      ? axiosInstance
+          .get(`${SOURCES_API_BASE}/sources/${params.platform}`)
+          .catch((error) => {
+            if (error.status === 404 || error.status === 400) {
+              return {
+                object: 'Platform',
+                notFound: true
+              };
+            }
+
+            throw error;
+          })
+      : {
+          object: 'Platform',
+          notFound: true
+        }
+  );
+
+  detailPromises.push(
     axiosInstance
       .get(
         `${CATALOG_API_BASE}/order_items/${params['order-item']}/progress_messages`
@@ -129,41 +141,24 @@ export const getOrderDetail = (params) => {
 
         throw error;
       })
-  ];
+  );
 
-  if (params && params.platform && params.platform !== 'undefined') {
-    detailPromises.push(
-      axiosInstance
-        .get(`${SOURCES_API_BASE}/sources/${params.platform}`)
-        .catch((error) => {
-          if (error.status === 404 || error.status === 400) {
-            return {
-              object: 'Platform',
-              notFound: true
-            };
-          }
+  detailPromises.push(
+    params.portfolio && params.portfolio !== 'undefined'
+      ? axiosInstance
+          .get(`${CATALOG_API_BASE}/portfolios/${params.portfolio}`)
+          .catch((error) => {
+            if (error.status === 404 || error.status === 400) {
+              return {
+                object: 'Portfolio',
+                notFound: true
+              };
+            }
 
-          throw error;
-        })
-    );
-  }
-
-  if (params && params.portfolio && params.portfolio !== 'undefined') {
-    detailPromises.push(
-      axiosInstance
-        .get(`${CATALOG_API_BASE}/portfolios/${params.portfolio}`)
-        .catch((error) => {
-          if (error.status === 404 || error.status === 400) {
-            return {
-              object: 'Portfolio',
-              notFound: true
-            };
-          }
-
-          throw error;
-        })
-    );
-  }
+            throw error;
+          })
+      : { object: 'Portfolio', notFound: true }
+  );
 
   return Promise.all(detailPromises);
 };

--- a/src/smart-components/order/order-detail/order-detail.js
+++ b/src/smart-components/order/order-detail/order-detail.js
@@ -31,6 +31,7 @@ import {
   OrderDetailStackItem
 } from '../../../presentational-components/styled-components/orders';
 import UnAvailableAlertContainer from '../../../presentational-components/styled-components/unavailable-alert-container';
+import { FormattedMessage } from 'react-intl';
 
 const requiredParams = [
   'order-item',
@@ -68,16 +69,41 @@ const OrderDetail = () => {
     portfolio
   } = orderDetailData;
 
-  const unAvailable = [portfolioItem, platform, portfolio || {}]
-    .filter(({ notFound }) => notFound)
-    .map(({ object }) => (
+  const unAvailable = () => {
+    const notFound = [portfolioItem, platform, portfolio || {}].filter(
+      ({ notFound }) => notFound
+    );
+    if (notFound.length === 0) {
+      return null;
+    }
+
+    let notFoundObjects = [];
+    if (portfolioItem.notFound) {
+      notFoundObjects.push(portfolioItem.object);
+    } else {
+      notFoundObjects = notFound.map(({ object }) => object);
+    }
+
+    return (
       <Alert
-        key={object}
+        key="order-object-missing"
         variant="warning"
         isInline
-        title={`The ${object} for this order is not available`}
+        title={
+          <FormattedMessage
+            id={'order-detail-not-found'}
+            defaultMessage={`The ${notFoundObjects.join(
+              ', '
+            )} {count, plural, one {is}
+                    other {are}}  not available`}
+            values={{ count: notFoundObjects.length }}
+          />
+        }
       />
-    ));
+    );
+  };
+
+  const unavailableMessages = unAvailable();
 
   return (
     <OrderDetailStack className="bg-fill">
@@ -90,9 +116,9 @@ const OrderDetail = () => {
               <CatalogBreadcrumbs />
             </Level>
             <Level className="flex-no-wrap">
-              {unAvailable.length > 0 ? (
+              {unavailableMessages ? (
                 <UnAvailableAlertContainer>
-                  {unAvailable}
+                  {unavailableMessages}
                 </UnAvailableAlertContainer>
               ) : (
                 <Fragment>
@@ -112,7 +138,7 @@ const OrderDetail = () => {
                 </Fragment>
               )}
             </Level>
-            {unAvailable.length === 0 && (
+            {!unavailableMessages && (
               <Level>
                 <OrderDetailInformation
                   portfolioItemId={portfolioItem.id}

--- a/src/test/smart-components/order/orders.test.js
+++ b/src/test/smart-components/order/orders.test.js
@@ -431,7 +431,7 @@ describe('<Orders />', () => {
     });
     wrapper.update();
 
-    expect(wrapper.find(Alert)).toHaveLength(2);
+    expect(wrapper.find(Alert)).toHaveLength(1);
     done();
   });
 });


### PR DESCRIPTION
Fixes https://projects.engineering.redhat.com/browse/SSP-1534

1. Fixes the order of the array of promises in getOrderDetails.
2. If the portfolio item is missing, only display the message for that, not for the platform or portfolio

![Screenshot from 2020-05-17 13-24-35](https://user-images.githubusercontent.com/12769982/82155691-ccd60e80-9844-11ea-8c74-eabe071ddb18.png)
![Screenshot from 2020-05-17 13-24-55](https://user-images.githubusercontent.com/12769982/82155697-d1022c00-9844-11ea-8a7f-feb21605cb95.png)
![Screenshot from 2020-05-17 13-24-23](https://user-images.githubusercontent.com/12769982/82155698-d19ac280-9844-11ea-87c9-c2879e29a010.png)
![Screenshot from 2020-05-17 13-24-02](https://user-images.githubusercontent.com/12769982/82155699-d19ac280-9844-11ea-9b30-86c7ed4c61c6.png)
