### PR TITLE
Improve the viewState hash routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9694,7 +9694,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/test/__mocks__/fileMock.js",
       "\\.(css|scss)$": "identity-obj-proxy"
     },
-    "testURL": "http://localhost:5000/"
+    "testURL": "http://localhost:5000/catalog"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/src/utilities/view-state-middleware.js
+++ b/src/utilities/view-state-middleware.js
@@ -1,4 +1,5 @@
 import { encodeState } from '../routing/uri-state-manager';
+import { catalogHistory } from '../router';
 
 const viewStateMiddleware = () => (dispatch) => (action) => {
   if (
@@ -6,13 +7,28 @@ const viewStateMiddleware = () => (dispatch) => (action) => {
     action?.payload?.meta &&
     action?.meta?.storeState
   ) {
-    window.location.hash = encodeState(
+    const hash = encodeState(
       {
         ...action.meta,
         ...action.payload.meta
       },
       action.meta.stateKey
     );
+    /**
+     * Use replace event in case that app did not compute the viewState hash yet (eg. navigating in main menu).
+     * Use history replace event to prevent the multiple prev routes with the same pathname on stack witouth the hash param.
+     * The browser goBack method will now skip the non hash route.
+     * Users wont have to trigger the goBack action multiple times to get to the actual previous view.
+     */
+    const routingAction =
+      catalogHistory.location.hash && catalogHistory.location.hash !== hash
+        ? catalogHistory.push
+        : catalogHistory.replace;
+    routingAction({
+      pathname: catalogHistory.location.pathname,
+      search: catalogHistory.location.search,
+      hash
+    });
   }
 
   return dispatch(action);


### PR DESCRIPTION
### Changes
- use replace history method when appending hash to pathname for the first time
  - before it took several goBack actions to actually navigate to previous valid view
  - the sequence looked something like this when navigating back from portfolios to products:
```
/portfolios#viewStateHash -> /portfolios -> /products#hash
```
  - now it skips the middle step which is only temporary
```
/portfolios#viewStateHash -> /products#hash
```