### PR TITLE
Add a hash to JS bundles

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -37,8 +37,8 @@ const commonConfig = {
     }
   },
   output: {
-    filename: 'js/[name].js',
-    chunkFilename: 'js/[name].js',
+    filename: 'js/[name].[contenthash].js',
+    chunkFilename: 'js/[name].[contenthash].js',
     path: common.paths.public,
     publicPath: common.paths.publicPath
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9694,7 +9694,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
     "prod": " NODE_ENV=production webpack-dev-server --config config/webpack.config.js --env.prod=true --mode production",
     "server:ctr": "node src/server/generateServerKey.js",
-    "start": "BETA=true webpack-dev-server --config config/webpack.config.js --env.prod=false --mode development",
+    "start": "rm -rf ./dist && webpack-dev-server --config config/webpack.config.js --env.prod=false --mode development",
     "travis:build": "NODE_ENV=production webpack --config config/webpack.config.js --env.prod=true --mode production",
     "travis:verify": "npm-run-all travis:build lint test",
     "verify": "npm-run-all build lint test"

--- a/profiles/local-frontends.js
+++ b/profiles/local-frontends.js
@@ -7,12 +7,16 @@ const APP_ID = 'catalog';
 const FRONTEND_PORT = 8002;
 
 const routes = {
+  [`/${SECTION}/${APP_ID}`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
+  [`/beta/${SECTION}/${APP_ID}`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
   [`/beta/${SECTION}/${APP_ID}/portfolios`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
   [`/${SECTION}/${APP_ID}/portfolios`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
-  [`/beta/${SECTION}/${APP_ID}/platforms`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
+  [`/beta/${SECTION}/${APP_ID}/portfolios`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
   [`/${SECTION}/${APP_ID}/platforms`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
-  [`/beta/${SECTION}/${APP_ID}/orders`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
+  [`/beta/${SECTION}/${APP_ID}/platforms`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
   [`/${SECTION}/${APP_ID}/orders`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
+  [`/beta/${SECTION}/${APP_ID}/orders`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
+  [`/apps/${APP_ID}`]: { host: `https://${localhost}:${FRONTEND_PORT}` },
   [`/beta/apps/${APP_ID}`]: { host: `https://${localhost}:${FRONTEND_PORT}` }
 };
 


### PR DESCRIPTION
In preparation for service workes and browser caching and pre-loading of the assets, we need to ensure that w have unique asset names in order to be able to use the most aggressive and efficient cache strategy.

The webpack `contentHash` generates a unique hash based on the file contents. This should allow us to use the `CacheFirst` service worker cache strategy.

I've also had to adjust the spadnx confix because we were missing the root override `/anasible/catalog` and it was serving the old `App.js` and `index.html` directly from ci.cloud and not the localhost.

### We no longer need to develop on /beta version of the. In order to do that just add `BETA=true` before the UI start script. It was done automatically before.