### PR TITLE
Use 403 as a default unauthorized route.

### DIFF
--- a/src/smart-components/error-pages/error-redirects.js
+++ b/src/smart-components/error-pages/error-redirects.js
@@ -6,7 +6,7 @@ export const UnauthorizedRedirect = () => {
   return (
     <Redirect
       to={{
-        pathname: '/401',
+        pathname: '/403',
         state: {
           from: location
         }

--- a/src/test/routing/catalog-route.test.js
+++ b/src/test/routing/catalog-route.test.js
@@ -19,7 +19,7 @@ describe('<CatalogRoute />', () => {
             >
               <div id="behind-protected-route"></div>
             </CatalogRoute>
-            <Route path="/401">
+            <Route path="/403">
               <CommonApiError />
             </Route>
           </Switch>
@@ -28,7 +28,7 @@ describe('<CatalogRoute />', () => {
     );
     expect(
       wrapper.find(MemoryRouter).instance().history.location.pathname
-    ).toEqual('/401');
+    ).toEqual('/403');
     expect(wrapper.find(CommonApiError)).toHaveLength(1);
     expect(wrapper.find('#behind-protected-route')).toHaveLength(0);
   });
@@ -45,7 +45,7 @@ describe('<CatalogRoute />', () => {
             >
               <div id="behind-protected-route"></div>
             </CatalogRoute>
-            <Route path="/401">
+            <Route path="/403">
               <CommonApiError />
             </Route>
           </Switch>
@@ -54,7 +54,7 @@ describe('<CatalogRoute />', () => {
     );
     expect(
       wrapper.find(MemoryRouter).instance().history.location.pathname
-    ).toEqual('/401');
+    ).toEqual('/403');
     expect(wrapper.find(CommonApiError)).toHaveLength(1);
     expect(wrapper.find('#behind-protected-route')).toHaveLength(0);
   });
@@ -98,7 +98,7 @@ describe('<CatalogRoute />', () => {
             >
               <div id="behind-protected-route"></div>
             </CatalogRoute>
-            <Route path="/401">
+            <Route path="/403">
               <CommonApiError />
             </Route>
           </Switch>
@@ -107,7 +107,7 @@ describe('<CatalogRoute />', () => {
     );
     expect(
       wrapper.find(MemoryRouter).instance().history.location.pathname
-    ).toEqual('/401');
+    ).toEqual('/403');
     expect(wrapper.find(CommonApiError)).toHaveLength(1);
     expect(wrapper.find('#behind-protected-route')).toHaveLength(0);
   });

--- a/src/test/smart-components/portfolio/add-portfolio-modal.test.js
+++ b/src/test/smart-components/portfolio/add-portfolio-modal.test.js
@@ -157,6 +157,6 @@ describe('<AddPortfolioModal />', () => {
 
     expect(
       wrapper.find(MemoryRouter).instance().history.location.pathname
-    ).toEqual('/401');
+    ).toEqual('/403');
   });
 });

--- a/src/test/smart-components/portfolio/portfolio.test.js
+++ b/src/test/smart-components/portfolio/portfolio.test.js
@@ -720,7 +720,7 @@ describe('<Portfolio />', () => {
     expect(search).toEqual('?portfolio=portfolio-id');
   });
 
-  it('should redirect the user to 401 page if the user capability show is set to false', async (done) => {
+  it('should redirect the user to 403 page if the user capability show is set to false', async (done) => {
     const store = mockStore({
       ...initialState,
       portfolioReducer: {
@@ -758,13 +758,13 @@ describe('<Portfolio />', () => {
             path="/portfolio"
             render={(...args) => <Portfolio {...initialProps} {...args} />}
           />
-          <Route path="/401" component={CommonApiError} />
+          <Route path="/403" component={CommonApiError} />
         </ComponentWrapper>
       );
     });
     expect(
       wrapper.find(MemoryRouter).instance().history.location.pathname
-    ).toEqual('/401');
+    ).toEqual('/403');
     wrapper.update();
     expect(wrapper.find(CommonApiError)).toHaveLength(1);
     done();

--- a/src/test/smart-components/portfolio/remove-portfolio-modal.test.js
+++ b/src/test/smart-components/portfolio/remove-portfolio-modal.test.js
@@ -279,6 +279,6 @@ describe('<RemovePortfolioModal />', () => {
         .find(MemoryRouter)
         .children()
         .props().history.location.pathname
-    ).toEqual('/401');
+    ).toEqual('/403');
   });
 });

--- a/src/test/smart-components/portfolio/share-portfolio-modal.test.js
+++ b/src/test/smart-components/portfolio/share-portfolio-modal.test.js
@@ -217,7 +217,7 @@ describe('<SharePortfolioModal', () => {
     wrapper.update();
     expect(
       wrapper.find(MemoryRouter).instance().history.location.pathname
-    ).toEqual('/401');
+    ).toEqual('/403');
     done();
   });
 });


### PR DESCRIPTION
### Changes
- use 403  route as a default for unauthorized redirects
  - 401 is for authentication issues, we do not want to communicate to the user that he should log in
  - 403 is for authorization issues, we know who the user is, we just simply tell him that they do not have the authorization do some action