### PR TITLE
Update "set approval" modal

### DIFF
--- a/src/forms/edit-workflow_form.schema.js
+++ b/src/forms/edit-workflow_form.schema.js
@@ -6,7 +6,7 @@ const editWorkflowSchema = (loadWorkflows) => ({
     {
       component: componentTypes.SELECT,
       name: 'selectedWorkflows',
-      label: 'Select approval process',
+      label: '',
       loadOptions: asyncFormValidator(loadWorkflows),
       multi: true,
       isSearchable: true,

--- a/src/smart-components/common/edit-approval-workflow.js
+++ b/src/smart-components/common/edit-approval-workflow.js
@@ -1,7 +1,14 @@
 import React, { useEffect, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { Modal } from '@patternfly/react-core';
+import {
+  Modal,
+  TextContent,
+  Text,
+  TextVariants,
+  Stack,
+  StackItem
+} from '@patternfly/react-core';
 import FormRenderer from '../common/form-renderer';
 import editApprovalWorkflowSchema from '../../forms/edit-workflow_form.schema';
 import {
@@ -85,24 +92,34 @@ const EditApprovalWorkflow = ({
 
   return (
     <Modal
-      title={`Set approval process for ${objectName(query[querySelector])}`}
+      title="Set approval process"
       isOpen
       onClose={() => history.push(pushParam)}
       isSmall
     >
-      {!isFetching ? (
-        <FormRenderer
-          initialValues={{
-            selectedWorkflows: data ? data.map((wf) => wf.id) : undefined
-          }}
-          onSubmit={onSubmit}
-          onCancel={() => history.push(pushParam)}
-          schema={editApprovalWorkflowSchema(loadWorkflowOptions)}
-          formContainer="modal"
-          buttonsLabels={{ submitLabel: 'Save' }}
-        />
-      ) : (
-        <WorkflowLoader />
+      {isFetching && <WorkflowLoader />}
+      {!isFetching && (
+        <Stack gutter="md">
+          <StackItem>
+            <TextContent>
+              <Text>
+                Select approval processes for <strong>{objectName(query[querySelector])}</strong>
+              </Text>
+            </TextContent>
+          </StackItem>
+          <StackItem>
+            <FormRenderer
+              initialValues={{
+                selectedWorkflows: data ? data.map((wf) => wf.id) : undefined
+              }}
+              onSubmit={onSubmit}
+              onCancel={() => history.push(pushParam)}
+              schema={editApprovalWorkflowSchema(loadWorkflowOptions)}
+              formContainer="modal"
+              buttonsLabels={{ submitLabel: 'Save' }}
+            />
+          </StackItem>
+        </Stack>
       )}
     </Modal>
   );

--- a/src/test/smart-components/common/edit-approval-workflow.test.js
+++ b/src/test/smart-components/common/edit-approval-workflow.test.js
@@ -4,7 +4,6 @@ import thunk from 'redux-thunk';
 import { shallow, mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-import { Modal } from '@patternfly/react-core';
 import { shallowToJson } from 'enzyme-to-json';
 import { MemoryRouter, Route } from 'react-router-dom';
 import promiseMiddleware from 'redux-promise-middleware';
@@ -112,7 +111,7 @@ describe('<EditApprovalWorkflow />', () => {
         {
           component: componentTypes.SELECT,
           name: 'selectedWorkflows',
-          label: 'Select approval process',
+          label: '',
           loadOptions: expect.any(Function),
           multi: true,
           isSearchable: true,
@@ -145,9 +144,6 @@ describe('<EditApprovalWorkflow />', () => {
     wrapper.update();
     const modal = wrapper.find(Modal);
     const form = wrapper.find(FormRenderer);
-    expect(modal.props().title).toEqual(
-      'Set approval process for Test Resource Name'
-    );
     expect(form.props().schema).toEqual(expectedSchema);
     done();
   });


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1539

This PR set the modal title to the generic "Set Approval" and moves the full portfolio name into the body of the modal (just like "Share Portfolio".)  This allows long portfolio names to wrap properly.

Before
![Screen Shot 2020-05-28 at 4 24 31 PM](https://user-images.githubusercontent.com/1287144/83190018-cb87ca00-a0ff-11ea-9c40-d41aa51a6c4b.png)

After
![Screen Shot 2020-06-01 at 10 28 04 AM](https://user-images.githubusercontent.com/1287144/83419223-bc03cc00-a3f2-11ea-90e9-ac076ab1124a.png)





