### PR TITLE
Update Sources link text to match UI

### DIFF
--- a/src/smart-components/platform/platforms.js
+++ b/src/smart-components/platform/platforms.js
@@ -44,7 +44,7 @@ const Platforms = () => {
         {is_org_admin ? (
           <Text component={TextVariants.p}>
             To connect to a source, go to{' '}
-            <a href={`${document.baseURI}settings/sources`}>Catalog sources</a>
+            <a href={`${document.baseURI}settings/sources`}>Sources</a>
             &nbsp;under Settings.
           </Text>
         ) : (

--- a/src/smart-components/products/products.js
+++ b/src/smart-components/products/products.js
@@ -144,7 +144,7 @@ const Products = () => {
         {is_org_admin ? (
           <Text component={TextVariants.p}>
             To connect to a source, go to{' '}
-            <a href={`${document.baseURI}settings/sources`}>Catalog sources</a>
+            <a href={`${document.baseURI}settings/sources`}>Sources</a>
             &nbsp;under Settings.
           </Text>
         ) : (


### PR DESCRIPTION
Change "Catalog sources" to "Sources"

The settings area only shows a "Sources" link.
![image](https://user-images.githubusercontent.com/2591569/83196143-5c16d800-a109-11ea-9c8f-ee559ee120d0.png)

I believe "Catalog sources" was the text being used before the Sources UI moved to the global gear icon.

Before
![image](https://user-images.githubusercontent.com/2591569/83196089-41446380-a109-11ea-9d56-2c270f711d2b.png)

After: 
![image](https://user-images.githubusercontent.com/2591569/83259925-e6e9e800-a186-11ea-86cb-4c5eb0e52b49.png)
