### PR TITLE
Add navigation pre-load to SW config

### DIFF
--- a/config/webpack.plugins.js
+++ b/config/webpack.plugins.js
@@ -36,19 +36,37 @@ const plugins = [
   ]),
   new WorkboxWebpackPlugin.GenerateSW({
     clientsClaim: true,
+    navigationPreload: true,
     exclude: [/\.map$/, /asset-manifest\.json$/],
     // navigateFallback: paths.publicUrlOrPath + 'index.html',
     navigateFallbackDenylist: [
       // Exclude URLs with hashes
       new RegExp('#'),
-      // Exclude any URLs whose last part seems to be a file extension
-      // as they're likely a resource and not a SPA route.
-      // URLs containing a "?" character won't be blacklisted as they're likely
-      // a route with query params (e.g. auth callbacks).
-      new RegExp('/[^/?]+\\.[^/]+$'),
       // For now exclude any API calls
       // we might want use staleWhileRevalide or networkFirst strategy for entitlements or rbac permissions later
       new RegExp(/\/api\//)
+    ],
+    runtimeCaching: [
+      {
+        urlPattern: /^https?.*\.js$/,
+        handler: 'CacheFirst',
+        options: {
+          cacheName: 'offlineCache',
+          expiration: {
+            maxEntries: 200
+          }
+        }
+      },
+      {
+        urlPattern: /\.(png|svg|jpg)$/,
+        handler: 'CacheFirst',
+        options: {
+          cacheName: 'imageCache',
+          expiration: {
+            maxEntries: 200
+          }
+        }
+      }
     ]
   })
 ];


### PR DESCRIPTION
The service worker registration was successful. It reduced time to the first interactive on `ci.cloud.redhat.com` about 60% which is great. We can now start optimizing the config and start deliberately caching certain resources. 

### Changes
- pre-cache all js files in the background
  - this is a non-bocking operation so the user won't notice that additional data is downloading
  - this also reduces overall bandwidth usage for any user that visits the app more than one time, which is probably everybody
- create specific cache for image files
- allow navigation preload
  - routes are not configured just yet, that will come later on

**If you want to test it locally, let me know, there is a way to run it in dev environment. I can send you a command to run it.**