### PR TITLE
Fix survey editor not propagating reset changes.

### DIFF
--- a/src/smart-components/survey-editing/survey-editor.js
+++ b/src/smart-components/survey-editing/survey-editor.js
@@ -157,6 +157,15 @@ const SurveyEditor = ({ closeUrl, search, portfolioItem, uploadIcon }) => {
   const [isFetching, setIsFetching] = useState(false);
   const [baseSchema, setBaseSchema] = useState();
   const [servicePlan, setServicePlan] = useState();
+  /**
+   * There is an issues with later versions react final form, that it ignores parent props changes and caches
+   * itself to increase performance. This had an unfortunate side effect of ignoring the outside schema changes
+   * which are not propagated to the component tree. We use this counter to destroy the old and create a new instance
+   * when the key (updateHack) counter is changed. There is currently no better sollution due to the fact that the
+   * react final form is an outside dependency.
+   * We will make an effort to fix it inside the library but until then we need this workaround.
+   */
+  const [updateHack, setUpdateHack] = useState(0);
   const dispatch = useDispatch();
   const { push } = useHistory();
   const getServicePlan = () =>
@@ -231,46 +240,56 @@ const SurveyEditor = ({ closeUrl, search, portfolioItem, uploadIcon }) => {
     getServicePlansApi()
       .resetServicePlanModified(id)
       .then(getServicePlan)
-      .then(() =>
-        dispatch(
+      .then(() => {
+        /**
+         * Counter has to updated again after the update was successfull
+         * This mutation amkes sure that new instance will be created after the data was returned
+         * form API.
+         */
+        setUpdateHack((prevCount) => prevCount + 1);
+        return dispatch(
           addNotification({
             variant: 'success',
             title: `Survey of ${portfolioItem.name} has been restored.`,
             dismissable: true
           })
-        )
-      );
+        );
+      });
   };
 
   return (
     <Fragment>
       {schema ? (
-        <BuilderWrapper
-          {...pf4Skin}
-          schema={schema}
-          disableDrag
-          disableAdd
-          schemaTemplate={baseSchema}
-          mode="subset"
-        >
-          {({ getSchema, isValid, ...props }) => (
-            <Fragment>
-              <SurveyEditingToolbar
-                key="survey-editor-toolbar"
-                uploadIcon={uploadIcon}
-                product={portfolioItem}
-                handleSaveSurvey={() => handleSaveSurvey(getSchema())}
-                isValid={isValid}
-                closeUrl={closeUrl}
-                search={search}
-                isFetching={isFetching || !schema}
-                modified={servicePlan.modified}
-                handleResetSurvey={() => handleResetSurvey(servicePlan.id)}
-              />
-              <BuilderTemplate {...props} />;
-            </Fragment>
-          )}
-        </BuilderWrapper>
+        [
+          <BuilderWrapper
+            {...pf4Skin}
+            // this key is required to destroy outdated instances of the form builder
+            key={updateHack}
+            schema={schema}
+            disableDrag
+            disableAdd
+            schemaTemplate={baseSchema}
+            mode="subset"
+          >
+            {({ getSchema, isValid, ...props }) => (
+              <Fragment>
+                <SurveyEditingToolbar
+                  key="survey-editor-toolbar"
+                  uploadIcon={uploadIcon}
+                  product={portfolioItem}
+                  handleSaveSurvey={() => handleSaveSurvey(getSchema())}
+                  isValid={isValid}
+                  closeUrl={closeUrl}
+                  search={search}
+                  isFetching={isFetching || !schema}
+                  modified={servicePlan?.modified}
+                  handleResetSurvey={() => handleResetSurvey(servicePlan.id)}
+                />
+                <BuilderTemplate {...props} />;
+              </Fragment>
+            )}
+          </BuilderWrapper>
+        ]
       ) : (
         <Fragment>
           <SurveyEditingToolbar


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1616

### Changes
- force to create a new instance of survey editor when the survey was reset
  - this is a hacky solution, the core of the problem is inside the react final form library and has to be fixed there or we need to find a different state manager

![survey-editor-reset](https://user-images.githubusercontent.com/22619452/84629005-eb820080-aee9-11ea-9b32-bef0758de981.gif)
