### PR TITLE
Redirect to oder detail from order success notification.

### DIFF
--- a/src/helpers/order/order-helper.js
+++ b/src/helpers/order/order-helper.js
@@ -30,8 +30,10 @@ export async function sendSubmitOrder({
     service_parameters,
     provider_control_parameters: providerControlParameters || {}
   };
-  await orderApi.addToOrder(order.id, orderItem);
-  return orderApi.submitOrder(order.id);
+  const orderItemResponse = await orderApi.addToOrder(order.id, orderItem);
+  return orderApi
+    .submitOrder(order.id)
+    .then((order) => ({ ...order, orderItem: orderItemResponse }));
 }
 
 export function cancelOrder(orderId) {

--- a/src/presentational-components/order/order-notification.js
+++ b/src/presentational-components/order/order-notification.js
@@ -3,12 +3,25 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/cjs/actions';
-import { ORDERS_ROUTE } from '../../constants/routes';
+import { ORDER_ROUTE } from '../../constants/routes';
 
-const OrderNotification = ({ id, dispatch }) => (
+const OrderNotification = ({
+  id,
+  dispatch,
+  portfolioItemId,
+  portfolioId,
+  platformId,
+  orderItemId
+}) => (
   <Fragment>
     You can track the progress of Order # {id} in your{' '}
-    <Link onClick={() => dispatch(clearNotifications())} to={ORDERS_ROUTE}>
+    <Link
+      onClick={() => dispatch(clearNotifications())}
+      to={{
+        pathname: ORDER_ROUTE,
+        search: `?order=${id}&order-item=${orderItemId}&portfolio-item=${portfolioItemId}&platform=${platformId}&portfolio=${portfolioId}`
+      }}
+    >
       Orders
     </Link>{' '}
     page.
@@ -17,7 +30,11 @@ const OrderNotification = ({ id, dispatch }) => (
 
 OrderNotification.propTypes = {
   id: PropTypes.string.isRequired,
-  dispatch: PropTypes.func.isRequired
+  dispatch: PropTypes.func.isRequired,
+  portfolioItemId: PropTypes.string.isRequired,
+  portfolioId: PropTypes.string.isRequired,
+  platformId: PropTypes.string.isRequired,
+  orderItemId: PropTypes.string.isRequired
 };
 
 export default OrderNotification;

--- a/src/redux/actions/order-actions.js
+++ b/src/redux/actions/order-actions.js
@@ -21,15 +21,24 @@ export const setSelectedPlan = (data) => ({
   payload: data
 });
 
-export const sendSubmitOrder = (apiProps) => (dispatch) =>
+export const sendSubmitOrder = (apiProps, portfolioItem) => (dispatch) =>
   dispatch({
     type: ActionTypes.SUBMIT_SERVICE_ORDER,
-    payload: OrderHelper.sendSubmitOrder(apiProps).then(({ id }) =>
+    payload: OrderHelper.sendSubmitOrder(apiProps).then(({ id, orderItem }) =>
       dispatch(
         addNotification({
           variant: 'success',
           title: 'Your order has been accepted successfully',
-          description: <OrderNotification id={id} dispatch={dispatch} />,
+          description: (
+            <OrderNotification
+              id={id}
+              dispatch={dispatch}
+              portfolioItemId={portfolioItem.id}
+              portfolioId={portfolioItem.portfolio_id}
+              platformId={portfolioItem.service_offering_source_ref}
+              orderItemId={orderItem.id}
+            />
+          ),
           dismissable: true
         })
       )

--- a/src/smart-components/common/order-modal.js
+++ b/src/smart-components/common/order-modal.js
@@ -23,12 +23,15 @@ import {
   sendSubmitOrder
 } from '../../redux/actions/order-actions';
 import SpinnerWrapper from '../../presentational-components/styled-components/spinner-wrapper';
+import useQuery from '../../utilities/use-query';
 
 const OrderModal = ({ closeUrl }) => {
   const [isFetching, setFetching] = useState(true);
   const { search } = useLocation();
   const { push } = useHistory();
   const dispatch = useDispatch();
+  const [searchParams] = useQuery(['portfolio-item']);
+  const portfolioItemId = searchParams['portfolio-item'];
   const { portfolioItem } = useSelector(
     ({ portfolioReducer: { portfolioItem } }) => portfolioItem
   );
@@ -37,17 +40,18 @@ const OrderModal = ({ closeUrl }) => {
   );
 
   useEffect(() => {
-    dispatch(fetchServicePlans(portfolioItem.id)).then(() =>
-      setFetching(false)
-    );
+    dispatch(fetchServicePlans(portfolioItemId)).then(() => setFetching(false));
   }, []);
 
   const onSubmit = (data) => {
     dispatch(
-      sendSubmitOrder({
-        portfolio_item_id: portfolioItem.id,
-        service_parameters: data
-      })
+      sendSubmitOrder(
+        {
+          portfolio_item_id: portfolioItem.id,
+          service_parameters: data
+        },
+        portfolioItem
+      )
     );
     push({
       pathname: closeUrl,

--- a/src/test/redux/actions/order-actions.test.js
+++ b/src/test/redux/actions/order-actions.test.js
@@ -101,7 +101,9 @@ describe('Order actions', () => {
   it('should dispatch correct actions after submitting order', () => {
     const store = mockStore({});
     mockApi.onPost(`${CATALOG_API_BASE}/orders`).reply(200, { id: '123' });
-    mockApi.onPost(`${CATALOG_API_BASE}/orders/123/order_items`).reply(200, {});
+    mockApi
+      .onPost(`${CATALOG_API_BASE}/orders/123/order_items`)
+      .reply(200, { id: 'order-item-id' });
     mockApi.onPost(`${CATALOG_API_BASE}/orders/123/submit_order`).reply(200, {
       id: 'new-order-id'
     });
@@ -124,14 +126,21 @@ describe('Order actions', () => {
 
     return store
       .dispatch(
-        sendSubmitOrder({
-          portfolio_item_id: 'Foo',
-          service_plan_ref: 'Bar',
-          service_parameters: {
-            bax: 'quxx',
-            providerControlParameters: { namespace: 'default' }
+        sendSubmitOrder(
+          {
+            portfolio_item_id: 'Foo',
+            service_plan_ref: 'Bar',
+            service_parameters: {
+              bax: 'quxx',
+              providerControlParameters: { namespace: 'default' }
+            }
+          },
+          {
+            id: 'Foo',
+            portfolio_id: 'portfolio-id',
+            service_offering_source_ref: 'source-id'
           }
-        })
+        )
       )
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);

--- a/src/test/smart-components/common/order-modal.test.js
+++ b/src/test/smart-components/common/order-modal.test.js
@@ -93,11 +93,11 @@ describe('<OrderModal />', () => {
         <OrderWrapper
           store={store}
           initialEntries={[
-            '/portfolios/detail/123/product/321/order?source=source-id&portfolio=123'
+            '/portfolio/portfolio-item/order?source=source-id&portfolio=123&portfolio-item=321'
           ]}
         >
           <Route
-            path="/portfolios/detail/:id/product/:portfolioItemId/order"
+            path="/portfolio/portfolio-item/order"
             render={(args) => <OrderModal {...initialProps} {...args} />}
           />
         </OrderWrapper>
@@ -152,7 +152,7 @@ describe('<OrderModal />', () => {
         <OrderWrapper
           store={store}
           initialEntries={[
-            '/portfolios/detail/123/product/321/order?source=source-id&portfolio=123'
+            '/portfolios/detail/123/product/321/order?source=source-id&portfolio=123&portfolio-item=321'
           ]}
         >
           <Route

--- a/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
@@ -125,7 +125,7 @@ describe('<PortfolioItemDetail />', () => {
   it('should mount and open order modal', async (done) => {
     const store = mockStore(initialState);
     mockApi
-      .onGet(`${CATALOG_API_BASE}/portfolio_items/123/service_plans`)
+      .onGet(`${CATALOG_API_BASE}/portfolio_items/321/service_plans`)
       .replyOnce(200, {});
 
     let wrapper;


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1629?workflowName=Software+Simplified+Workflow+for+Project+HSDM1&stepId=1

user should end on the order detail screen, not on the list of all orders screen

![order-detail-redirect](https://user-images.githubusercontent.com/22619452/84871901-6af60800-b081-11ea-9df1-db33187f07dc.gif)
