### PR TITLE
Add platform detail toolbar loader.

### DIFF
--- a/src/presentational-components/shared/loader-placeholders.js
+++ b/src/presentational-components/shared/loader-placeholders.js
@@ -23,6 +23,7 @@ import {
   Button
 } from '@patternfly/react-core';
 import styled, { keyframes } from 'styled-components';
+import { StyledToolbar } from '../styled-components/toolbars';
 
 const wave = keyframes`
   0% {
@@ -215,3 +216,9 @@ ListLoader.defaultProps = {
 };
 
 export const OrderDetailToolbarPlaceholder = () => <Skeleton height={70} />;
+
+export const PlatformToolbarPlaceholder = () => (
+  <StyledToolbar className="pf-u-pr-lg pf-u-pl-lg pf-u-pb-md pf-u-pt-md">
+    <Skeleton height={36} width={300} />
+  </StyledToolbar>
+);

--- a/src/smart-components/platform/platform.js
+++ b/src/smart-components/platform/platform.js
@@ -16,6 +16,7 @@ import {
 } from '../../constants/routes';
 import ToolbarRenderer from '../../toolbar/toolbar-renderer';
 import { createPlatformsTopToolbarSchema } from '../../toolbar/schemas/platforms-toolbar.schema';
+import { PlatformToolbarPlaceholder } from '../../presentational-components/shared/loader-placeholders';
 
 const PlatformTemplates = lazy(() =>
   import(/* webpackChunkName: "platform-templates" */ './platform-templates')
@@ -89,7 +90,7 @@ const Platform = () => {
           })}
         />
       </Route>
-      <Suspense fallback={<div></div>}>
+      <Suspense fallback={<PlatformToolbarPlaceholder />}>
         <Switch>
           <Route path={PLATFORM_SERVICE_OFFERINGS_ROUTE}>
             <ServiceOfferingDetail />

--- a/src/test/presentational-components/platform/__snapshots__/platform-item.test.js.snap
+++ b/src/test/presentational-components/platform/__snapshots__/platform-item.test.js.snap
@@ -8,10 +8,10 @@ exports[`<PlatformItem /> should render correctly 1`] = `
     key="Foo"
   >
     <Card
-      className="sc-fzozJi dCCegk"
+      className="sc-fzplWN kZIWSH"
     >
       <article
-        className="pf-c-card sc-fzozJi dCCegk"
+        className="pf-c-card sc-fzplWN kZIWSH"
       >
         <CardHeader>
           <div
@@ -29,7 +29,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                     height={40}
                   >
                     <div
-                      className="sc-AxhCb kcBhCv"
+                      className="sc-AxheI eDjZka"
                       height={40}
                     >
                       <IconPlaceholder
@@ -59,7 +59,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                         <t
                           afterLoad={[Function]}
                           beforeLoad={[Function]}
-                          className="sc-AxiKw kPfjgK"
+                          className="sc-AxgMl hkMtbB"
                           delayMethod="throttle"
                           delayTime={0}
                           effect=""
@@ -77,7 +77,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                           <t
                             afterLoad={[Function]}
                             beforeLoad={[Function]}
-                            className="sc-AxiKw kPfjgK"
+                            className="sc-AxgMl hkMtbB"
                             delayMethod="throttle"
                             delayTime={0}
                             height={0}
@@ -86,7 +86,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                             visibleByDefault={false}
                           >
                             <img
-                              className="sc-AxiKw kPfjgK"
+                              className="sc-AxgMl hkMtbB"
                               height={0}
                               hidden={true}
                               onError={[Function]}
@@ -108,10 +108,10 @@ exports[`<PlatformItem /> should render correctly 1`] = `
         >
           <Styled(CardBody)>
             <CardBody
-              className="sc-AxmLO dGjJwL"
+              className="sc-fzpans hEOQak"
             >
               <div
-                className="pf-c-card__body sc-AxmLO dGjJwL"
+                className="pf-c-card__body sc-fzpans hEOQak"
               >
                 <TextContent>
                   <div
@@ -127,7 +127,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                         >
                           <styled.div>
                             <div
-                              className="sc-Axmtr TurKp"
+                              className="sc-fzoLsD VNciv"
                             />
                           </styled.div>
                         </h3>
@@ -147,7 +147,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                     key="card-prop-long_description"
                   >
                     <div
-                      className="sc-AxhUy cLUHxg"
+                      className="sc-Axmtr bQyRiD"
                     />
                   </styled.div>
                 </ItemDetails>

--- a/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
+++ b/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
@@ -17,20 +17,20 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
 >
   <Styled(Component)>
     <Component
-      className="sc-fzoLsD iHpspR"
+      className="sc-fznyAO hahLsc"
     >
       <GalleryItem
-        className="sc-fzoLsD iHpspR"
+        className="sc-fznyAO hahLsc"
       >
         <div
-          className="sc-fzoLsD iHpspR"
+          className="sc-fznyAO hahLsc"
         >
           <Styled(Card)>
             <Card
-              className="sc-fzozJi dCCegk"
+              className="sc-fzplWN kZIWSH"
             >
               <article
-                className="pf-c-card sc-fzozJi dCCegk"
+                className="pf-c-card sc-fzplWN kZIWSH"
               >
                 <CardHeader
                   className="card_header"
@@ -51,7 +51,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                             height={40}
                           >
                             <div
-                              className="sc-AxhCb kcBhCv"
+                              className="sc-AxheI eDjZka"
                               height={40}
                             >
                               <IconPlaceholder
@@ -81,7 +81,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                 <t
                                   afterLoad={[Function]}
                                   beforeLoad={[Function]}
-                                  className="sc-AxiKw kPfjgK"
+                                  className="sc-AxgMl hkMtbB"
                                   delayMethod="throttle"
                                   delayTime={0}
                                   effect=""
@@ -99,7 +99,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                   <t
                                     afterLoad={[Function]}
                                     beforeLoad={[Function]}
-                                    className="sc-AxiKw kPfjgK"
+                                    className="sc-AxgMl hkMtbB"
                                     delayMethod="throttle"
                                     delayTime={0}
                                     height={0}
@@ -108,7 +108,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                     visibleByDefault={false}
                                   >
                                     <img
-                                      className="sc-AxiKw kPfjgK"
+                                      className="sc-AxgMl hkMtbB"
                                       height={0}
                                       hidden={true}
                                       onError={[Function]}
@@ -141,10 +141,10 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                 >
                   <Styled(CardBody)>
                     <CardBody
-                      className="sc-AxmLO dGjJwL"
+                      className="sc-fzpans hEOQak"
                     >
                       <div
-                        className="pf-c-card__body sc-AxmLO dGjJwL"
+                        className="pf-c-card__body sc-fzpans hEOQak"
                       >
                         <TextContent>
                           <div
@@ -162,7 +162,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                 >
                                   <styled.div>
                                     <div
-                                      className="sc-Axmtr TurKp"
+                                      className="sc-fzoLsD VNciv"
                                     >
                                       Foo
                                     </div>
@@ -193,7 +193,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                             key="card-prop-description"
                           >
                             <div
-                              className="sc-AxhUy cLUHxg"
+                              className="sc-Axmtr bQyRiD"
                             >
                               Bar
                             </div>


### PR DESCRIPTION
### Changes
- added small toolbar placeholder when switching between platform templates and inventories
  - removes the ugly popping of the toolbar after the JS chunk is loaded for the first time
  - transition is a bit easier on the eye

![screenshot-ci foo redhat com_1337-2020 06 18-15_49_00](https://user-images.githubusercontent.com/22619452/85028663-a8d75700-b17b-11ea-8231-fd8d590d773c.png)
