### PR TITLE
Fixed missing breadcrumbs separator

### DIFF
--- a/src/smart-components/common/catalog-breadcrumbs.js
+++ b/src/smart-components/common/catalog-breadcrumbs.js
@@ -22,7 +22,10 @@ const CatalogBreadcrumbs = () => {
           key={pathname}
           className="pf-c-breadcrumb__item"
         >
-          <BreadcrumbItem isActive={fragments.length === index + 1}>
+          <BreadcrumbItem
+            showDivider={index > 0}
+            isActive={fragments.length === index + 1}
+          >
             {title}
           </BreadcrumbItem>
         </ConditionalLink>

--- a/src/smart-components/common/catalog-link.js
+++ b/src/smart-components/common/catalog-link.js
@@ -30,6 +30,7 @@ const CatalogLink = ({
   nav,
   preserveSearch,
   preserveHash,
+  showDivider,
   ...props
 }) => {
   const { search, hash } = useLocation();
@@ -49,7 +50,8 @@ CatalogLink.propTypes = {
   }),
   nav: PropTypes.bool,
   preserveSearch: PropTypes.bool,
-  preserveHash: PropTypes.bool
+  preserveHash: PropTypes.bool,
+  showDivider: PropTypes.any // this has to be removed from the spread props. This is PF internal prop which is forced on breadcrumbs child
 };
 
 CatalogLink.defaultProps = {

--- a/src/test/smart-components/common/catalog-breadcrumbs.test.js
+++ b/src/test/smart-components/common/catalog-breadcrumbs.test.js
@@ -50,6 +50,6 @@ describe('<CatalogBreadcrumbs />', () => {
         .find(BreadcrumbItem)
         .last()
         .props()
-    ).toEqual({ children: 'Second', isActive: true });
+    ).toEqual({ children: 'Second', isActive: true, showDivider: true });
   });
 });


### PR DESCRIPTION
After the PF upgrade, custom breadcrumbs child components (which have to be used always in order to enable client-side routing) no longer receive a separator icon.

### Changes
- `showDivider` prop is explicitly set
- `showDivider` prop is no excluded from catalog link, breadcrumbs are forcing this prop to all of its children and we can no longer safely just pass props to the actual link element

### Before
![screenshot-ci cloud redhat com-2020 07 02-12_46_42](https://user-images.githubusercontent.com/22619452/86350277-b9e79400-bc62-11ea-80ce-4964d482af09.png)

### After
![screenshot-ci foo redhat com_1337-2020 07 02-12_46_55](https://user-images.githubusercontent.com/22619452/86350273-b8b66700-bc62-11ea-8244-2248888703ff.png)
