### PR TITLE
Fixed outdated toolbar layout.

### DIFF
--- a/src/presentational-components/styled-components/toolbars.js
+++ b/src/presentational-components/styled-components/toolbars.js
@@ -1,16 +1,23 @@
+import React from 'react';
 import styled from 'styled-components';
-import { Level } from '@patternfly/react-core';
+import { Level, Toolbar, ToolbarGroup } from '@patternfly/react-core';
 
-export const StyledToolbar = styled.div`
-  > *:not(:last-child) {
-    margin-right: var(--pf-global--spacer--md);
-  }
+export const StyledToolbar = styled(({ noWrap, ...props }) => (
+  <Toolbar {...props} />
+))`
   background-color: #ffffff;
   h2 {
     margin-bottom: 0 !important;
   }
   position: relative;
   top: 1px;
+  .pf-c-toolbar__content-section {
+    flex-wrap: ${({ noWrap }) => (noWrap ? 'nowrap' : 'wrap')};
+  }
+`;
+
+export const StyledToolbarGroup = styled(ToolbarGroup)`
+  flex-wrap: wrap;
 `;
 
 export const TopToolbarWrapper = styled.div`

--- a/src/test/presentational-components/platform/__snapshots__/platform-item.test.js.snap
+++ b/src/test/presentational-components/platform/__snapshots__/platform-item.test.js.snap
@@ -8,10 +8,10 @@ exports[`<PlatformItem /> should render correctly 1`] = `
     key="Foo"
   >
     <Card
-      className="sc-fzplWN kZIWSH"
+      className="sc-fznyAO jPogVH"
     >
       <article
-        className="pf-c-card sc-fzplWN kZIWSH"
+        className="pf-c-card sc-fznyAO jPogVH"
       >
         <CardHeader>
           <div
@@ -19,10 +19,10 @@ exports[`<PlatformItem /> should render correctly 1`] = `
           >
             <Styled(Level)>
               <Level
-                className="sc-fznKkj jHfxlR"
+                className="sc-fznZeY dhizEt"
               >
                 <div
-                  className="pf-l-level sc-fznKkj jHfxlR"
+                  className="pf-l-level sc-fznZeY dhizEt"
                 >
                   <CardIcon
                     height={40}
@@ -32,7 +32,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                       height={40}
                     >
                       <div
-                        className="sc-AxheI eDjZka"
+                        className="sc-Axmtr edxmJB"
                         height={40}
                       >
                         <IconPlaceholder
@@ -62,7 +62,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                           <t
                             afterLoad={[Function]}
                             beforeLoad={[Function]}
-                            className="sc-AxgMl hkMtbB"
+                            className="sc-AxheI hyVVbz"
                             delayMethod="throttle"
                             delayTime={0}
                             effect=""
@@ -80,7 +80,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                             <t
                               afterLoad={[Function]}
                               beforeLoad={[Function]}
-                              className="sc-AxgMl hkMtbB"
+                              className="sc-AxheI hyVVbz"
                               delayMethod="throttle"
                               delayTime={0}
                               height={0}
@@ -89,7 +89,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                               visibleByDefault={false}
                             >
                               <img
-                                className="sc-AxgMl hkMtbB"
+                                className="sc-AxheI hyVVbz"
                                 height={0}
                                 hidden={true}
                                 onError={[Function]}
@@ -112,10 +112,10 @@ exports[`<PlatformItem /> should render correctly 1`] = `
         >
           <Styled(CardBody)>
             <CardBody
-              className="sc-fzpans uQIxF"
+              className="sc-fzplWN eHMLLo"
             >
               <div
-                className="pf-c-card__body sc-fzpans uQIxF"
+                className="pf-c-card__body sc-fzplWN eHMLLo"
               >
                 <TextContent>
                   <div
@@ -131,7 +131,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                         >
                           <styled.div>
                             <div
-                              className="sc-fzoLsD VNciv"
+                              className="sc-fzpans olCT"
                             />
                           </styled.div>
                         </h3>
@@ -151,7 +151,7 @@ exports[`<PlatformItem /> should render correctly 1`] = `
                     key="card-prop-long_description"
                   >
                     <div
-                      className="sc-Axmtr bQyRiD"
+                      className="sc-AxmLO dHHURS"
                     />
                   </styled.div>
                 </ItemDetails>

--- a/src/test/presentational-components/portfolio/__snapshots__/portfolios-filter-toolbar.test.js.snap
+++ b/src/test/presentational-components/portfolio/__snapshots__/portfolios-filter-toolbar.test.js.snap
@@ -14,7 +14,30 @@ exports[`<PortfoliosFilterToolbar /> should render correctly with create button 
         "Toolbar": [Function],
         "ToolbarGroup": Object {
           "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "baseHash": 1882630949,
+            "componentId": "sc-AxheI",
+            "isStatic": false,
+            "rules": Array [
+              "
+  flex-wrap: wrap;
+",
+            ],
+            "staticRulesId": "",
+          },
+          "displayName": "Styled(Component)",
+          "foldedComponentIds": Array [],
           "render": [Function],
+          "shouldForwardProp": undefined,
+          "styledComponentId": "sc-AxheI",
+          "target": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
         },
         "ToolbarItem": [Function],
         "TopToolbar": [Function],
@@ -43,25 +66,16 @@ exports[`<PortfoliosFilterToolbar /> should render correctly with create button 
       >
         <Component
           component="ToolbarGroup"
-          key="filter-group/single-toolbar-item-group"
+          key="portfolio-actions-group"
         >
           <Component
-            component="ToolbarItem"
-            key="filter-group/single-toolbar-item"
-          >
-            <Component
-              component="FilterToolbarItem"
-              isClearable={true}
-              key="filter-input"
-              onFilterChange={[MockFunction]}
-              searchValue=""
-            />
-          </Component>
+            component="FilterToolbarItem"
+            isClearable={true}
+            key="filter-input"
+            onFilterChange={[MockFunction]}
+            searchValue=""
+          />
         </Component>
-        <Component
-          component="ToolbarGroup"
-          key="portfolio-button-group/single-toolbar-item-group"
-        />
       </Component>
       <Component
         component="LevelItem"
@@ -86,7 +100,30 @@ exports[`<PortfoliosFilterToolbar /> should render correctly without the create 
         "Toolbar": [Function],
         "ToolbarGroup": Object {
           "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "baseHash": 1882630949,
+            "componentId": "sc-AxheI",
+            "isStatic": false,
+            "rules": Array [
+              "
+  flex-wrap: wrap;
+",
+            ],
+            "staticRulesId": "",
+          },
+          "displayName": "Styled(Component)",
+          "foldedComponentIds": Array [],
           "render": [Function],
+          "shouldForwardProp": undefined,
+          "styledComponentId": "sc-AxheI",
+          "target": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
         },
         "ToolbarItem": [Function],
         "TopToolbar": [Function],
@@ -115,25 +152,16 @@ exports[`<PortfoliosFilterToolbar /> should render correctly without the create 
       >
         <Component
           component="ToolbarGroup"
-          key="filter-group/single-toolbar-item-group"
+          key="portfolio-actions-group"
         >
           <Component
-            component="ToolbarItem"
-            key="filter-group/single-toolbar-item"
-          >
-            <Component
-              component="FilterToolbarItem"
-              isClearable={true}
-              key="filter-input"
-              onFilterChange={[MockFunction]}
-              searchValue=""
-            />
-          </Component>
+            component="FilterToolbarItem"
+            isClearable={true}
+            key="filter-input"
+            onFilterChange={[MockFunction]}
+            searchValue=""
+          />
         </Component>
-        <Component
-          component="ToolbarGroup"
-          key="portfolio-button-group/single-toolbar-item-group"
-        />
       </Component>
       <Component
         component="LevelItem"

--- a/src/test/smart-components/order/__snapshots__/orders.test.js.snap
+++ b/src/test/smart-components/order/__snapshots__/orders.test.js.snap
@@ -14,7 +14,30 @@ exports[`<Orders /> should render correctly 1`] = `
         "Toolbar": [Function],
         "ToolbarGroup": Object {
           "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "baseHash": 1882630949,
+            "componentId": "sc-AxheI",
+            "isStatic": false,
+            "rules": Array [
+              "
+  flex-wrap: wrap;
+",
+            ],
+            "staticRulesId": "",
+          },
+          "displayName": "Styled(Component)",
+          "foldedComponentIds": Array [],
           "render": [Function],
+          "shouldForwardProp": undefined,
+          "styledComponentId": "sc-AxheI",
+          "target": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
         },
         "ToolbarItem": [Function],
         "TopToolbar": [Function],
@@ -59,7 +82,30 @@ exports[`<Orders /> should render correctly in loading state 1`] = `
         "Toolbar": [Function],
         "ToolbarGroup": Object {
           "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "baseHash": 1882630949,
+            "componentId": "sc-AxheI",
+            "isStatic": false,
+            "rules": Array [
+              "
+  flex-wrap: wrap;
+",
+            ],
+            "staticRulesId": "",
+          },
+          "displayName": "Styled(Component)",
+          "foldedComponentIds": Array [],
           "render": [Function],
+          "shouldForwardProp": undefined,
+          "styledComponentId": "sc-AxheI",
+          "target": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "render": [Function],
+          },
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
         },
         "ToolbarItem": [Function],
         "TopToolbar": [Function],

--- a/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
+++ b/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
@@ -17,20 +17,20 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
 >
   <Styled(Component)>
     <Component
-      className="sc-fznyAO hahLsc"
+      className="sc-fznKkj cHdoJl"
     >
       <GalleryItem
-        className="sc-fznyAO hahLsc"
+        className="sc-fznKkj cHdoJl"
       >
         <div
-          className="sc-fznyAO hahLsc"
+          className="sc-fznKkj cHdoJl"
         >
           <Styled(Card)>
             <Card
-              className="sc-fzplWN kZIWSH"
+              className="sc-fznyAO jPogVH"
             >
               <article
-                className="pf-c-card sc-fzplWN kZIWSH"
+                className="pf-c-card sc-fznyAO jPogVH"
               >
                 <CardHeader>
                   <div
@@ -38,10 +38,10 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                   >
                     <Styled(Level)>
                       <Level
-                        className="sc-fznKkj jHfxlR"
+                        className="sc-fznZeY dhizEt"
                       >
                         <div
-                          className="pf-l-level sc-fznKkj jHfxlR"
+                          className="pf-l-level sc-fznZeY dhizEt"
                         >
                           <CardIcon
                             height={40}
@@ -52,7 +52,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                               height={40}
                             >
                               <div
-                                className="sc-AxheI eDjZka"
+                                className="sc-Axmtr edxmJB"
                                 height={40}
                               >
                                 <IconPlaceholder
@@ -82,7 +82,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                   <t
                                     afterLoad={[Function]}
                                     beforeLoad={[Function]}
-                                    className="sc-AxgMl hkMtbB"
+                                    className="sc-AxheI hyVVbz"
                                     delayMethod="throttle"
                                     delayTime={0}
                                     effect=""
@@ -100,7 +100,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                     <t
                                       afterLoad={[Function]}
                                       beforeLoad={[Function]}
-                                      className="sc-AxgMl hkMtbB"
+                                      className="sc-AxheI hyVVbz"
                                       delayMethod="throttle"
                                       delayTime={0}
                                       height={0}
@@ -109,7 +109,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                       visibleByDefault={false}
                                     >
                                       <img
-                                        className="sc-AxgMl hkMtbB"
+                                        className="sc-AxheI hyVVbz"
                                         height={0}
                                         hidden={true}
                                         onError={[Function]}
@@ -143,10 +143,10 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                 >
                   <Styled(CardBody)>
                     <CardBody
-                      className="sc-fzpans uQIxF"
+                      className="sc-fzplWN eHMLLo"
                     >
                       <div
-                        className="pf-c-card__body sc-fzpans uQIxF"
+                        className="pf-c-card__body sc-fzplWN eHMLLo"
                       >
                         <TextContent>
                           <div
@@ -164,7 +164,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                 >
                                   <styled.div>
                                     <div
-                                      className="sc-fzoLsD VNciv"
+                                      className="sc-fzpans olCT"
                                     >
                                       Foo
                                     </div>
@@ -195,7 +195,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                             key="card-prop-description"
                           >
                             <div
-                              className="sc-Axmtr bQyRiD"
+                              className="sc-AxmLO dHHURS"
                             >
                               Bar
                             </div>

--- a/src/toolbar/helpers.js
+++ b/src/toolbar/helpers.js
@@ -1,33 +1,21 @@
 import { toolbarComponentTypes } from './toolbar-mapper';
 
-export const createSingleItemGroup = ({
-  groupName,
-  hidden = false,
-  ...item
-}) => ({
-  component: toolbarComponentTypes.TOOLBAR_GROUP,
-  key: `${groupName}/single-toolbar-item-group`,
-  fields: hidden
-    ? []
-    : [
-        {
-          component: toolbarComponentTypes.TOOLBAR_ITEM,
-          key: `${groupName}/single-toolbar-item`,
-          fields: [item]
-        }
-      ]
-});
-
 export const createLinkButton = ({ pathname, preserveSearch, ...item }) => ({
-  component: toolbarComponentTypes.LINK,
-  pathname,
-  preserveSearch,
+  component: toolbarComponentTypes.TOOLBAR_ITEM,
   key: `${item.key}/button-link`,
-  isDisabled: item.isDisabled,
   fields: [
     {
-      component: toolbarComponentTypes.BUTTON,
-      ...item
+      component: toolbarComponentTypes.LINK,
+      pathname,
+      preserveSearch,
+      key: `${item.key}/button-link`,
+      isDisabled: item.isDisabled,
+      fields: [
+        {
+          component: toolbarComponentTypes.BUTTON,
+          ...item
+        }
+      ]
     }
   ]
 });

--- a/src/toolbar/schemas/add-products-toolbar.schema.js
+++ b/src/toolbar/schemas/add-products-toolbar.schema.js
@@ -1,5 +1,5 @@
 import { toolbarComponentTypes } from '../toolbar-mapper';
-import { createSingleItemGroup, createLinkButton } from '../helpers';
+import { createLinkButton } from '../helpers';
 import FilterSelect from '../../presentational-components/shared/filter-select';
 import ButtonWithSpinner from '../../presentational-components/shared/button-with-spinner';
 import AsyncPagination from '../../smart-components/common/async-pagination';
@@ -59,7 +59,7 @@ const createAddProductsSchema = ({
                     }
                   ]
                 },
-                createSingleItemGroup({
+                {
                   groupName: 'cancel-group-item',
                   ...createLinkButton({
                     key: 'add-products-cancel-button',
@@ -69,21 +69,26 @@ const createAddProductsSchema = ({
                     preserveSearch: true,
                     title: 'Cancel'
                   })
-                }),
-                createSingleItemGroup({
-                  groupName: 'add-group-item',
-                  key: 'portfolio-items-add-group',
-                  component: ButtonWithSpinner,
-                  variant: 'primary',
-                  'aria-label': 'Add products to Portfolio',
-                  title: 'Add',
-                  type: 'button',
-                  onClick: onClickAddToPortfolio,
-                  isDisabled: !itemsSelected || isFetching,
-                  showSpinner: isFetching,
-                  children: 'Add',
-                  id: 'add-products-to-portfolio'
-                })
+                },
+                {
+                  component: toolbarComponentTypes.TOOLBAR_ITEM,
+                  key: 'add-group-item',
+                  fields: [
+                    {
+                      key: 'portfolio-items-add-group',
+                      component: ButtonWithSpinner,
+                      variant: 'primary',
+                      'aria-label': 'Add products to Portfolio',
+                      title: 'Add',
+                      type: 'button',
+                      onClick: onClickAddToPortfolio,
+                      isDisabled: !itemsSelected || isFetching,
+                      showSpinner: isFetching,
+                      children: 'Add',
+                      id: 'add-products-to-portfolio'
+                    }
+                  ]
+                }
               ]
             },
             {

--- a/src/toolbar/schemas/portfolio-toolbar.schema.js
+++ b/src/toolbar/schemas/portfolio-toolbar.schema.js
@@ -8,7 +8,7 @@ import {
 } from '@patternfly/react-core';
 
 import { toolbarComponentTypes } from '../toolbar-mapper';
-import { createSingleItemGroup, createLinkButton } from '../helpers';
+import { createLinkButton } from '../helpers';
 import AsyncPagination from '../../smart-components/common/async-pagination';
 import CatalogLink from '../../smart-components/common/catalog-link';
 
@@ -157,8 +157,9 @@ const createPortfolioToolbarSchema = ({
           description,
           fields: [
             {
-              component: toolbarComponentTypes.LEVEL_ITEM,
+              component: toolbarComponentTypes.TOOLBAR,
               key: 'portfolio-actions',
+              noWrap: true,
               fields: [
                 createLinkButton({
                   pathname: sharePortfolioRoute,
@@ -171,14 +172,20 @@ const createPortfolioToolbarSchema = ({
                   hidden: !share && !unshare
                 }),
                 {
-                  component: PortfolioActionsToolbar,
-                  editPortfolioRoute,
-                  workflowPortfolioRoute,
-                  removePortfolioRoute,
-                  copyPortfolio,
-                  copyInProgress,
-                  userCapabilities,
-                  key: 'portfolio-actions-dropdown'
+                  component: toolbarComponentTypes.TOOLBAR_ITEM,
+                  key: 'portfolio-actions-dropdown-item',
+                  fields: [
+                    {
+                      component: PortfolioActionsToolbar,
+                      editPortfolioRoute,
+                      workflowPortfolioRoute,
+                      removePortfolioRoute,
+                      copyPortfolio,
+                      copyInProgress,
+                      userCapabilities,
+                      key: 'portfolio-actions-dropdown'
+                    }
+                  ]
                 }
               ]
             }
@@ -194,7 +201,7 @@ const createPortfolioToolbarSchema = ({
                   component: toolbarComponentTypes.TOOLBAR,
                   key: 'portfolio-items-actions',
                   fields: [
-                    createSingleItemGroup({
+                    {
                       groupName: 'filter-portfolio-items',
                       component: toolbarComponentTypes.FILTER_TOOLBAR_ITEM,
                       isClearable: true,
@@ -202,8 +209,8 @@ const createPortfolioToolbarSchema = ({
                       searchValue,
                       onFilterChange,
                       placeholder
-                    }),
-                    createSingleItemGroup({
+                    },
+                    {
                       hidden: meta.count === 0 || !userCapabilities.update,
                       groupName: 'add-portfolio-items',
                       key: 'portfolio-items-add-group',
@@ -215,18 +222,24 @@ const createPortfolioToolbarSchema = ({
                         title: 'Add',
                         key: 'add-products-button'
                       })
-                    }),
-                    createSingleItemGroup({
-                      component: toolbarComponentTypes.BUTTON,
+                    },
+                    {
+                      component: toolbarComponentTypes.TOOLBAR_ITEM,
+                      key: 'remove-products-item',
                       hidden: meta.count === 0 || !userCapabilities.update,
-                      groupName: 'remove-portfolio-items',
-                      variant: 'link',
-                      title: 'Remove',
-                      key: 'remove-products-button',
-                      id: 'remove-products-button',
-                      isDisabled: !itemsSelected,
-                      onClick: removeProducts
-                    })
+                      fields: [
+                        {
+                          component: toolbarComponentTypes.BUTTON,
+                          groupName: 'remove-portfolio-items',
+                          variant: 'link',
+                          title: 'Remove',
+                          key: 'remove-products-button',
+                          id: 'remove-products-button',
+                          isDisabled: !itemsSelected,
+                          onClick: removeProducts
+                        }
+                      ]
+                    }
                   ]
                 },
                 {

--- a/src/toolbar/schemas/portfolios-toolbar.schema.js
+++ b/src/toolbar/schemas/portfolios-toolbar.schema.js
@@ -1,5 +1,5 @@
 import { toolbarComponentTypes } from '../toolbar-mapper';
-import { createSingleItemGroup, createLinkButton } from '../helpers';
+import { createLinkButton } from '../helpers';
 import { hasPermission } from '../../helpers/shared/helpers';
 
 import AsyncPagination from '../../smart-components/common/async-pagination';
@@ -31,31 +31,35 @@ const createPortfolioToolbarSchema = ({
                   component: toolbarComponentTypes.TOOLBAR,
                   key: 'main-portfolio-toolbar',
                   fields: [
-                    createSingleItemGroup({
-                      groupName: 'filter-group',
-                      component: toolbarComponentTypes.FILTER_TOOLBAR_ITEM,
-                      key: 'filter-input',
-                      searchValue,
-                      onFilterChange,
-                      placeholder,
-                      isClearable: true
-                    }),
-                    createSingleItemGroup({
-                      hidden:
-                        meta.count === 0 ||
-                        !hasPermission(userPermissions, [
-                          'catalog:portfolios:create'
-                        ]),
-                      groupName: 'portfolio-button-group',
-                      key: 'create-portfolio',
-                      ...createLinkButton({
-                        pathname: '/portfolios/add-portfolio',
-                        variant: 'primary',
-                        key: 'create-portfolio-button',
-                        'aria-label': 'Create portfolio',
-                        title: 'Create'
-                      })
-                    })
+                    {
+                      key: 'portfolio-actions-group',
+                      component: toolbarComponentTypes.TOOLBAR_GROUP,
+                      fields: [
+                        {
+                          component: toolbarComponentTypes.FILTER_TOOLBAR_ITEM,
+                          key: 'filter-input',
+                          searchValue,
+                          onFilterChange,
+                          placeholder,
+                          isClearable: true
+                        },
+                        {
+                          hidden:
+                            meta.count === 0 ||
+                            !hasPermission(userPermissions, [
+                              'catalog:portfolios:create'
+                            ]),
+                          key: 'create-portfolio',
+                          ...createLinkButton({
+                            pathname: '/portfolios/add-portfolio',
+                            variant: 'primary',
+                            key: 'create-portfolio-button',
+                            'aria-label': 'Create portfolio',
+                            title: 'Create'
+                          })
+                        }
+                      ]
+                    }
                   ]
                 },
                 {

--- a/src/toolbar/schemas/products-toolbar.schema.js
+++ b/src/toolbar/schemas/products-toolbar.schema.js
@@ -1,5 +1,4 @@
 import { toolbarComponentTypes } from '../toolbar-mapper';
-import { createSingleItemGroup } from '../helpers';
 
 import AsyncPagination from '../../smart-components/common/async-pagination';
 
@@ -31,7 +30,7 @@ const createPortfolioToolbarSchema = ({
                   component: toolbarComponentTypes.TOOLBAR,
                   key: 'main-portfolio-toolbar',
                   fields: [
-                    createSingleItemGroup({
+                    {
                       groupName: 'filter-group',
                       component: toolbarComponentTypes.FILTER_TOOLBAR_ITEM,
                       key: 'filter-input',
@@ -39,7 +38,7 @@ const createPortfolioToolbarSchema = ({
                       onFilterChange,
                       placeholder,
                       isClearable: true
-                    })
+                    }
                   ]
                 },
                 {

--- a/src/toolbar/toolbar-mapper.js
+++ b/src/toolbar/toolbar-mapper.js
@@ -5,7 +5,7 @@ import {
   Level,
   LevelItem,
   ToolbarItem,
-  ToolbarGroup
+  ToolbarContent
 } from '@patternfly/react-core';
 
 import FilterToolbarItem from '../presentational-components/shared/filter-toolbar-item';
@@ -14,7 +14,10 @@ import TopToolbar, {
 } from '../presentational-components/shared/top-toolbar';
 import AppTabs from '../presentational-components/shared/app-tabs';
 import CatalogLink from '../smart-components/common/catalog-link';
-import { StyledToolbar } from '../presentational-components/styled-components/toolbars';
+import {
+  StyledToolbar,
+  StyledToolbarGroup
+} from '../presentational-components/styled-components/toolbars';
 
 const ToolbarButton = ({ title, ...props }) => (
   <Button {...props}>{title}</Button>
@@ -24,15 +27,25 @@ ToolbarButton.propTypes = {
   title: PropTypes.string.isRequired
 };
 
-const AppToolbar = ({ ...props }) => (
-  <StyledToolbar className="pf-u-pr-lg" {...props} />
+const AppToolbar = ({ children, ...props }) => (
+  <StyledToolbar className={'pf-u-p-0'} {...props}>
+    <ToolbarContent className="pf-u-pl-0">{children}</ToolbarContent>
+  </StyledToolbar>
 );
+
+AppToolbar.propTypes = {
+  noWrap: PropTypes.bool,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node)
+  ])
+};
 
 const toolbarMapper = {
   TopToolbar,
   TopToolbarTitle,
   Toolbar: AppToolbar,
-  ToolbarGroup,
+  ToolbarGroup: StyledToolbarGroup,
   ToolbarItem,
   FilterToolbarItem,
   Link: CatalogLink,


### PR DESCRIPTION
There was an issue with underlying PF toolbar components. [Fix for platform toolbars](https://github.com/RedHatInsights/catalog-ui/pull/645) distorted the rest of the toolbars. Change to the actual DOM is necessary to make it work on all pages.

### Changes
- use new Toolbar component composition
- added wrap property to toolbar component
- added wrap property to toolbar group component (no idea why toolbar group is not wrapped by default)

### Before
![screenshot-ci cloud redhat com-2020 07 08-11_10_06](https://user-images.githubusercontent.com/22619452/86900706-f6583b80-c10b-11ea-8756-3dcca59e50bc.png)

### After
![screenshot-ci foo redhat com_1337-2020 07 08-11_10_28](https://user-images.githubusercontent.com/22619452/86900717-fa845900-c10b-11ea-9700-fcde5f4e373b.png)
