### PR TITLE
Add react intl messages scraper script

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,8 @@
     "plugin:react/recommended"
   ],
   "plugins": [
-    "react"
+    "react",
+    "formatjs"
   ],
   "parserOptions": {
     "ecmaVersion": 7,

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ node_modules
 # production
 dist
 
+#translations
+translations
+
 #test coverage statistics
 cc-test-reporter
 coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1298,6 +1298,26 @@
         "@formatjs/intl-utils": "^2.3.0"
       }
     },
+    "@formatjs/intl-numberformat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.0.2.tgz",
+      "integrity": "sha512-Mok7ZcEkm0ShfIPQLykPMWDDa6zuWiVflp6yfsMF2IorilEZx0dzl7/5x4fhs2XN1fOpss54H9MtlyPpcW1VXw==",
+      "dev": true,
+      "requires": {
+        "@formatjs/intl-utils": "^3.6.0"
+      },
+      "dependencies": {
+        "@formatjs/intl-utils": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.6.0.tgz",
+          "integrity": "sha512-KojfGYH3b0HbyN8H+HRHxEYOctC9tOne8jU1MNw7O+g8QyIPK9y0y1cyXlj6FoLsHRi26u9jR1CJg5XrRfArug==",
+          "dev": true,
+          "requires": {
+            "emojis-list": "^3.0.0"
+          }
+        }
+      }
+    },
     "@formatjs/intl-relativetimeformat": {
       "version": "4.5.16",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.16.tgz",
@@ -2314,6 +2334,22 @@
       "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.2.tgz",
       "integrity": "sha512-MRQEy2LooG621ln0JOQXjcVIZWWY2VkefIxeO1cpO57tCnYAQdmq+b7CMw7pQC6RCc1itfcdwJKdF9/y4cLoZA=="
     },
+    "@types/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-iacbaYN9IWWrGWTwlYLVOeUtN/e4cjN9Uh6v7Yo1Qa/vJzeSQeh10L/erBBSl53BTmbnQ07vsWp8mmNHGI4WbQ==",
+      "dev": true
+    },
+    "@types/eslint": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-6.8.1.tgz",
+      "integrity": "sha512-eutiEpQ4SN7kdF8QVDPyiSSy7ZFM+werJVw6/mRxLGbG4oet6/p81WFjSIcuY9PzM+dsu25Yh5EAUmQ9aJC1gg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -2467,6 +2503,44 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
+      "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
+      }
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -5800,6 +5874,43 @@
         }
       }
     },
+    "eslint-plugin-formatjs": {
+      "version": "2.3.21",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-2.3.21.tgz",
+      "integrity": "sha512-s/sgFXDseHNH0BA3ax2E/z6lAEOJw6PgdK+Kuwn/wYk5MxzvhUXEVdyfNRs3yI01rvyMhJdeqXGfUJjXJ1A8PA==",
+      "dev": true,
+      "requires": {
+        "@types/emoji-regex": "^8.0.0",
+        "@types/eslint": "^6.8.0",
+        "@types/estree": "^0.0.44",
+        "@typescript-eslint/typescript-estree": "^2.29.0",
+        "emoji-regex": "^9.0.0",
+        "intl-messageformat-parser": "^5.2.4"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "0.0.44",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
+          "integrity": "sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
+          "integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==",
+          "dev": true
+        },
+        "intl-messageformat-parser": {
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.2.4.tgz",
+          "integrity": "sha512-vwuG+rYawjr73UFD60x1coJaU0u0cWEHT8s2XhfYqxQv7cJEj7CIZhCZLldzjUO2IKZgWkvOOP6krSfMTJBuRA==",
+          "dev": true,
+          "requires": {
+            "@formatjs/intl-numberformat": "^5.0.2"
+          }
+        }
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
@@ -8302,6 +8413,12 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-finite": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
@@ -8313,6 +8430,15 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-hexadecimal": {
       "version": "1.0.4",
@@ -16129,6 +16255,15 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint": "^6.7.1",
     "eslint-config-prettier": "^6.7.0",
     "eslint-loader": "^3.0.2",
+    "eslint-plugin-formatjs": "^2.3.21",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",
     "file-loader": "^4.3.0",
@@ -108,14 +109,15 @@
     "write-file-webpack-plugin": "^4.5.1"
   },
   "scripts": {
-    "build": "NODE_ENV=production webpack --config config/webpack.config.js --env.prod=true --mode production",
     "analyze": "NODE_ENV=production webpack --config config/webpack.config.js --env.prod=true --env.analyze=true --mode production",
-    "test": "jest --passWithNoTests --runInBand",
+    "build": "NODE_ENV=production webpack --config config/webpack.config.js --env.prod=true --mode production",
+    "extract:messages": "npx @formatjs/cli extract 'src/**/*.{js,jsx}' --out-file ./translations/messages.json",
     "lint": "yarn eslint ./src",
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
     "prod": " NODE_ENV=production webpack-dev-server --config config/webpack.config.js --env.prod=true --mode production",
     "server:ctr": "node src/server/generateServerKey.js",
     "start": "rm -rf ./dist && webpack-dev-server --config config/webpack.config.js --env.prod=false --mode development",
+    "test": "jest --passWithNoTests --runInBand",
     "travis:build": "NODE_ENV=production webpack --config config/webpack.config.js --env.prod=true --mode production",
     "travis:verify": "npm-run-all travis:build lint test",
     "verify": "npm-run-all build lint test"

--- a/src/redux/actions/approval-actions.js
+++ b/src/redux/actions/approval-actions.js
@@ -31,9 +31,8 @@ export const updateWorkflows = (toUnlinkIds, toLinkIds, resourceObject) => (
             <Fragment>
               {toUnlinkIds.length > 0 ? (
                 <FormattedMessage
-                  id="workflows.update_workflows"
-                  defaultMessage={`{count, number} {count, plural, one {approval process was}
-                    other {approval processes were}} unlinked successfully. `}
+                  id="workflows.update_workflows.unlink"
+                  defaultMessage="{count, number} {count, plural, one {approval process was} other {approval processes were}} unlinked successfully."
                   values={{ count: toUnlinkIds.length }}
                 />
               ) : (
@@ -41,9 +40,8 @@ export const updateWorkflows = (toUnlinkIds, toLinkIds, resourceObject) => (
               )}
               {toLinkIds.length > 0 ? (
                 <FormattedMessage
-                  id="workflows.update_workflows"
-                  defaultMessage={`{count, number} {count, plural, one {approval process was}
-                    other {approval processes were}} linked successfully.`}
+                  id="workflows.update_workflows.link"
+                  defaultMessage="{count, number} {count, plural, one {approval process was} other {approval processes were}} linked successfully."
                   values={{ count: toLinkIds.length }}
                 />
               ) : (

--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -266,11 +266,8 @@ export const removeProductsFromPortfolio = (portfolioItems, portfolioName) => (
           dismissable: true,
           description: (
             <FormattedMessage
-              id="portfolio.remove-portfolio-items"
-              defaultMessage={`You have removed {count, number} {count, plural,
-            one {product}
-            other {products}
-          } from the {portfolioName} portfolio. {undo} if this was a mistake.`}
+              id="portfolio.remove.portfolio-items"
+              defaultMessage="You have removed {count, number} {count, plural, one {product} other {products} } from the {portfolioName} portfolio. {undo} if this was a mistake." // eslint-disable-line max-len
               values={{
                 count: portfolioItems.length,
                 portfolioName,

--- a/src/smart-components/order/order-detail/order-detail.js
+++ b/src/smart-components/order/order-detail/order-detail.js
@@ -97,11 +97,12 @@ const OrderDetail = () => {
         isInline
         title={
           <FormattedMessage
-            id={'order-detail-not-found'}
-            defaultMessage={`The ${notFoundObjects.join(
-              ', '
-            )} for this order {count, plural, one {is} other {are}} not available`}
-            values={{ count: notFoundObjects.length }}
+            id="order.detail.not-found"
+            defaultMessage="The {objects} for this order {count, plural, one {is} other {are}} not available"
+            values={{
+              objects: notFoundObjects.join(', '),
+              count: notFoundObjects.length
+            }}
           />
         }
       />


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1652

To create messages json run `npm run extract:messages` or `yarn extract:messages`.

A new file with messages will be created in `./translations/messages.json`. It is ignored from the repository since we don't know how and where to send these for translation.

It looks like something likes this:
```json
[
  {
    "id": "workflows.update_workflows.unlink",
    "defaultMessage": "{count, number} {count, plural, one {approval process was} other {approval processes were}} unlinked successfully."
  },
  {
    "id": "workflows.update_workflows.link",
    "defaultMessage": "{count, number} {count, plural, one {approval process was} other {approval processes were}} linked successfully."
  },
  {
    "id": "portfolio.remove.portfolio-items",
    "defaultMessage": "You have removed {count, number} {count, plural, one {product} other {products} } from the {portfolioName} portfolio. {undo} if this was a mistake."
  },
  {
    "id": "order.detail.not-found",
    "defaultMessage": "The {objects} for this order {count, plural, one {is} other {are}} not available"
  }
]
```

This can then be used to create messages for various locales



