### PR TITLE
Update custom_release.sh to work with 4 branches

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -1,13 +1,31 @@
 #!/usr/bin/env bash
+set -e
+set -x
 
 NODE_ENV=production npm run build
 
-if [ "${TRAVIS_BRANCH}" = "master" ]; then
-    .travis/release.sh "ci-beta"
-    .travis/release.sh "qa-beta"
-elif [ "${TRAVIS_BRANCH}" = "stable" ]; then
-    .travis/release.sh "ci-stable"
-    .travis/release.sh "qa-stable"
-elif [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+if [ "${TRAVIS_BRANCH}" = "master" ]
+then
+    for env in ci qa
+    do
+        echo "PUSHING ${env}-beta"
+        rm -rf ./dist/.git
+        .travis/release.sh "${env}-beta"
+    done
+fi
+
+if [ "${TRAVIS_BRANCH}" = "stable" ]
+then
+    for env in ci qa
+    do
+        echo "PUSHING ${env}-stable"
+        rm -rf ./dist/.git
+        .travis/release.sh "${env}-stable"
+    done
+fi
+
+if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+    echo "PUSHING ${TRAVIS_BRANCH}"
+    rm -rf ./build/.git
     .travis/release.sh "${TRAVIS_BRANCH}"
 fi

--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -4,6 +4,10 @@ NODE_ENV=production npm run build
 
 if [ "${TRAVIS_BRANCH}" = "master" ]; then
     .travis/release.sh "ci-beta"
-elif [[ "${TRAVIS_BRANCH}" = "ci-stable"  || "${TRAVIS_BRANCH}" = "qa-beta" || "${TRAVIS_BRANCH}" = "qa-stable" || "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+    .travis/release.sh "qa-beta"
+elif [ "${TRAVIS_BRANCH}" = "master-stable" ]; then
+    .travis/release.sh "ci-stable"
+    .travis/release.sh "qa-stable"
+elif [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
     .travis/release.sh "${TRAVIS_BRANCH}"
 fi

--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -5,7 +5,7 @@ NODE_ENV=production npm run build
 if [ "${TRAVIS_BRANCH}" = "master" ]; then
     .travis/release.sh "ci-beta"
     .travis/release.sh "qa-beta"
-elif [ "${TRAVIS_BRANCH}" = "master-stable" ]; then
+elif [ "${TRAVIS_BRANCH}" = "stable" ]; then
     .travis/release.sh "ci-stable"
     .travis/release.sh "qa-stable"
 elif [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then


### PR DESCRIPTION
Requires the creation of a new `master-stable` branch in place of ci-stable and qa-stable.

cc @brahmanim 