### PR TITLE
Fixed copy select reset

### DIFF
--- a/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
@@ -114,7 +114,7 @@ const CopyPortfolioItemModal = ({
       variant="small"
     >
       <FormRenderer
-        initialValues={{ portfolio_id: portfolioId, portfolio_item_name: name }}
+        initialValues={{ portfolio_id: portfolioId }}
         schema={copySchema(name, portfolioChange, nameFetching)}
         onSubmit={onSubmit}
         onCancel={() =>


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1665

### Issues
- the select value was resetting when the portfolio item copy name changed
  - the form state management was setting an initial value to the copy name each time the name was changed, that caused a change of form global initial values leading to form re-initialization leading to dressing the form to its initial state and resetting the select value to initial value was always the value of the currently selected portfolio
  - the initial name value was never even used since the value was always set by the select component, or when the form was initially mounted thus re-writing the initial value
- fixed by removing the initial value