### PR TITLE
Order detail cards

### DIFF
--- a/src/messages/orders.messages.js
+++ b/src/messages/orders.messages.js
@@ -5,6 +5,10 @@ const ordersMessages = defineMessages({
     id: 'orders.common.orderedBy',
     defaultMessage: 'Ordered by {owner}'
   },
+  orderedByLabel: {
+    id: 'orders.approval.orderedBy',
+    defaultMessage: 'Ordered by'
+  },
   lastUpdated: {
     id: 'orders.common.lastUpdated',
     defaultMessage: 'Last updated'
@@ -41,7 +45,7 @@ const ordersMessages = defineMessages({
   },
   approvalTitle: {
     id: 'orders.approval.title',
-    defaultMessage: 'Approval request'
+    defaultMessage: 'Summary'
   },
   approvalDetail: {
     id: 'orders.approval.view-detail',
@@ -112,6 +116,22 @@ const ordersMessages = defineMessages({
   backToOrders: {
     id: 'orders.toolbar.backLink',
     defaultMessage: 'Back to orders'
+  },
+  approvalProduct: {
+    id: 'orders.approval.product',
+    defaultMessage: 'Product'
+  },
+  orderDate: {
+    id: 'orders.approval.order-date',
+    defaultMessage: 'Order date'
+  },
+  approvalParameters: {
+    id: 'orders.approval.parameters',
+    defaultMessage: 'Parameters'
+  },
+  activity: {
+    id: 'orders.approval.activity',
+    defaultMessage: 'Activity'
   }
 });
 

--- a/src/messages/states.messages.js
+++ b/src/messages/states.messages.js
@@ -44,6 +44,22 @@ const statesMessages = defineMessages({
   error: {
     id: 'common.states.error',
     defaultMessage: 'Error'
+  },
+  pending: {
+    id: 'common.states.pending',
+    defaultMessage: 'Pending'
+  },
+  skipped: {
+    id: 'common.states.skipped',
+    defaultMessage: 'Skipped'
+  },
+  started: {
+    id: 'common.states.started',
+    defaultMessage: 'Started'
+  },
+  notified: {
+    id: 'common.states.notified',
+    defaultMessage: 'Notified'
   }
 });
 

--- a/src/smart-components/order/order-detail/approval-request.js
+++ b/src/smart-components/order/order-detail/approval-request.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
   Bullseye,
@@ -11,14 +11,33 @@ import {
   TextListVariants,
   TextListItem,
   TextListItemVariants,
-  Title
+  Title,
+  Grid,
+  GridItem,
+  Stack,
+  StackItem,
+  Card,
+  CardBody
 } from '@patternfly/react-core';
+
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  sortable,
+  SortByDirection
+} from '@patternfly/react-table';
+
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/cjs/DateFormat';
 import InfoIcon from '@patternfly/react-icons/dist/js/icons/info-icon';
 import { fetchApprovalRequests } from '../../../redux/actions/order-actions';
 import { useIntl } from 'react-intl';
 import ordersMessages from '../../../messages/orders.messages';
 import statesMessages from '../../../messages/states.messages';
+import labelMessages from '../../../messages/labels.messages';
+import { CheckCircleIcon } from '@patternfly/react-icons';
+
+const rowOrder = ['updated', 'group_name', 'state'];
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -26,7 +45,7 @@ const checkRequest = async (fetchRequests) => {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     const result = await fetchRequests();
-    if (result.data.length > 0) {
+    if (result?.data.length > 0) {
       return 'Finished';
     }
 
@@ -42,15 +61,23 @@ const isEmpty = (approvalRequest) =>
 const ApprovalRequests = () => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
-  const { order, approvalRequest, orderItem } = useSelector(
-    ({ orderReducer: { orderDetail } }) => orderDetail
-  );
+  const [sortBy, setSortBy] = useState({});
+  const {
+    order,
+    approvalRequest = { data: [] },
+    platform,
+    orderItem,
+    portfolio,
+    portfolioItem
+  } = useSelector(({ orderReducer: { orderDetail } }) => orderDetail);
 
   useEffect(() => {
     if (order.state !== 'Failed' && orderItem?.id && isEmpty(approvalRequest)) {
       checkRequest(() => dispatch(fetchApprovalRequests(orderItem.id)));
     }
   }, []);
+
+  const handleSort = (_e, index, direction) => setSortBy({ index, direction });
 
   if (order.state === 'Failed' && isEmpty(approvalRequest)) {
     return (
@@ -69,6 +96,51 @@ const ApprovalRequests = () => {
     );
   }
 
+  const columns = [
+    { title: 'Updated', transforms: [sortable] },
+    { title: 'Name', transforms: [sortable] },
+    'Status'
+  ];
+
+  const rows = approvalRequest.data
+    .map((request) =>
+      rowOrder.map((key) => {
+        if (key === 'state') {
+          return (
+            <Fragment>
+              {request[key] === 'completed' && (
+                <Fragment>
+                  <CheckCircleIcon color="var(--pf-global--success-color--100)" />
+                  &nbsp;
+                </Fragment>
+              )}
+              {formatMessage(statesMessages[request[key]])}
+            </Fragment>
+          );
+        }
+
+        if (key === 'updated') {
+          /**
+           * The fragment here is required other wise the super smart PF table will delete the first React element
+           */
+          return (
+            <Fragment>
+              <DateFormat date={request[key]} type="exact" />
+            </Fragment>
+          );
+        }
+
+        return request[key];
+      })
+    )
+    .sort((a, b) =>
+      a[sortBy.index] < b[sortBy.index]
+        ? -1
+        : a[sortBy.index] < b[sortBy.index]
+        ? 1
+        : 0
+    );
+
   return (
     <TextContent>
       {isEmpty(approvalRequest) ? (
@@ -85,57 +157,108 @@ const ApprovalRequests = () => {
           </Flex>
         </Bullseye>
       ) : (
-        <Fragment>
-          <Text component={TextVariants.h2}>
-            {formatMessage(ordersMessages.approvalTitle)}
-          </Text>
-          {approvalRequest.data.map((request) => (
-            <TextList key={request.id} component={TextListVariants.dl}>
-              <TextListItem component={TextListItemVariants.dt}>
-                <a
-                  href={`${document.baseURI}ansible/catalog/approval/request?request=${request.approval_request_ref}`}
+        <Grid hasGutter>
+          <GridItem md={12} lg={6} xl={4}>
+            <Stack hasGutter>
+              <StackItem>
+                <Card>
+                  <CardBody>
+                    <Text className="pf-u-mb-md" component={TextVariants.h2}>
+                      {formatMessage(ordersMessages.approvalTitle)}
+                    </Text>
+                    <TextList component={TextListVariants.dl}>
+                      <TextListItem component={TextListItemVariants.dt}>
+                        {formatMessage(ordersMessages.approvalProduct)}
+                      </TextListItem>
+                      <TextListItem component={TextListItemVariants.dd}>
+                        {portfolioItem.name}
+                      </TextListItem>
+                      <TextListItem component={TextListItemVariants.dt}>
+                        {formatMessage(ordersMessages.orderID)}
+                      </TextListItem>
+                      <TextListItem component={TextListItemVariants.dd}>
+                        {order.id}
+                      </TextListItem>
+                      <TextListItem component={TextListItemVariants.dt}>
+                        {formatMessage(ordersMessages.orderDate)}
+                      </TextListItem>
+                      <TextListItem component={TextListItemVariants.dd}>
+                        <DateFormat
+                          date={order.created_at}
+                          variant="relative"
+                        />
+                      </TextListItem>
+                      <TextListItem component={TextListItemVariants.dt}>
+                        {formatMessage(ordersMessages.orderedByLabel)}
+                      </TextListItem>
+                      <TextListItem component={TextListItemVariants.dd}>
+                        {order.owner}
+                      </TextListItem>
+                      <TextListItem component={TextListItemVariants.dt}>
+                        {formatMessage(labelMessages.portfolio)}
+                      </TextListItem>
+                      <TextListItem component={TextListItemVariants.dd}>
+                        {portfolio.name}
+                      </TextListItem>
+                      <TextListItem component={TextListItemVariants.dt}>
+                        {formatMessage(labelMessages.platform)}
+                      </TextListItem>
+                      <TextListItem component={TextListItemVariants.dd}>
+                        {platform.name}
+                      </TextListItem>
+                    </TextList>
+                  </CardBody>
+                </Card>
+              </StackItem>
+              <StackItem>
+                <Card>
+                  <CardBody>
+                    <Text className="pf-u-mb-md" component={TextVariants.h2}>
+                      {formatMessage(ordersMessages.approvalParameters)}
+                    </Text>
+                    <TextList component={TextListVariants.dl}>
+                      {Object.entries(orderItem.service_parameters).map(
+                        ([key, value]) => (
+                          <Fragment key={key}>
+                            <TextListItem component={TextListItemVariants.dt}>
+                              {key}
+                            </TextListItem>
+                            <TextListItem component={TextListItemVariants.dd}>
+                              {value}
+                            </TextListItem>
+                          </Fragment>
+                        )
+                      )}
+                    </TextList>
+                  </CardBody>
+                </Card>
+              </StackItem>
+            </Stack>
+          </GridItem>
+          <GridItem md={12} lg={6} xl={8}>
+            <Card>
+              <CardBody>
+                <Text className="pf-u-mb-md" component={TextVariants.h2}>
+                  {formatMessage(ordersMessages.activity)}
+                </Text>
+                <Table
+                  aria-label="Approval request activity"
+                  onSort={handleSort}
+                  sortBy={sortBy}
+                  cells={columns}
+                  rows={
+                    sortBy.direction === SortByDirection.asc
+                      ? rows
+                      : rows.reverse()
+                  }
                 >
-                  {formatMessage(ordersMessages.approvalDetail)}
-                </a>
-              </TextListItem>
-              <TextListItem component={TextListItemVariants.dt}>
-                {formatMessage(ordersMessages.approvalCreated)}
-              </TextListItem>
-              <TextListItem component={TextListItemVariants.dd}>
-                <DateFormat date={order.created_at} variant="relative" />
-              </TextListItem>
-              <TextListItem component={TextListItemVariants.dt}>
-                {formatMessage(statesMessages.title)}
-              </TextListItem>
-              <TextListItem component={TextListItemVariants.dd}>
-                {formatMessage(statesMessages[request.state.toLowerCase()])}
-              </TextListItem>
-              {request.reason && (
-                <Fragment>
-                  <TextListItem component={TextListItemVariants.dt}>
-                    {formatMessage(ordersMessages.approvalReason)}
-                  </TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                    {request.reason}
-                  </TextListItem>
-                </Fragment>
-              )}
-              {request.request_completed_at && (
-                <Fragment>
-                  <TextListItem component={TextListItemVariants.dt}>
-                    {formatMessage(ordersMessages.approvalCompleted)}
-                  </TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                    <DateFormat
-                      date={request.request_completed_at}
-                      variant="relative"
-                    />
-                  </TextListItem>
-                </Fragment>
-              )}
-            </TextList>
-          ))}
-        </Fragment>
+                  <TableHeader />
+                  <TableBody />
+                </Table>
+              </CardBody>
+            </Card>
+          </GridItem>
+        </Grid>
       )}
     </TextContent>
   );

--- a/src/smart-components/order/order-detail/order-detail.js
+++ b/src/smart-components/order/order-detail/order-detail.js
@@ -6,9 +6,7 @@ import {
   Stack,
   StackItem,
   Bullseye,
-  Alert,
-  Card,
-  CardBody
+  Alert
 } from '@patternfly/react-core';
 import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner/Spinner';
 import AngleLeftIcon from '@patternfly/react-icons/dist/js/icons/angle-left-icon';

--- a/src/smart-components/order/order-detail/order-detail.js
+++ b/src/smart-components/order/order-detail/order-detail.js
@@ -158,20 +158,16 @@ const OrderDetail = () => {
               </Bullseye>
             ) : (
               <Suspense fallback={<div></div>}>
-                <Card>
-                  <CardBody>
-                    <Switch>
-                      <Route
-                        path={`${match.url}/approval`}
-                        component={ApprovalRequests}
-                      />
-                      <Route path={`${match.url}/lifecycle`}>
-                        <OrderLifecycle />
-                      </Route>
-                      <Route path={match.url} component={OrderDetails} />
-                    </Switch>
-                  </CardBody>
-                </Card>
+                <Switch>
+                  <Route
+                    path={`${match.url}/approval`}
+                    component={ApprovalRequests}
+                  />
+                  <Route path={`${match.url}/lifecycle`}>
+                    <OrderLifecycle />
+                  </Route>
+                  <Route path={match.url} component={OrderDetails} />
+                </Switch>
               </Suspense>
             )}
           </StackItem>

--- a/src/smart-components/order/order-detail/order-details.js
+++ b/src/smart-components/order/order-detail/order-details.js
@@ -7,7 +7,13 @@ import {
   TextList,
   TextListVariants,
   TextListItem,
-  TextListItemVariants
+  TextListItemVariants,
+  Grid,
+  Card,
+  CardBody,
+  GridItem,
+  Stack,
+  StackItem
 } from '@patternfly/react-core';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/cjs/DateFormat';
 
@@ -28,48 +34,77 @@ const OrderDetails = () => {
   } = useSelector(({ orderReducer: { orderDetail } }) => orderDetail);
 
   return (
-    <TextContent>
-      <Text component={TextVariants.h2}>
-        {formatMessage(ordersMessages.orderDetails)}
-      </Text>
-      <TextList component={TextListVariants.dl}>
-        <TextListItem component={TextListItemVariants.dt}>
-          {formatMessage(ordersMessages.orderID)}
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dd}>
-          {order.id}
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dt}>
-          {formatMessage(statesMessages.ordered)}
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dd}>
-          <DateFormat date={order.created_at} variant="relative" />
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dt}>
-          {formatMessage(labelMessages.portfolio)}
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dd}>
-          {portfolio?.name}
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dt}>
-          {formatMessage(labelMessages.platform)}
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dd}>
-          {platform?.name || undefined}
-        </TextListItem>
-      </TextList>
-      <hr className="pf-c-divider" />
-      <Text component={TextVariants.h2}>
-        {formatMessage(ordersMessages.orderParameters)}
-      </Text>
-      {orderItem?.service_parameters && (
-        <ReactJsonView src={orderItem.service_parameters} />
-      )}
-      <Text component={TextVariants.h2}>
-        {formatMessage(ordersMessages.orderProgressMessages)}
-      </Text>
-      {progressMessages?.data && <ReactJsonView src={progressMessages.data} />}
-    </TextContent>
+    <Grid hasGutter>
+      <GridItem md={12} lg={6} xl={4}>
+        <Stack hasGutter>
+          <StackItem>
+            <Card>
+              <CardBody>
+                <TextContent>
+                  <Text className="pf-u-mb-md" component={TextVariants.h2}>
+                    {formatMessage(ordersMessages.orderDetails)}
+                  </Text>
+                  <TextList component={TextListVariants.dl}>
+                    <TextListItem component={TextListItemVariants.dt}>
+                      {formatMessage(ordersMessages.orderID)}
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>
+                      {order.id}
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dt}>
+                      {formatMessage(statesMessages.ordered)}
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>
+                      <DateFormat date={order.created_at} variant="relative" />
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dt}>
+                      {formatMessage(labelMessages.portfolio)}
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>
+                      {portfolio?.name}
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dt}>
+                      {formatMessage(labelMessages.platform)}
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>
+                      {platform?.name || undefined}
+                    </TextListItem>
+                  </TextList>
+                </TextContent>
+              </CardBody>
+            </Card>
+          </StackItem>
+          <StackItem>
+            <Card>
+              <CardBody>
+                <TextContent>
+                  <Text className="pf-u-mb-md" component={TextVariants.h2}>
+                    {formatMessage(ordersMessages.orderParameters)}
+                  </Text>
+                </TextContent>
+                {orderItem?.service_parameters && (
+                  <ReactJsonView src={orderItem.service_parameters} />
+                )}
+              </CardBody>
+            </Card>
+          </StackItem>
+        </Stack>
+      </GridItem>
+      <GridItem md={12} lg={6} xl={8}>
+        <Card>
+          <CardBody>
+            <TextContent>
+              <Text className="pf-u-mb-md" component={TextVariants.h2}>
+                {formatMessage(ordersMessages.orderProgressMessages)}
+              </Text>
+            </TextContent>
+            {progressMessages?.data && (
+              <ReactJsonView src={progressMessages.data} />
+            )}
+          </CardBody>
+        </Card>
+      </GridItem>
+    </Grid>
   );
 };
 

--- a/src/smart-components/order/order-detail/order-lifecycle.js
+++ b/src/smart-components/order/order-detail/order-lifecycle.js
@@ -7,6 +7,7 @@ import useQuery from '../../../utilities/use-query';
 import { ORDER_ROUTE } from '../../../constants/routes';
 import { useIntl } from 'react-intl';
 import ordersMessages from '../../../messages/orders.messages';
+import { Card, CardBody } from '@patternfly/react-core';
 
 const OrderLifecycle = () => {
   const { formatMessage } = useIntl();
@@ -28,17 +29,19 @@ const OrderLifecycle = () => {
   }
 
   return (
-    <div>
-      <a
-        href={orderItem.external_url}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {formatMessage(ordersMessages.lifecycleLink)}
-        &nbsp;
-        <ExternalLinkAlt />
-      </a>
-    </div>
+    <Card>
+      <CardBody>
+        <a
+          href={orderItem.external_url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {formatMessage(ordersMessages.lifecycleLink)}
+          &nbsp;
+          <ExternalLinkAlt />
+        </a>
+      </CardBody>
+    </Card>
   );
 };
 


### PR DESCRIPTION
wait for #663 
jira: https://projects.engineering.redhat.com/browse/SSP-1673

###Changes
- update the approval tab according to new design
![screenshot-ci foo redhat com_1337-2020 07 20-14_11_50](https://user-images.githubusercontent.com/22619452/87936375-04567680-ca93-11ea-9691-9f6f3e879f17.png)


![screenshot-ci foo redhat com_1337-2020 07 20-14_09_23](https://user-images.githubusercontent.com/22619452/87936215-bd688100-ca92-11ea-81cf-417fcaddeaeb.png)

![screenshot-ci foo redhat com_1337-2020 07 20-14_12_01](https://user-images.githubusercontent.com/22619452/87936368-01f41c80-ca93-11ea-8ebd-5e9bb67eaba6.png)


cc @sbuenafe-rh @fionayhlin

I do have a couple of questions for our UX team.
- I see that the updated date for approval on mocks is using the exact value, but we have been using the relative date everywhere else. So should it bee relative or exact
- There was an icon for the completed request. Do we have icons for the rest of the request states?
- And what about the lifecycle tab? Currently, there is just the link. Are there any changes to that tab?