### PR TITLE
mobile order screen styling fix

### DIFF
--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -170,6 +170,7 @@ section.ins-l-icon-group__with-major .ins-battery:last-of-type {
   padding-left: 15px;
   border-left: 2px solid #eaeaea; 
 }
+
 section.ins-l-icon-group__with-major .ins-battery:last-of-type span.label {
   font-weight: 500;
   margin: 0 10px; 
@@ -178,6 +179,11 @@ section.ins-l-icon-group__with-major .ins-battery:last-of-type span.label {
 .ins-c-primary-toolbar__pagination {
   margin-left: auto;
 }
+
+.ins-c-primary-toolbar .ins-c-primary-toolbar__group-filter {
+  margin-right: 7px;
+}
+
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
This PR adds space between the filter and pagination in the mobile layout

Jira: https://projects.engineering.redhat.com/browse/SSP-1628

Old
![Screen Shot 2020-07-20 at 8 38 24 PM copy](https://user-images.githubusercontent.com/1287144/87999977-6ed6d900-caca-11ea-914d-9b3ec14563db.png)

New
![Screen Shot 2020-07-20 at 8 35 59 PM](https://user-images.githubusercontent.com/1287144/87999496-05a29600-cac9-11ea-9f77-1367bcb930ac.png)
