### PR TITLE
Portfolio card count fix

### DIFF
--- a/src/presentational-components/portfolio/porfolio-card.js
+++ b/src/presentational-components/portfolio/porfolio-card.js
@@ -183,7 +183,8 @@ const PortfolioCard = ({
           <PortfolioCardHeader
             id={id}
             to={to}
-            portfolioName={`${name} (${portfolio_items || 0})`}
+            portfolioName={name}
+            portfolio_items={portfolio_items || 0}
             headerActions={
               <HeaderActions
                 portfolioId={id}

--- a/src/presentational-components/portfolio/portfolio-card-header.js
+++ b/src/presentational-components/portfolio/portfolio-card-header.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import {
+  Badge,
   Level,
   LevelItem,
   Text,
@@ -12,16 +13,23 @@ import EllipsisTextContainer from '../styled-components/ellipsis-text-container'
 import styled from 'styled-components';
 
 const HeaderTitle = styled(LevelItem)`
-  max-width: calc(100% - 44px);
+  max-width: calc(100% - 80px);
+  width: calc(100% - 80px);
 `;
 
 const HeaderLevel = styled(Level)`
   width: 100%;
 `;
 
-const PortfolioCardHeader = ({ id, to, portfolioName, headerActions }) => (
+const PortfolioCardHeader = ({
+  id,
+  to,
+  portfolioName,
+  portfolio_items,
+  headerActions
+}) => (
   <HeaderLevel>
-    <HeaderTitle className="pf-m-grow">
+    <HeaderTitle>
       <TextContent>
         <Link to={to} id={`portfolio-link-${id}`}>
           <Text
@@ -34,14 +42,14 @@ const PortfolioCardHeader = ({ id, to, portfolioName, headerActions }) => (
         </Link>
       </TextContent>
     </HeaderTitle>
-    <LevelItem onClick={(event) => event.preventDefault()}>
-      {headerActions}
-    </LevelItem>
+    <Badge isRead>{portfolio_items}</Badge>
+    <div onClick={(event) => event.preventDefault()}>{headerActions}</div>
   </HeaderLevel>
 );
 
 PortfolioCardHeader.propTypes = {
   portfolioName: PropTypes.string.isRequired,
+  portfolio_items: PropTypes.number,
   headerActions: PropTypes.node,
   id: PropTypes.string,
   to: PropTypes.shape({

--- a/src/test/presentational-components/portfolio/__snapshots__/portfolio-card-header.test.js.snap
+++ b/src/test/presentational-components/portfolio/__snapshots__/portfolio-card-header.test.js.snap
@@ -2,9 +2,7 @@
 
 exports[`<PortfolioCardHeader /> should render correctly 1`] = `
 <Styled(Level)>
-  <Styled(LevelItem)
-    className="pf-m-grow"
-  >
+  <Styled(LevelItem)>
     <TextContent>
       <Link
         id="portfolio-link-undefined"
@@ -27,7 +25,10 @@ exports[`<PortfolioCardHeader /> should render correctly 1`] = `
       </Link>
     </TextContent>
   </Styled(LevelItem)>
-  <LevelItem
+  <Badge
+    isRead={true}
+  />
+  <div
     onClick={[Function]}
   />
 </Styled(Level)>

--- a/src/test/presentational-components/portfolio/__snapshots__/portfolio-card.test.js.snap
+++ b/src/test/presentational-components/portfolio/__snapshots__/portfolio-card.test.js.snap
@@ -22,7 +22,8 @@ exports[`<PortfolioCard /> should render correctly 1`] = `
           />
         }
         id="123"
-        portfolioName="name (0)"
+        portfolioName="name"
+        portfolio_items={0}
         to={
           Object {
             "pathname": "/portfolio",


### PR DESCRIPTION
This PR moves the  Product count out of the card title and into a badge

jira: https://projects.engineering.redhat.com/browse/SSP-1707

Old
<img width="1198" alt="Screen Shot 2020-07-24 at 11 40 29 AM" src="https://user-images.githubusercontent.com/1287144/88409112-80f29900-cda2-11ea-9d11-15212a666df6.png">

New
<img width="1197" alt="Screen Shot 2020-07-24 at 11 39 43 AM" src="https://user-images.githubusercontent.com/1287144/88409156-8cde5b00-cda2-11ea-86d0-e79a00c09394.png">

