### PR TITLE
Set selectedPortfolio when changing portfolio query param

### DIFF
--- a/src/redux/actions/portfolio-actions.js
+++ b/src/redux/actions/portfolio-actions.js
@@ -405,3 +405,18 @@ export const getPortfolioItemDetail = (params) => (dispatch) => {
       })
   );
 };
+
+export const setOrFetchPortfolio = (id, portfolios) => {
+  const existingPorfolio = portfolios?.data?.find(
+    (portfolio) => portfolio.id === id
+  );
+
+  if (existingPorfolio) {
+    return {
+      type: `${ActionTypes.FETCH_PORTFOLIO}_FULFILLED`,
+      payload: existingPorfolio
+    };
+  }
+
+  return fetchSelectedPortfolio(id);
+};

--- a/src/smart-components/dialog-routes/portfolio-routes.js
+++ b/src/smart-components/dialog-routes/portfolio-routes.js
@@ -1,4 +1,4 @@
-import React, { lazy } from 'react';
+import React, { lazy, useEffect } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import {
   ADD_PORTFOLIO_ROUTE,
@@ -17,8 +17,12 @@ import {
 import useInitialUriHash from '../../routing/use-initial-uri-hash';
 import CatalogRoute from '../../routing/catalog-route';
 import useQuery from '../../utilities/use-query';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { PORTFOLIO_RESOURCE_TYPE } from '../../utilities/constants';
+import {
+  setOrFetchPortfolio,
+  resetSelectedPortfolio
+} from '../../redux/actions/portfolio-actions';
 
 const CopyPortfolioItemModal = lazy(() =>
   import(
@@ -55,21 +59,33 @@ const AddPortfolioModal = lazy(() =>
 
 const PortfolioRoutes = () => {
   const viewState = useInitialUriHash();
-  const { portfolioItemId, portfolioItemUserCapabilities } = useSelector(
-    (state) => ({
-      portfolioItemId:
-        state?.portfolioReducer?.portfolioItem?.portfolioItem?.id,
-      portfolioItemUserCapabilities:
-        state?.portfolioReducer?.portfolioItem?.portfolioItem?.metadata
-          ?.user_capabilities
-    })
-  );
+  const {
+    portfolioItemId,
+    portfolioItemUserCapabilities,
+    portfolios,
+    selectedPortfolio
+  } = useSelector((state) => ({
+    portfolioItemId: state?.portfolioReducer?.portfolioItem?.portfolioItem?.id,
+    portfolioItemUserCapabilities:
+      state?.portfolioReducer?.portfolioItem?.portfolioItem?.metadata
+        ?.user_capabilities,
+    portfolios: state?.portfolioReducer?.portfolios,
+    selectedPortfolio: state?.portfolioReducer?.selectedPortfolio
+  }));
   const { portfolioUserCapabilities, itemName } = useSelector((state) => ({
     portfolioUserCapabilities:
       state?.portfolioReducer?.selectedPortfolio?.metadata?.user_capabilities,
     itemName: () => state?.portfolioReducer?.selectedPortfolio?.name
   }));
   const [{ portfolio: id }, search] = useQuery(['portfolio']);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (id && (!selectedPortfolio.id || id !== selectedPortfolio.id)) {
+      dispatch(setOrFetchPortfolio(id, portfolios));
+    }
+  }, [id]);
+
   return (
     <div>
       <Switch>
@@ -105,7 +121,7 @@ const PortfolioRoutes = () => {
           <SharePortfolioModal
             closeUrl={PORTFOLIOS_ROUTE}
             querySelector="portfolio"
-            removeQuery
+            removeSearch
             viewState={viewState?.portfolio}
             portfolioName={itemName}
           />
@@ -122,8 +138,9 @@ const PortfolioRoutes = () => {
             objectType={PORTFOLIO_RESOURCE_TYPE}
             objectName={itemName}
             querySelector="portfolio"
-            removeQuery
+            removeSearch
             keepHash
+            onClose={() => dispatch(resetSelectedPortfolio())}
           />
         </Route>
         <Route exact path={NESTED_WORKFLOW_PORTFOLIO_ROUTE}>

--- a/src/smart-components/dialog-routes/portfolio-routes.js
+++ b/src/smart-components/dialog-routes/portfolio-routes.js
@@ -17,7 +17,7 @@ import {
 import useInitialUriHash from '../../routing/use-initial-uri-hash';
 import CatalogRoute from '../../routing/catalog-route';
 import useQuery from '../../utilities/use-query';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { PORTFOLIO_RESOURCE_TYPE } from '../../utilities/constants';
 import {
   setOrFetchPortfolio,
@@ -59,19 +59,25 @@ const AddPortfolioModal = lazy(() =>
 
 const PortfolioRoutes = () => {
   const viewState = useInitialUriHash();
-  const {
-    portfolioItemId,
-    portfolioItemUserCapabilities,
-    portfolios,
-    selectedPortfolio
-  } = useSelector((state) => ({
-    portfolioItemId: state?.portfolioReducer?.portfolioItem?.portfolioItem?.id,
-    portfolioItemUserCapabilities:
+
+  const portfolioItemId = useSelector(
+    (state) => state?.portfolioReducer?.portfolioItem?.portfolioItem?.id
+  );
+  const portfolioItemUserCapabilities = useSelector(
+    (state) =>
       state?.portfolioReducer?.portfolioItem?.portfolioItem?.metadata
         ?.user_capabilities,
-    portfolios: state?.portfolioReducer?.portfolios,
-    selectedPortfolio: state?.portfolioReducer?.selectedPortfolio
-  }));
+    shallowEqual
+  );
+  const portfolios = useSelector(
+    (state) => state?.portfolioReducer?.portfolios,
+    shallowEqual
+  );
+  const selectedPortfolio = useSelector(
+    (state) => state?.portfolioReducer?.selectedPortfolio,
+    shallowEqual
+  );
+
   const { portfolioUserCapabilities, itemName } = useSelector((state) => ({
     portfolioUserCapabilities:
       state?.portfolioReducer?.selectedPortfolio?.metadata?.user_capabilities,

--- a/src/test/redux/actions/portfolio-actions.test.js
+++ b/src/test/redux/actions/portfolio-actions.test.js
@@ -18,7 +18,8 @@ import {
   RESET_SELECTED_PORTFOLIO,
   DELETE_TEMPORARY_PORTFOLIO,
   RESTORE_PORTFOLIO_PREV_STATE,
-  UPDATE_TEMPORARY_PORTFOLIO
+  UPDATE_TEMPORARY_PORTFOLIO,
+  FETCH_PORTFOLIO
 } from '../../../redux/action-types';
 import {
   fetchPortfolios,
@@ -29,7 +30,8 @@ import {
   removePortfolio,
   removeProductsFromPortfolio,
   undoRemoveProductsFromPortfolio,
-  undoRemovePortfolio
+  undoRemovePortfolio,
+  setOrFetchPortfolio
 } from '../../../redux/actions/portfolio-actions';
 import { CATALOG_API_BASE } from '../../../utilities/constants';
 
@@ -571,5 +573,29 @@ describe('Portfolio actions', () => {
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
+  });
+
+  describe('setOrFetchPortfolio', () => {
+    const id = '123';
+    const fullPorfolios = {
+      data: [{ id: '898' }, { id, customProperty: 'cosi' }]
+    };
+    const emptyPortfolios = {
+      data: [{ id: '898' }]
+    };
+
+    it('should set existing portfolio', () => {
+      expect(setOrFetchPortfolio(id, fullPorfolios)).toEqual({
+        type: `${FETCH_PORTFOLIO}_FULFILLED`,
+        payload: fullPorfolios.data[1]
+      });
+    });
+
+    it('should fetch portfolio', () => {
+      expect(setOrFetchPortfolio(id, emptyPortfolios)).toEqual({
+        type: FETCH_PORTFOLIO,
+        payload: expect.any(Promise)
+      });
+    });
   });
 });

--- a/src/test/smart-components/common/edit-approval-workflow.test.js
+++ b/src/test/smart-components/common/edit-approval-workflow.test.js
@@ -191,6 +191,8 @@ describe('<EditApprovalWorkflow />', () => {
         return [204];
       });
 
+    let onCloseMock = jest.fn();
+
     let wrapper;
     await act(async () => {
       wrapper = mount(
@@ -205,6 +207,7 @@ describe('<EditApprovalWorkflow />', () => {
                 {...args}
                 {...initialProps}
                 querySelector="portfolio"
+                onClose={onCloseMock}
               />
             )}
           />
@@ -234,6 +237,8 @@ describe('<EditApprovalWorkflow />', () => {
         .simulate('click');
     });
 
+    expect(onCloseMock).not.toHaveBeenCalled();
+
     await act(async () => {
       wrapper.find('form').simulate('submit');
     });
@@ -241,6 +246,8 @@ describe('<EditApprovalWorkflow />', () => {
     wrapper.update();
 
     setImmediate(() => {
+      expect(onCloseMock).toHaveBeenCalled();
+
       expect(
         wrapper.find(MemoryRouter).instance().history.location.pathname
       ).toEqual('/foo');

--- a/src/test/smart-components/platform/platform-inventories.test.js
+++ b/src/test/smart-components/platform/platform-inventories.test.js
@@ -44,6 +44,9 @@ describe('<PlatformInventories />', () => {
         ...approvalInitialState,
         resolvedWorkflows: []
       },
+      portfolioReducer: {
+        isLoading: false
+      },
       platformReducer: {
         ...platformInitialState,
         selectedPlatform: {

--- a/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/portfolio-item-details.test.js
@@ -60,7 +60,7 @@ describe('<PortfolioItemDetail />', () => {
       },
       portfolioReducer: {
         selectedPortfolio: {
-          id: '333',
+          id: '123',
           name: 'Portfolio name'
         },
         portfolioItem: {

--- a/src/test/smart-components/portfolio/share-portfolio-modal.test.js
+++ b/src/test/smart-components/portfolio/share-portfolio-modal.test.js
@@ -36,6 +36,7 @@ describe('<SharePortfolioModal/>', () => {
     };
     initialState = {
       portfolioReducer: {
+        isLoading: false,
         selectedPortfolio: {
           id: '2',
           name: 'Portfolio 1',


### PR DESCRIPTION
Fixes https://projects.engineering.redhat.com/browse/SSP-1676

- `share` and `setApproval` modals depend on `selectedPortfolio`, however this value was not filled in the list. So now the `routes` component check if there is `portfolio` query and if no portfolio is selected, it will select it automatically + if the portfolio is not in the store already, it's fetched (i.e. on access via URL).
- `removeQuery` prop does not exist, changed to `removeSearch`

**Before**

![image](https://user-images.githubusercontent.com/32869456/88659872-0db89200-d0d6-11ea-8826-cc0e77dccd26.png)


**After**

![image](https://user-images.githubusercontent.com/32869456/88659805-f11c5a00-d0d5-11ea-8f1f-4f3e9bf082e5.png)
