### PR TITLE
Update edit workflow process modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2007,13 +2007,13 @@
       "integrity": "sha512-q8C98ihcRYBY+FB+KY3bQ9y1Pn/NjBff4hwKsxatrs/MSO/++CuEncg4q7WHjIq2zadA4/7W+Vg3CXuiOP0geg=="
     },
     "@patternfly/react-core": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.32.1.tgz",
-      "integrity": "sha512-4FrKJvMfjHjWtmvGu1QVxo/nCdUgePlkdNzMs91r0wdL16CpfoQVtZcfZe4343fRAQ2ObeYfZ2GuiwvS1sw8Og==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.33.0.tgz",
+      "integrity": "sha512-h+DLRz6v91sC1GQvnm+dRovJE7V+YfzVzVY6cTRUEZEZMov0QQc8mt2/SnO3fK3qCuWG5JJyFjCuTQsixiG90Q==",
       "requires": {
-        "@patternfly/react-icons": "^4.5.0",
-        "@patternfly/react-styles": "^4.5.0",
-        "@patternfly/react-tokens": "^4.6.0",
+        "@patternfly/react-icons": "^4.5.2",
+        "@patternfly/react-styles": "^4.5.1",
+        "@patternfly/react-tokens": "^4.7.1",
         "focus-trap": "4.0.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -2021,19 +2021,19 @@
       },
       "dependencies": {
         "@patternfly/react-icons": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.5.0.tgz",
-          "integrity": "sha512-wXAENYa6nST4D8DBkiCrZXf4aRTmVQNA4cyImMJ3aQWAzwJ7Xc1zIBBuYSX5EP0JOuf9DzWVCrzvgfQz1Fcx8g=="
+          "version": "4.5.2",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.5.2.tgz",
+          "integrity": "sha512-Cwv9v1sCKQMKSLWGDQo+5eM6rBm60fpthe7tYaIVqLkaPqnLQdlRJ7XG3B3/YlXuKzFz02ieGdPfYBLZg/B4zw=="
         },
         "@patternfly/react-styles": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.5.0.tgz",
-          "integrity": "sha512-6w8mvxx/cC+yUzBKlWY8YRnavlWCTLWly1si0skleYPF1t69f3P+jeXNy39kH6+o2vXJR5MeecLrnuMV0XtKvg=="
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.5.1.tgz",
+          "integrity": "sha512-nzHb8S8EOpylZqz+8XFav7HUp9dKKv796798dnibdSeYAOCezwU7+IXDcFRupVNMowCTIGNUSXtTXzh1bxg51A=="
         },
         "@patternfly/react-tokens": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.6.0.tgz",
-          "integrity": "sha512-zpA4AlYqJNJm5aqsarBVjod1gjP9muJ5oWI2ZwGUFiw4YNRn8eY7QKQ1VvNZxqwI+WSXl98jTqJiKuJGF3DEvw=="
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.7.1.tgz",
+          "integrity": "sha512-u0VJGGngzHLVKoPaftPSweBggSH6JIbIJGAYgkSpkngMcj8SFWLw/c8otXt4qMh8Bi3ia+HmC2ELYKzNFidUdg=="
         }
       }
     },
@@ -8740,7 +8740,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@data-driven-forms/form-builder": "0.0.10-rc7",
     "@data-driven-forms/pf4-component-mapper": "^2.8.7",
     "@data-driven-forms/react-form-renderer": "^2.8.7",
-    "@patternfly/react-core": "^4.32.1",
+    "@patternfly/react-core": "^4.32.14",
     "@patternfly/react-table": "^4.12.1",
     "@patternfly/react-icons": "^4.5.0",
     "@redhat-cloud-services/approval-client": "^1.0.64",

--- a/src/forms/edit-workflow_form.schema.js
+++ b/src/forms/edit-workflow_form.schema.js
@@ -1,20 +1,38 @@
 import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
 import asyncFormValidator from '../utilities/async-form-validator';
 
+const resolveNewWorkflowProps = (props, _fieldApi, formOptions) => {
+  const initialWorkflows = formOptions.getState().values['initial-workflows'];
+  return {
+    key: initialWorkflows.length, // used to trigger options re-load and disable options update
+    loadOptions: (...args) =>
+      props.loadOptions(...args).then((data) =>
+        data.map((option) => ({
+          ...option,
+          ...(initialWorkflows.find(({ id }) => id === option.value) // we have to disable options that are already in the chip group
+            ? { isDisabled: true }
+            : {})
+        }))
+      )
+  };
+};
+
 const editWorkflowSchema = (loadWorkflows) => ({
   fields: [
     {
       component: componentTypes.SELECT,
-      name: 'selectedWorkflows',
+      name: 'new-workflows',
       label: '',
       loadOptions: asyncFormValidator(loadWorkflows),
       multi: true,
       isSearchable: true,
-      isClearable: true
+      isClearable: true,
+      resolveProps: resolveNewWorkflowProps
     },
     {
       component: 'initial-chips',
-      name: 'selected-workflows-spy'
+      name: 'initial-workflows',
+      label: 'Current approval processes'
     }
   ]
 });

--- a/src/forms/edit-workflow_form.schema.js
+++ b/src/forms/edit-workflow_form.schema.js
@@ -11,6 +11,10 @@ const editWorkflowSchema = (loadWorkflows) => ({
       multi: true,
       isSearchable: true,
       isClearable: true
+    },
+    {
+      component: 'initial-chips',
+      name: 'selected-workflows-spy'
     }
   ]
 });

--- a/src/forms/form-fields/initial-chips.js
+++ b/src/forms/form-fields/initial-chips.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Chip, ChipGroup } from '@patternfly/react-core';
+import useFieldApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-field-api';
+
+const InitialChips = ({ name }) => {
+  const {
+    input: { value }
+  } = useFieldApi({ name });
+  return (
+    <ChipGroup>
+      {value.map(({ name, id }) => (
+        <Chip key={id}>{name}</Chip>
+      ))}
+    </ChipGroup>
+  );
+};
+
+export default InitialChips;

--- a/src/forms/form-fields/initial-chips.js
+++ b/src/forms/form-fields/initial-chips.js
@@ -1,18 +1,33 @@
 import React from 'react';
-import { Chip, ChipGroup } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+import { Chip, ChipGroup, FormGroup } from '@patternfly/react-core';
 import useFieldApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-field-api';
 
-const InitialChips = ({ name }) => {
+const InitialChips = ({ name, label }) => {
   const {
-    input: { value }
+    input: { value, onChange }
   } = useFieldApi({ name });
+  const handleRemove = (id) => onChange(value.filter((item) => item.id !== id));
+  if (value?.length === 0) {
+    return null;
+  }
+
   return (
-    <ChipGroup>
-      {value.map(({ name, id }) => (
-        <Chip key={id}>{name}</Chip>
-      ))}
-    </ChipGroup>
+    <FormGroup label={label}>
+      <ChipGroup>
+        {value.map(({ name, id }) => (
+          <Chip key={id} onClick={() => handleRemove(id)}>
+            {name}
+          </Chip>
+        ))}
+      </ChipGroup>
+    </FormGroup>
   );
+};
+
+InitialChips.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired
 };
 
 export default InitialChips;

--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -48,8 +48,12 @@ const GlobalStyle = createGlobalStyle`
 /**
 * Update DDF select styles for select component
 */
+.ddorg__pf4-component-mapper__select-toggle.pf-c-select__toggle.pf-m-typeahead {
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
 .ddorg__pf4-component-mapper__select-toggle {
-  min-height: 36px;
+  min-height: 34px;
 }
 
 .filter-select {

--- a/src/smart-components/common/edit-approval-workflow.js
+++ b/src/smart-components/common/edit-approval-workflow.js
@@ -131,7 +131,8 @@ const EditApprovalWorkflow = ({
           <StackItem>
             <FormRenderer
               initialValues={{
-                selectedWorkflows: data ? data.map((wf) => wf.id) : undefined
+                selectedWorkflows: data ? data.map((wf) => wf.id) : undefined,
+                'selected-workflows-spy': data
               }}
               onSubmit={onSubmit}
               onCancel={close}

--- a/src/smart-components/common/edit-approval-workflow.js
+++ b/src/smart-components/common/edit-approval-workflow.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useReducer, useRef } from 'react';
+import difference from 'lodash/difference';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -86,19 +87,25 @@ const EditApprovalWorkflow = ({
     history.push(pushParam);
   };
 
-  const onSubmit = (formData, formApi) => {
-    const initialWorkflows =
-      formApi.getState().initialValues.selectedWorkflows || [];
-    const newWorkflows = formData.selectedWorkflows || [];
-
+  const onSubmit = (formData) => {
     close();
-    const toUnlinkWorkflows = initialWorkflows.filter(
-      (wf) => newWorkflows.findIndex((w) => w === wf) < 0
+    const unlinkArray = data
+      .filter(
+        ({ id }) =>
+          !formData['initial-workflows'].find((workflow) => id === workflow.id)
+      )
+      .map(({ id }) => id);
+    /**
+     * prevent uneccesary unlink and link API calls of the same workflow
+     */
+    const linkDiff = difference(formData['new-workflows'], unlinkArray);
+    const unLinkDiff = difference(unlinkArray, formData['new-workflows']);
+    const toLinkWorkflows = linkDiff.filter(
+      (id) => !data.find((item) => item.id === id)
     );
-    const toLinkWorkflows = newWorkflows.filter(
-      (wf) => initialWorkflows.findIndex((w) => w === wf) < 0
+    const toUnlinkWorkflows = unLinkDiff.filter((id) =>
+      data.find((item) => item.id === id)
     );
-
     if (toUnlinkWorkflows.length > 0 || toLinkWorkflows.length > 0) {
       dispatch(
         updateWorkflows(toUnlinkWorkflows, toLinkWorkflows, {
@@ -130,9 +137,9 @@ const EditApprovalWorkflow = ({
           </StackItem>
           <StackItem>
             <FormRenderer
+              subscription={{ values: true }}
               initialValues={{
-                selectedWorkflows: data ? data.map((wf) => wf.id) : undefined,
-                'selected-workflows-spy': data
+                'initial-workflows': data
               }}
               onSubmit={onSubmit}
               onCancel={close}

--- a/src/smart-components/common/form-renderer.js
+++ b/src/smart-components/common/form-renderer.js
@@ -20,6 +20,7 @@ import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/vali
 import translateSchema from '../../utilities/translate-schema';
 import Select from '@data-driven-forms/pf4-component-mapper/dist/cjs/select';
 import CopyNameDisplay from '../../forms/form-fields/copy-name-display';
+import InitialChips from '../../forms/form-fields/initial-chips';
 
 export const catalogComponentMapper = {
   [componentTypes.TEXT_FIELD]: TextField,
@@ -35,7 +36,8 @@ export const catalogComponentMapper = {
   'share-group-edit': ShareGroupEdit,
   'copy-name-display': CopyNameDisplay,
   'textarea-field': Textarea,
-  'select-field': Pf4SelectWrapper
+  'select-field': Pf4SelectWrapper,
+  'initial-chips': InitialChips
 };
 
 const catalogValidatorMapper = {

--- a/src/test/smart-components/common/edit-approval-workflow.test.js
+++ b/src/test/smart-components/common/edit-approval-workflow.test.js
@@ -106,12 +106,18 @@ describe('<EditApprovalWorkflow />', () => {
       fields: [
         {
           component: componentTypes.SELECT,
-          name: 'selectedWorkflows',
           label: '',
           loadOptions: expect.any(Function),
           multi: true,
           isSearchable: true,
-          isClearable: true
+          isClearable: true,
+          name: 'new-workflows',
+          resolveProps: expect.any(Function)
+        },
+        {
+          component: 'initial-chips',
+          label: 'Current approval processes',
+          name: 'initial-workflows'
         }
       ]
     };

--- a/src/test/smart-components/platform/platform-inventories.test.js
+++ b/src/test/smart-components/platform/platform-inventories.test.js
@@ -42,7 +42,7 @@ describe('<PlatformInventories />', () => {
       breadcrumbsReducer: { fragments: [] },
       approvalReducer: {
         ...approvalInitialState,
-        resolvedWorkflows: []
+        resolvedWorkflows: { data: [], meta: { limit: 50, offset: 0 } }
       },
       portfolioReducer: {
         isLoading: false


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1682

### Changes
- existing approval workflows are now inside a chip group
- existing approval workflows are no longer an initial value of the select
- select options are disabled if the option is present in the chip group
- the submit callback only sends necessary workflow ids
  - if the user unlinks workflow and then picks the same from the select, that id is not passed to the API call.

![processes](https://user-images.githubusercontent.com/22619452/88810478-abcf5980-d1b5-11ea-8095-6cbf655e4ed4.gif)
