### PR TITLE
Copy created messages to states messages

### DIFF
--- a/src/messages/states.messages.js
+++ b/src/messages/states.messages.js
@@ -1,3 +1,5 @@
+import labelMessages from './labels.messages';
+
 const { defineMessages } = require('react-intl');
 
 const statesMessages = defineMessages({
@@ -62,4 +64,8 @@ const statesMessages = defineMessages({
 export const getTranslatableState = (state) =>
   state.replace(/\s/g, '').replace(/^./, (char) => char.toLowerCase());
 
-export default statesMessages;
+/**
+ * We must include the created state so the dynamic data from DB can look for these messages in one place
+ * The created message is shared among other components and is just a state message
+ */
+export default { ...statesMessages, created: labelMessages.created };


### PR DESCRIPTION
Introduced in the advanced filter for portfolios or #690 

jira: https://projects.engineering.redhat.com/browse/SSP-1726

We have to be very careful when moving messages around. This was a dynamically assigned value to the format message API. I think I will create a wrapper around that function to add keys to rich text translation and a fallback so it does not cause runtime crashes if the definition was not found.