### PR TITLE
Custom format messages

### DIFF
--- a/src/forms/form-fields/copy-name-display.js
+++ b/src/forms/form-fields/copy-name-display.js
@@ -2,11 +2,11 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import useFieldApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-field-api';
 import { FormGroup, TextContent, Text } from '@patternfly/react-core';
-import { useIntl } from 'react-intl';
 import labelMessages from '../../messages/labels.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const CopyNameDisplay = ({ label, getName, fieldSpy }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const [name, setName] = useState(formatMessage(labelMessages.loading));
   const {
     input: { value },

--- a/src/forms/form-fields/share-group-edit.js
+++ b/src/forms/form-fields/share-group-edit.js
@@ -15,8 +15,8 @@ import {
 import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
 import { StyledLevelItem } from '../../presentational-components/styled-components/level';
 import styled from 'styled-components';
-import { useIntl } from 'react-intl';
 import portfolioMessages from '../../messages/portfolio.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const StyledText = styled(Text)`
   line-height: 36px !important;
@@ -77,7 +77,7 @@ SharedGroup.propTypes = {
 };
 
 const ShareGroupEdit = ({ name, permissionVerbs }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <FieldArray name={name}>
       {({ fields: { map, remove, length } }) => (

--- a/src/forms/form-fields/share-group-select.js
+++ b/src/forms/form-fields/share-group-select.js
@@ -6,10 +6,10 @@ import { InternalSelect } from '@data-driven-forms/pf4-component-mapper/dist/cjs
 import FieldArray from '@data-driven-forms/react-form-renderer/dist/cjs/field-array';
 
 import asyncFormValidator from '../../utilities/async-form-validator';
-import { useIntl } from 'react-intl';
 import formsMessages from '../../messages/forms.messages';
 import portfolioMessages from '../../messages/portfolio.messages';
 import { StyledLevelItem } from '../../presentational-components/styled-components/level';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const initialState = {
   /**
@@ -47,7 +47,7 @@ export const NewGroupSelect = ({
     shareReducer,
     initialState
   );
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
 
   let tooltipContent;
   if (!group && !permission) {

--- a/src/presentational-components/order/order-notification.js
+++ b/src/presentational-components/order/order-notification.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/cjs/actions';
-import { useIntl } from 'react-intl';
 import { ORDER_ROUTE } from '../../constants/routes';
 import ordersMessages from '../../messages/orders.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const OrderNotification = ({
   id,
@@ -15,7 +15,7 @@ const OrderNotification = ({
   platformId,
   orderItemId
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return formatMessage(ordersMessages.orderSuccess, {
     id,
     // eslint-disable-next-line react/display-name

--- a/src/presentational-components/portfolio/back-to-products.js
+++ b/src/presentational-components/portfolio/back-to-products.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import { useIntl } from 'react-intl';
 import { Button } from '@patternfly/react-core';
 import AngleLeftIcon from '@patternfly/react-icons/dist/js/icons/angle-left-icon';
 
 import portfolioMessages from '../../messages/portfolio.messages';
 import CatalogLink from '../../smart-components/common/catalog-link';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const BackToProducts = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <div className="pf-u-mb-md">
       <AngleLeftIcon className="pf-u-mr-sm" />

--- a/src/presentational-components/portfolio/porfolio-card.js
+++ b/src/presentational-components/portfolio/porfolio-card.js
@@ -29,9 +29,9 @@ import {
   StyledGalleryItem
 } from '../styled-components/styled-gallery';
 import { StyledCardBody } from '../styled-components/card';
-import { useIntl } from 'react-intl';
 import actionMessages from '../../messages/actions.messages';
 import labelMessages from '../../messages/labels.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const TO_DISPLAY = ['description'];
 
@@ -40,7 +40,7 @@ const HeaderActions = ({
   handleCopyPortfolio,
   userCapabilities: { share, copy, unshare, update, destroy, set_approval }
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const [isOpen, setOpen] = useState(false);
   const dropdownItems = [];
   if (share || unshare) {
@@ -171,7 +171,7 @@ const PortfolioCard = ({
   },
   ...props
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const to = {
     pathname: PORTFOLIO_ROUTE,
     search: `?portfolio=${id}`

--- a/src/presentational-components/shared/content-list.js
+++ b/src/presentational-components/shared/content-list.js
@@ -9,11 +9,11 @@ import {
 } from '@patternfly/react-table';
 
 import { ListLoader } from '../../presentational-components/shared/loader-placeholders';
-import { useIntl } from 'react-intl';
 import filteringMessages from '../../messages/filtering.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const NoItems = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <Text component={TextVariants.h1}>
       {formatMessage(filteringMessages.noItems)}

--- a/src/presentational-components/shared/loader-placeholders.js
+++ b/src/presentational-components/shared/loader-placeholders.js
@@ -24,10 +24,10 @@ import {
   Button
 } from '@patternfly/react-core';
 import styled, { keyframes } from 'styled-components';
-import { useIntl } from 'react-intl';
 import { StyledToolbar } from '../styled-components/toolbars';
 import actionMessages from '../../messages/actions.messages';
 import formsMessages from '../../messages/forms.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const wave = keyframes`
   0% {
@@ -163,7 +163,7 @@ IconPlaceholder.defaultProps = {
 const FormItemLoader = () => <Skeleton height={38} className="pf-u-mb-lg" />;
 
 export const ShareLoader = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <Form>
       <TextContent>
@@ -190,7 +190,7 @@ export const ShareLoader = () => {
 };
 
 export const WorkflowLoader = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <Form>
       <FormGroup fieldId="2" label="Select workflow">

--- a/src/presentational-components/shared/pf4-select-wrapper.js
+++ b/src/presentational-components/shared/pf4-select-wrapper.js
@@ -9,7 +9,8 @@ import {
   TextVariants
 } from '@patternfly/react-core';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
-import { useIntl, defineMessage } from 'react-intl';
+import { defineMessage } from 'react-intl';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const createOptions = (options, inputValue, isRequired, optionsMessages) => {
   if (inputValue && isRequired) {
@@ -37,7 +38,7 @@ const Select = ({
   meta,
   ...rest
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const optionsMessages = useRef({
     none: formatMessage(
       defineMessage({

--- a/src/smart-components/common/edit-approval-workflow.js
+++ b/src/smart-components/common/edit-approval-workflow.js
@@ -20,9 +20,10 @@ import { loadWorkflowOptions } from '../../helpers/approval/approval-helper';
 import { WorkflowLoader } from '../../presentational-components/shared/loader-placeholders';
 import useQuery from '../../utilities/use-query';
 import useEnhancedHistory from '../../utilities/use-enhanced-history';
-import { useIntl, defineMessage } from 'react-intl';
+import { defineMessage } from 'react-intl';
 import actionMessages from '../../messages/actions.messages';
 import approvalMessages from '../../messages/approval.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const initialState = {
   isFetching: true
@@ -46,7 +47,7 @@ const EditApprovalWorkflow = ({
   objectName = () => objectType,
   onClose
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const { current: modalTitle } = useRef(
     formatMessage(
       defineMessage({

--- a/src/smart-components/common/form-renderer.js
+++ b/src/smart-components/common/form-renderer.js
@@ -1,6 +1,5 @@
 import React, { memo } from 'react';
 import PropTypes from 'prop-types';
-import { useIntl } from 'react-intl';
 import ReactFormRender from '@data-driven-forms/react-form-renderer/dist/cjs/form-renderer';
 import validatorMapper from '@data-driven-forms/react-form-renderer/dist/cjs/validator-mapper';
 import FormTemplate from '@data-driven-forms/pf4-component-mapper/dist/cjs/form-template';
@@ -21,6 +20,7 @@ import translateSchema from '../../utilities/translate-schema';
 import Select from '@data-driven-forms/pf4-component-mapper/dist/cjs/select';
 import CopyNameDisplay from '../../forms/form-fields/copy-name-display';
 import InitialChips from '../../forms/form-fields/initial-chips';
+import useFormatMessage from '../../utilities/use-format-message';
 
 export const catalogComponentMapper = {
   [componentTypes.TEXT_FIELD]: TextField,
@@ -62,7 +62,7 @@ export const catalogValidatorAlias = {
 };
 
 const FormRenderer = ({ formContainer, templateProps, schema, ...rest }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <div>
       <ReactFormRender

--- a/src/smart-components/content-gallery/content-gallery.js
+++ b/src/smart-components/content-gallery/content-gallery.js
@@ -4,11 +4,11 @@ import { Section } from '@redhat-cloud-services/frontend-components/components/c
 import { Text, TextVariants, Gallery } from '@patternfly/react-core';
 
 import { CardLoader } from '../../presentational-components/shared/loader-placeholders';
-import { useIntl } from 'react-intl';
 import filteringMessages from '../../messages/filtering.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const NoItems = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <div>
       <Text component={TextVariants.h1}>

--- a/src/smart-components/error-pages/common-api-error.js
+++ b/src/smart-components/error-pages/common-api-error.js
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react';
-import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import {
   Bullseye,
@@ -13,13 +12,14 @@ import Exclamation from '@patternfly/react-icons/dist/js/icons/exclamation-icon'
 import CatalogLink from '../common/catalog-link';
 import styled from 'styled-components';
 import apiErrorsMessages from '../../messages/api-errors.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const SourceSpan = styled.span`
   white-space: nowrap;
 `;
 
 const CommonApiError = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const { state, pathname } = useLocation();
   const translations = useRef({
     titles: {

--- a/src/smart-components/order/cancel-order-modal.js
+++ b/src/smart-components/order/cancel-order-modal.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Modal, Title } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { useIntl } from 'react-intl';
 import ordersMessages from '../../messages/orders.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const CancelOrderModal = ({ name, cancelOrder, onClose, isOpen }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <Modal
       isOpen={isOpen}

--- a/src/smart-components/order/order-detail/approval-request.js
+++ b/src/smart-components/order/order-detail/approval-request.js
@@ -31,11 +31,11 @@ import {
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/cjs/DateFormat';
 import InfoIcon from '@patternfly/react-icons/dist/js/icons/info-icon';
 import { fetchApprovalRequests } from '../../../redux/actions/order-actions';
-import { useIntl } from 'react-intl';
 import ordersMessages from '../../../messages/orders.messages';
 import statesMessages from '../../../messages/states.messages';
 import labelMessages from '../../../messages/labels.messages';
 import { CheckCircleIcon } from '@patternfly/react-icons';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const rowOrder = ['updated', 'group_name', 'state'];
 
@@ -59,7 +59,7 @@ const isEmpty = (approvalRequest) =>
   approvalRequest.data.length === 0;
 
 const ApprovalRequests = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const dispatch = useDispatch();
   const [sortBy, setSortBy] = useState({});
   const {

--- a/src/smart-components/order/order-detail/order-detail-information.js
+++ b/src/smart-components/order/order-detail/order-detail-information.js
@@ -7,10 +7,10 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclama
 import CardIcon from '../../../presentational-components/shared/card-icon';
 import { CATALOG_API_BASE } from '../../../utilities/constants';
 import CatalogLink from '../../common/catalog-link';
-import { useIntl } from 'react-intl';
 import statesMessages, {
   getTranslatableState
 } from '../../../messages/states.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const OrderDetailInformation = ({
   portfolioId,
@@ -19,7 +19,7 @@ const OrderDetailInformation = ({
   sourceId,
   state
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <Level className="pf-u-mt-sm" hasGutter>
       <Level hasGutter>

--- a/src/smart-components/order/order-detail/order-detail-menu.js
+++ b/src/smart-components/order/order-detail/order-detail-menu.js
@@ -5,13 +5,13 @@ import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import useEnhancedHistory from '../../../utilities/use-enhanced-history';
 import CatalogLink from '../../common/catalog-link';
-import { useIntl } from 'react-intl';
 import ordersMessages from '../../../messages/orders.messages';
 
 /**
  * Make sure to import correct Tabs styles
  */
 import '@patternfly/react-styles/css/components/Tabs/tabs.css';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const StyledCatalogLink = styled(CatalogLink)`
   color: var(--pf-c-tabs__link--Color);
@@ -45,7 +45,7 @@ const useNavItems = ({ state } = {}, formatMessage) => [
 ];
 
 const OrderDetailMenu = ({ baseUrl, isFetching }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const { push } = useEnhancedHistory();
   const orderDetailData = useSelector(
     ({ orderReducer: { orderDetail } }) => orderDetail || {}

--- a/src/smart-components/order/order-detail/order-detail-title.js
+++ b/src/smart-components/order/order-detail/order-detail-title.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Title } from '@patternfly/react-core';
-import { useIntl } from 'react-intl';
 import ordersMessages from '../../../messages/orders.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const OrderDetailTitle = ({ orderId }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <Title headingLevel="h1" size="3xl">
       {formatMessage(ordersMessages.detailTitle, {

--- a/src/smart-components/order/order-detail/order-detail.js
+++ b/src/smart-components/order/order-detail/order-detail.js
@@ -23,9 +23,9 @@ import useBreadcrumbs from '../../../utilities/use-breadcrumbs';
 import { fetchPlatforms } from '../../../redux/actions/platform-actions';
 import { ORDER_ROUTE } from '../../../constants/routes';
 import UnAvailableAlertContainer from '../../../presentational-components/styled-components/unavailable-alert-container';
-import { useIntl } from 'react-intl';
 import ordersMessages from '../../../messages/orders.messages';
 import CatalogLink from '../../common/catalog-link';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const ApprovalRequests = lazy(() =>
   import(/* webpackChunkName: "approval-request" */ './approval-request')
@@ -45,7 +45,7 @@ const requiredParams = [
 ];
 
 const OrderDetail = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const [isFetching, setIsFetching] = useState(true);
   const [queryValues] = useQuery(requiredParams);
   const orderDetailData = useSelector(

--- a/src/smart-components/order/order-detail/order-details.js
+++ b/src/smart-components/order/order-detail/order-details.js
@@ -18,13 +18,13 @@ import {
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/cjs/DateFormat';
 
 import ReactJsonView from 'react-json-view';
-import { useIntl } from 'react-intl';
 import statesMessages from '../../../messages/states.messages';
 import labelMessages from '../../../messages/labels.messages';
 import ordersMessages from '../../../messages/orders.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const OrderDetails = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const {
     order,
     platform,

--- a/src/smart-components/order/order-detail/order-lifecycle.js
+++ b/src/smart-components/order/order-detail/order-lifecycle.js
@@ -5,12 +5,12 @@ import ExternalLinkAlt from '@patternfly/react-icons/dist/js/icons/external-link
 
 import useQuery from '../../../utilities/use-query';
 import { ORDER_ROUTE } from '../../../constants/routes';
-import { useIntl } from 'react-intl';
 import ordersMessages from '../../../messages/orders.messages';
 import { Card, CardBody } from '@patternfly/react-core';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const OrderLifecycle = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const [, search] = useQuery([]);
   const { url } = useRouteMatch(ORDER_ROUTE);
   const orderDetailData = useSelector(

--- a/src/smart-components/order/order-detail/order-toolbar-actions.js
+++ b/src/smart-components/order/order-detail/order-toolbar-actions.js
@@ -5,15 +5,15 @@ import { useDispatch } from 'react-redux';
 
 import { cancelOrder } from '../../../redux/actions/order-actions';
 import CancelOrderModal from '../cancel-order-modal';
-import { useIntl } from 'react-intl';
 import ordersMessages from '../../../messages/orders.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const CANCELABLE_STATES = ['Approval Pending'];
 
 const canCancel = (state) => CANCELABLE_STATES.includes(state);
 
 const OrderToolbarActions = ({ state, orderId, portfolioItemName }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const dispatch = useDispatch();
   const [cancelModalOpen, setCancelModalOpen] = useState(false);
   return (

--- a/src/smart-components/order/order-item.js
+++ b/src/smart-components/order/order-item.js
@@ -26,11 +26,11 @@ import {
   ORDER_LIFECYCLE_ROUTE
 } from '../../constants/routes';
 import { TableCell } from '../../presentational-components/styled-components/table';
-import { useIntl } from 'react-intl';
 import statesMessages, {
   getTranslatableState
 } from '../../messages/states.messages';
 import ordersMessages from '../../messages/orders.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const routeMapper = {
   'Approval Pending': ORDER_APPROVAL_ROUTE,
@@ -39,7 +39,7 @@ const routeMapper = {
 
 const OrderItem = memo(
   ({ item }) => {
-    const { formatMessage } = useIntl();
+    const formatMessage = useFormatMessage();
     const { orderPlatform, orderPortfolio, orderName } = useSelector(
       ({
         portfolioReducer: {

--- a/src/smart-components/order/orders-list.js
+++ b/src/smart-components/order/orders-list.js
@@ -12,7 +12,6 @@ import {
   EmptyStateSecondaryActions,
   Button
 } from '@patternfly/react-core';
-import { useIntl } from 'react-intl';
 import { Section } from '@redhat-cloud-services/frontend-components/components/cjs/Section';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/components/cjs/PrimaryToolbar';
 import { EmptyTable } from '@redhat-cloud-services/frontend-components/components/cjs/EmptyTable';
@@ -35,6 +34,7 @@ import statesMessages from '../../messages/states.messages';
 import filteringMessages from '../../messages/filtering.messages';
 import ordersMessages from '../../messages/orders.messages';
 import labelMessages from '../../messages/labels.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const debouncedFilter = asyncFormValidator(
   (filters, meta = defaultSettings, dispatch, filteringCallback) => {
@@ -81,7 +81,7 @@ const ordersListState = (state, action) => {
 };
 
 const OrdersList = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const viewState = useInitialUriHash();
   const [
     { isFetching, isFiltering, filterType, filters },

--- a/src/smart-components/platform/platform-inventories.js
+++ b/src/smart-components/platform/platform-inventories.js
@@ -15,9 +15,9 @@ import { createRows } from './platform-table-helpers.js';
 import AsyncPagination from '../common/async-pagination';
 import BottomPaginationContainer from '../../presentational-components/shared/bottom-pagination-container';
 import useQuery from '../../utilities/use-query';
-import { useIntl } from 'react-intl';
 import labelMessages from '../../messages/labels.messages';
 import platformsMessages from '../../messages/platforms.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const initialState = {
   filterValue: '',
@@ -50,7 +50,7 @@ const platformInventoriesState = (state, action) => {
 };
 
 const PlatformInventories = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const { current: columns } = useRef([
     formatMessage(labelMessages.name),
     formatMessage(labelMessages.description),

--- a/src/smart-components/platform/platform-templates.js
+++ b/src/smart-components/platform/platform-templates.js
@@ -15,9 +15,9 @@ import AsyncPagination from '../common/async-pagination';
 import BottomPaginationContainer from '../../presentational-components/shared/bottom-pagination-container';
 import useQuery from '../../utilities/use-query';
 import { PLATFORM_SERVICE_OFFERINGS_ROUTE } from '../../constants/routes';
-import { useIntl } from 'react-intl';
 import filteringMessages from '../../messages/filtering.messages';
 import platformsMessages from '../../messages/platforms.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const initialState = {
   filterValue: '',
@@ -50,7 +50,7 @@ const debouncedFilter = asyncFormValidator(
 );
 
 const PlatformTemplates = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const [{ platform: id }] = useQuery(['platform']);
   const [{ filterValue, isFetching, isFiltering }, stateDispatch] = useReducer(
     platformItemsState,

--- a/src/smart-components/platform/platforms.js
+++ b/src/smart-components/platform/platforms.js
@@ -11,11 +11,11 @@ import PlatformCard from '../../presentational-components/platform/platform-card
 import { createPlatformsToolbarSchema } from '../../toolbar/schemas/platforms-toolbar.schema';
 import ContentGalleryEmptyState from '../../presentational-components/shared/content-gallery-empty-state';
 import UserContext from '../../user-context';
-import { useIntl } from 'react-intl';
 import platformsMessages from '../../messages/platforms.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const Platforms = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const [filterValue, setFilterValue] = useState('');
   const { platforms, isLoading } = useSelector(
     ({ platformReducer: { platforms, isPlatformDataLoading } }) => ({

--- a/src/smart-components/platform/service-offering/service-offering-detail.js
+++ b/src/smart-components/platform/service-offering/service-offering-detail.js
@@ -18,14 +18,14 @@ import { ProductLoaderPlaceholder } from '../../../presentational-components/sha
 import CardIcon from '../../../presentational-components/shared/card-icon';
 import CatalogBreadcrumbs from '../../common/catalog-breadcrumbs';
 import { StyledLevelItem } from '../../../presentational-components/styled-components/level';
-import { useIntl } from 'react-intl';
 import labelMessages from '../../../messages/labels.messages';
 import platformsMessages from '../../../messages/platforms.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const requiredParams = ['service', 'platform'];
 
 const ServiceOfferingDetail = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const [queryValues] = useQuery(requiredParams);
   const [isFetching, setIsFetching] = useState(true);
   const dispatch = useDispatch();

--- a/src/smart-components/portfolio/add-portfolio-modal.js
+++ b/src/smart-components/portfolio/add-portfolio-modal.js
@@ -16,13 +16,13 @@ import SpinnerWrapper from '../../presentational-components/styled-components/sp
 import { UnauthorizedRedirect } from '../error-pages/error-redirects';
 import { PORTFOLIO_ROUTE } from '../../constants/routes';
 import UserContext from '../../user-context';
-import { useIntl } from 'react-intl';
 import actionMessages from '../../messages/actions.messages';
 import portfolioMessages from '../../messages/portfolio.messages';
 import labelMessages from '../../messages/labels.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const AddPortfolioModal = ({ removeQuery, closeTarget, viewState }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const dispatch = useDispatch();
   const [submitting, setSubmitting] = useState(false);
   const [isOpen, setIsOpen] = useState(true);

--- a/src/smart-components/portfolio/add-products-to-portfolio/add-products-gallery.js
+++ b/src/smart-components/portfolio/add-products-to-portfolio/add-products-gallery.js
@@ -4,12 +4,12 @@ import { SearchIcon, FilterIcon } from '@patternfly/react-icons';
 
 import ContentGallery from '../../content-gallery/content-gallery';
 import ContentGalleryEmptyState from '../../../presentational-components/shared/content-gallery-empty-state';
-import { useIntl } from 'react-intl';
 import filteringMessages from '../../../messages/filtering.messages';
 import portfolioMessages from '../../../messages/portfolio.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const EmptyState = ({ platform }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <ContentGalleryEmptyState
       Icon={platform ? SearchIcon : FilterIcon}

--- a/src/smart-components/portfolio/portfolio-empty-state.js
+++ b/src/smart-components/portfolio/portfolio-empty-state.js
@@ -6,9 +6,9 @@ import ContentGalleryEmptyState, {
   EmptyStatePrimaryAction
 } from '../../presentational-components/shared/content-gallery-empty-state';
 import { Button } from '@patternfly/react-core';
-import { useIntl } from 'react-intl';
 import filteringMessages from '../../messages/filtering.messages';
 import portfolioMessages from '../../messages/portfolio.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const PortfolioEmptyState = ({
   url,
@@ -16,7 +16,7 @@ const PortfolioEmptyState = ({
   meta,
   userCapabilities: { update }
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const NoDataAction = () => (
     <EmptyStatePrimaryAction
       url={url}

--- a/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/copy-portfolio-item-modal.js
@@ -14,10 +14,10 @@ import {
 import asyncFormValidator from '../../../utilities/async-form-validator';
 import { listPortfolios } from '../../../helpers/portfolio/portfolio-helper';
 import { PORTFOLIO_ITEM_ROUTE } from '../../../constants/routes';
-import { useIntl } from 'react-intl';
 import actionMessages from '../../../messages/actions.messages';
 import labelMessages from '../../../messages/labels.messages';
 import portfolioMessages from '../../../messages/portfolio.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const loadPortfolios = (name) =>
   listPortfolios({ name }, { limit: 100, offset: 0 }).then(({ data }) =>
@@ -61,7 +61,7 @@ const CopyPortfolioItemModal = ({
   search,
   portfolioName
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const dispatch = useDispatch();
   const { push } = useHistory();
 

--- a/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
@@ -9,9 +9,9 @@ import {
 } from '@patternfly/react-core';
 import ButtonWithSpinner from '../../../presentational-components/shared/button-with-spinner';
 import CatalogLink from '../../common/catalog-link';
-import { useIntl } from 'react-intl';
 import actionMessages from '../../../messages/actions.messages';
 import portfolioMessages from '../../../messages/portfolio.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const DetailToolbarActions = ({
   copyUrl,
@@ -25,7 +25,7 @@ const DetailToolbarActions = ({
   availability,
   userCapabilities: { update, copy, set_approval }
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const dropdownItems = [];
   if (update) {
     dropdownItems.push(

--- a/src/smart-components/portfolio/portfolio-item-detail/icon-upload.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/icon-upload.js
@@ -5,8 +5,8 @@ import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/cjs/actions';
 import styled from 'styled-components';
-import { useIntl } from 'react-intl';
 import portfolioMessages from '../../../messages/portfolio.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const UploadButton = styled.button`
   border: none;
@@ -49,7 +49,7 @@ const ImagePreview = styled.img`
 `;
 
 const IconUpload = ({ uploadIcon, children }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const inputRef = useRef();
   const [image, setImage] = useState();
   const [isUploading, setIsUploading] = useState(false);

--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
@@ -7,8 +7,8 @@ import EditPortfolioItem from './edit-portfolio-item';
 import EditApprovalWorkflow from '../../../smart-components/common/edit-approval-workflow';
 import { PORTFOLIO_ITEM_RESOURCE_TYPE } from '../../../utilities/constants';
 import CatalogRoute from '../../../routing/catalog-route';
-import { useIntl } from 'react-intl';
 import portfolioMessages from '../../../messages/portfolio.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const ItemDetailDescription = ({
   userCapabilities,
@@ -18,7 +18,7 @@ const ItemDetailDescription = ({
   detailPaths,
   uploadIcon
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <Switch>
       <Route path={`${url}/edit-workflow`}>

--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-info-bar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/cjs/DateFormat';
-import { useIntl } from 'react-intl';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const messages = {
   platform: {
@@ -24,7 +24,7 @@ const messages = {
 };
 
 const ItemDetailInfoBar = ({ product, source, portfolio }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <TextContent className="pf-u-mb-md">
       <Text className="font-14">{formatMessage(messages.platform)}</Text>

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
@@ -22,11 +22,11 @@ import TopToolbar, {
 } from '../../../presentational-components/shared/top-toolbar';
 import ButtonWithSpinner from '../../../presentational-components/shared/button-with-spinner';
 import { StyledLevelItem } from '../../../presentational-components/styled-components/level';
-import { useIntl } from 'react-intl';
 import actionMessages from '../../../messages/actions.messages';
 import portfolioMessages from '../../../messages/portfolio.messages';
 import BackToProducts from '../../../presentational-components/portfolio/back-to-products';
 import { PORTFOLIO_ITEM_ROUTE_EDIT } from '../../../constants/routes';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const PortfolioItemIconItem = ({ id, sourceId }) => (
   <CardIcon
@@ -51,7 +51,7 @@ export const PortfolioItemDetailToolbar = ({
   userCapabilities,
   fromProducts
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const { pathname } = useLocation();
   return (
     <TopToolbar
@@ -130,7 +130,7 @@ PortfolioItemDetailToolbar.defaultProps = {
 };
 
 const SurveyEditorDropdown = ({ handleResetSurvey }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const [isOpen, setIsOpen] = useState(false);
   return (
     <Dropdown
@@ -167,7 +167,7 @@ export const SurveyEditingToolbar = ({
   modified,
   handleResetSurvey
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   return (
     <TopToolbar breadcrumbsSpacing={false} breadcrumbs>
       <Level>

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -20,9 +20,9 @@ import {
   PORTFOLIO_ITEM_ROUTE_EDIT
 } from '../../../constants/routes';
 import CatalogRoute from '../../../routing/catalog-route';
-import { useIntl } from 'react-intl';
 import portfolioMessages from '../../../messages/portfolio.messages';
 import BackToProducts from '../../../presentational-components/portfolio/back-to-products';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const SurveyEditor = lazy(() =>
   import(
@@ -38,7 +38,7 @@ const requiredParams = [
 ];
 
 const PortfolioItemDetail = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const [isOpen, setOpen] = useState(false);
   const [isFetching, setIsFetching] = useState(true);
   const dispatch = useDispatch();

--- a/src/smart-components/portfolio/portfolio-items.js
+++ b/src/smart-components/portfolio/portfolio-items.js
@@ -13,8 +13,8 @@ import AsyncPagination from '../common/async-pagination';
 import BottomPaginationContainer from '../../presentational-components/shared/bottom-pagination-container';
 import useQuery from '../../utilities/use-query';
 import { PORTFOLIO_ROUTE } from '../../constants/routes';
-import { useIntl } from 'react-intl';
 import filteringMessages from '../../messages/filtering.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const PortfolioItems = ({
   routes,
@@ -32,7 +32,7 @@ const PortfolioItems = ({
     filterValue
   }
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const { data, meta, name, description, userCapabilities } = useSelector(
     ({
       portfolioReducer: {

--- a/src/smart-components/portfolio/portfolios.js
+++ b/src/smart-components/portfolio/portfolios.js
@@ -22,7 +22,6 @@ import { ADD_PORTFOLIO_ROUTE, PORTFOLIO_ROUTE } from '../../constants/routes';
 import UserContext from '../../user-context';
 import { hasPermission } from '../../helpers/shared/helpers';
 import useInitialUriHash from '../../routing/use-initial-uri-hash';
-import { useIntl } from 'react-intl';
 import filteringMessages from '../../messages/filtering.messages';
 import portfolioMessages from '../../messages/portfolio.messages';
 
@@ -32,6 +31,7 @@ import PortfoliosPrimaryToolbar from './toolbars/portfolios-primary-toolbar';
 import TopToolbar, {
   TopToolbarTitle
 } from '../../presentational-components/shared/top-toolbar';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const debouncedFilter = asyncFormValidator(
   (filters, meta = defaultSettings, dispatch, filteringCallback) => {
@@ -90,7 +90,7 @@ const portfoliosState = (state, action) => {
 };
 
 const Portfolios = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const viewState = useInitialUriHash();
   const isMounted = useIsMounted();
   const [

--- a/src/smart-components/portfolio/remove-portfolio-modal.js
+++ b/src/smart-components/portfolio/remove-portfolio-modal.js
@@ -18,13 +18,13 @@ import { getPortfolioFromState } from '../../helpers/portfolio/portfolio-helper'
 import { PORTFOLIOS_ROUTE } from '../../constants/routes';
 import { UnauthorizedRedirect } from '../error-pages/error-redirects';
 import { defaultSettings } from '../../helpers/shared/pagination';
-import { useIntl } from 'react-intl';
 import portfolioMessages from '../../messages/portfolio.messages';
 import actionMessages from '../../messages/actions.messages';
 import labelMessages from '../../messages/labels.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const RemovePortfolioModal = ({ viewState }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const [{ portfolio: portfolioId }] = useQuery(['portfolio']);
   const dispatch = useDispatch();
   const portfolio = useSelector(({ portfolioReducer }) =>

--- a/src/smart-components/portfolio/share-portfolio-modal.js
+++ b/src/smart-components/portfolio/share-portfolio-modal.js
@@ -26,10 +26,10 @@ import { fetchFilterGroups } from '../../helpers/rbac/rbac-helper';
 import useQuery from '../../utilities/use-query';
 import useEnhancedHistory from '../../utilities/use-enhanced-history';
 import { UnauthorizedRedirect } from '../error-pages/error-redirects';
-import { useIntl } from 'react-intl';
 import portfolioMessages from '../../messages/portfolio.messages';
 import { ADD_NOTIFICATION } from '@redhat-cloud-services/frontend-components-notifications/cjs/actionTypes';
 import filteringMessages from '../../messages/filtering.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const SharePortfolioModal = ({
   closeUrl,
@@ -37,7 +37,7 @@ const SharePortfolioModal = ({
   viewState,
   portfolioName = () => ''
 }) => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const dispatch = useDispatch();
   const { push } = useEnhancedHistory({ removeSearch, keepHash: true });
   const [{ portfolio }, search] = useQuery(['portfolio']);

--- a/src/smart-components/portfolio/toolbars/portfolios-primary-toolbar.js
+++ b/src/smart-components/portfolio/toolbars/portfolios-primary-toolbar.js
@@ -6,8 +6,8 @@ import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/compo
 import AsyncPagination from '../../common/async-pagination';
 import CatalogLink from '../../common/catalog-link';
 import { Button } from '@patternfly/react-core';
-import { useIntl } from 'react-intl';
 import labelMessages from '../../../messages/labels.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
 
 const chipCategories = {
   name: labelMessages.name,
@@ -37,7 +37,7 @@ const PortfoliosPrimaryToolbar = ({
   isFiltering
 }) => {
   const dispatch = useDispatch();
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   if (meta.noData) {
     return null;
   }

--- a/src/smart-components/products/products.js
+++ b/src/smart-components/products/products.js
@@ -24,10 +24,10 @@ import { PORTFOLIO_ITEM_ROUTE } from '../../constants/routes';
 import BottomPaginationContainer from '../../presentational-components/shared/bottom-pagination-container';
 import useInitialUriHash from '../../routing/use-initial-uri-hash';
 import UserContext from '../../user-context';
-import { useIntl } from 'react-intl';
 import filteringMessages from '../../messages/filtering.messages';
 import productsMessages from '../../messages/products.messages';
 import platformsMessages from '../../messages/platforms.messages';
+import useFormatMessage from '../../utilities/use-format-message';
 
 const debouncedFilter = asyncFormValidator(
   (value, dispatch, filteringCallback) => {
@@ -76,7 +76,7 @@ const productsState = (state, action) => {
 };
 
 const Products = () => {
-  const { formatMessage } = useIntl();
+  const formatMessage = useFormatMessage();
   const viewState = useInitialUriHash();
   const { release } = useContext(AppContext);
   const [{ isFetching, filterValue, isFiltering }, stateDispatch] = useReducer(

--- a/src/test/utilities/__snapshots__/use-format-message.test.js.snap
+++ b/src/test/utilities/__snapshots__/use-format-message.test.js.snap
@@ -1,0 +1,188 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useFormatMessage should assign values to message properly 1`] = `
+<MessageDummy
+  definedMessage={
+    Object {
+      "defaultMessage": "Foo {foo} bar {bar}",
+      "id": "foo",
+    }
+  }
+  messageValues={
+    Object {
+      "bar": "bar value",
+      "foo": "foo value",
+    }
+  }
+>
+  <IntlProvider
+    defaultFormats={Object {}}
+    defaultLocale="en"
+    formats={Object {}}
+    locale="en"
+    messages={Object {}}
+    onError={[Function]}
+    textComponent={Symbol(react.fragment)}
+  >
+    <HookedComponent
+      definedMessage={
+        Object {
+          "defaultMessage": "Foo {foo} bar {bar}",
+          "id": "foo",
+        }
+      }
+      messageValues={
+        Object {
+          "bar": "bar value",
+          "foo": "foo value",
+        }
+      }
+    >
+      <span>
+        Foo foo value bar bar value
+      </span>
+    </HookedComponent>
+  </IntlProvider>
+</MessageDummy>
+`;
+
+exports[`useFormatMessage should return fallback message if the message is not defined properly 1`] = `
+<MessageDummy
+  definedMessage={
+    Object {
+      "defaultMessage": "Foo",
+    }
+  }
+>
+  <IntlProvider
+    defaultFormats={Object {}}
+    defaultLocale="en"
+    formats={Object {}}
+    locale="en"
+    messages={Object {}}
+    onError={[Function]}
+    textComponent={Symbol(react.fragment)}
+  >
+    <HookedComponent
+      definedMessage={
+        Object {
+          "defaultMessage": "Foo",
+        }
+      }
+    >
+      <span>
+        Unable to translate message. Definition: [object Object], values: [object Object], intl-error: Error: [React Intl] An \`id\` must be provided to format a message.
+      </span>
+    </HookedComponent>
+  </IntlProvider>
+</MessageDummy>
+`;
+
+exports[`useFormatMessage should return fallback message if the message is not defined properly 2`] = `
+<MessageDummy
+  definedMessage="nonsense"
+>
+  <IntlProvider
+    defaultFormats={Object {}}
+    defaultLocale="en"
+    formats={Object {}}
+    locale="en"
+    messages={Object {}}
+    onError={[Function]}
+    textComponent={Symbol(react.fragment)}
+  >
+    <HookedComponent
+      definedMessage="nonsense"
+    >
+      <span>
+        Unable to translate message. Definition: nonsense, values: [object Object], intl-error: Error: [React Intl] An \`id\` must be provided to format a message.
+      </span>
+    </HookedComponent>
+  </IntlProvider>
+</MessageDummy>
+`;
+
+exports[`useFormatMessage should return translated simple message 1`] = `
+<MessageDummy
+  definedMessage={
+    Object {
+      "defaultMessage": "Foo",
+      "id": "foo",
+    }
+  }
+>
+  <IntlProvider
+    defaultFormats={Object {}}
+    defaultLocale="en"
+    formats={Object {}}
+    locale="en"
+    messages={Object {}}
+    onError={[Function]}
+    textComponent={Symbol(react.fragment)}
+  >
+    <HookedComponent
+      definedMessage={
+        Object {
+          "defaultMessage": "Foo",
+          "id": "foo",
+        }
+      }
+    >
+      <span>
+        Foo
+      </span>
+    </HookedComponent>
+  </IntlProvider>
+</MessageDummy>
+`;
+
+exports[`useFormatMessage should wrap rich text value to fragment to prevent missing key error 1`] = `
+<MessageDummy
+  definedMessage={
+    Object {
+      "defaultMessage": "Foo {foo} bar <b>{bar}</b>",
+      "id": "foo",
+    }
+  }
+  messageValues={
+    Object {
+      "b": [Function],
+      "bar": "bar value",
+      "foo": "foo value",
+    }
+  }
+>
+  <IntlProvider
+    defaultFormats={Object {}}
+    defaultLocale="en"
+    formats={Object {}}
+    locale="en"
+    messages={Object {}}
+    onError={[Function]}
+    textComponent={Symbol(react.fragment)}
+  >
+    <HookedComponent
+      definedMessage={
+        Object {
+          "defaultMessage": "Foo {foo} bar <b>{bar}</b>",
+          "id": "foo",
+        }
+      }
+      messageValues={
+        Object {
+          "b": [Function],
+          "bar": "bar value",
+          "foo": "foo value",
+        }
+      }
+    >
+      <span>
+        Foo foo value bar 
+        <b>
+          bar value
+        </b>
+      </span>
+    </HookedComponent>
+  </IntlProvider>
+</MessageDummy>
+`;

--- a/src/test/utilities/use-format-message.test.js
+++ b/src/test/utilities/use-format-message.test.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { mountToJson } from 'enzyme-to-json';
+
+const { IntlProvider, defineMessage } = require('react-intl');
+const {
+  default: useFormatMessage
+} = require('../../utilities/use-format-message');
+
+describe('useFormatMessage', () => {
+  const HookedComponent = ({ definedMessage, messageValues }) => {
+    const formatMessage = useFormatMessage();
+    return <span>{formatMessage(definedMessage, messageValues)}</span>;
+  };
+
+  const MessageDummy = ({ definedMessage, messageValues }) => (
+    <IntlProvider locale="en">
+      <HookedComponent
+        messageValues={messageValues}
+        definedMessage={definedMessage}
+      />
+    </IntlProvider>
+  );
+
+  it('should return translated simple message', () => {
+    const message = defineMessage({ id: 'foo', defaultMessage: 'Foo' });
+    const wrapper = mount(<MessageDummy definedMessage={message} />);
+    expect(mountToJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should return fallback message if the message is not defined properly', () => {
+    let message = defineMessage({ defaultMessage: 'Foo' });
+    let wrapper = mount(<MessageDummy definedMessage={message} />);
+    expect(mountToJson(wrapper)).toMatchSnapshot();
+
+    message = defineMessage('nonsense');
+    wrapper = mount(<MessageDummy definedMessage={message} />);
+    expect(mountToJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should assign values to message properly', () => {
+    const message = defineMessage({
+      id: 'foo',
+      defaultMessage: 'Foo {foo} bar {bar}'
+    });
+    const wrapper = mount(
+      <MessageDummy
+        definedMessage={message}
+        messageValues={{ foo: 'foo value', bar: 'bar value' }}
+      />
+    );
+    expect(mountToJson(wrapper)).toMatchSnapshot();
+  });
+
+  /**
+   * Fragment is not visible in snapshot, but it does not throw that missing key error in the console.
+   * Can do really spy on console.error since that can return false negative due to other tests
+   */
+  it('should wrap rich text value to fragment to prevent missing key error', () => {
+    const message = defineMessage({
+      id: 'foo',
+      defaultMessage: 'Foo {foo} bar <b>{bar}</b>'
+    });
+    const wrapper = mount(
+      <MessageDummy
+        definedMessage={message}
+        messageValues={{
+          foo: 'foo value',
+          bar: 'bar value',
+          b: (chunks) => <b>{chunks}</b>
+        }}
+      />
+    );
+    expect(mountToJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/utilities/use-format-message.js
+++ b/src/utilities/use-format-message.js
@@ -1,12 +1,24 @@
+import React, { Fragment } from 'react';
 const { useIntl } = require('react-intl');
 
 const useFormatMessage = () => {
   const { formatMessage } = useIntl();
-  return (message, values) => {
+  return (message, values = {}) => {
+    const internalValues = Object.entries(values).reduce(
+      (acc, [key, value]) => {
+        return {
+          ...acc,
+          [key]:
+            typeof value === 'function'
+              ? (chunks) => <Fragment key={key}>{value(chunks)}</Fragment>
+              : value
+        };
+      },
+      {}
+    );
     try {
-      return formatMessage(message, values);
+      return formatMessage(message, internalValues);
     } catch (error) {
-      console.error(error);
       return `Unable to translate message. Definition: ${message}, values: ${values}, intl-error: ${error}`;
     }
   };

--- a/src/utilities/use-format-message.js
+++ b/src/utilities/use-format-message.js
@@ -1,0 +1,15 @@
+const { useIntl } = require('react-intl');
+
+const useFormatMessage = () => {
+  const { formatMessage } = useIntl();
+  return (message, values) => {
+    try {
+      return formatMessage(message, values);
+    } catch (error) {
+      console.error(error);
+      return `Unable to translate message. Definition: ${message}, values: ${values}, intl-error: ${error}`;
+    }
+  };
+};
+
+export default useFormatMessage;


### PR DESCRIPTION
### Changes
- replace `formatMessage` with custom `useFormatMessage` hook
  - uses react int formater obviously, but it changes the params to fix some of its issues.
  - adds a fallback message to prevent runtime crashes for undefined or incorrectly defined messages
  - fixes missing key react error in rich text messages by adding a Fragment wrapper

(most of the changes in this PR are just import changes)