### PR TITLE
Fix runtime error after deleting portfolio from detail.

### DIFF
--- a/src/test/utilities/empty-data-middleware.test.js
+++ b/src/test/utilities/empty-data-middleware.test.js
@@ -1,0 +1,126 @@
+import emptyDataMiddleware from '../../utilities/empty-data-middleware';
+
+describe('emptyDataMiddleware', () => {
+  let middleware = emptyDataMiddleware();
+  it('should not change pending input action', () => {
+    const dispatch = jest.fn();
+    const action = { type: 'FOO_PENDING' };
+    middleware(dispatch)(action);
+    expect(dispatch).toHaveBeenCalledWith({ ...action });
+  });
+
+  it('should not changed fulfilled action witouth required meta data', () => {
+    const dispatch = jest.fn();
+    const action = { type: 'FOO_FULFILLED' };
+    middleware(dispatch)(action);
+    expect(dispatch).toHaveBeenCalledWith({ ...action });
+  });
+
+  it('should add notData = false to non empty action', () => {
+    const dispatch = jest.fn();
+    const action = {
+      type: 'FOO_FULFILLED',
+      payload: { data: ['1'], meta: { count: 1 } },
+      meta: {}
+    };
+    const expectedAction = {
+      ...action,
+      payload: {
+        ...action.payload,
+        meta: { count: 1, noData: false }
+      }
+    };
+    middleware(dispatch)(action);
+    expect(dispatch).toHaveBeenCalledWith(expectedAction);
+  });
+
+  it('should add notData = false to empty action but with filter', () => {
+    const dispatch = jest.fn();
+    const action = {
+      type: 'FOO_FULFILLED',
+      payload: { data: [], meta: { count: 0 } },
+      meta: { filter: 'foo' }
+    };
+    const expectedAction = {
+      ...action,
+      payload: {
+        ...action.payload,
+        meta: { count: 0, noData: false }
+      }
+    };
+    middleware(dispatch)(action);
+    expect(dispatch).toHaveBeenCalledWith(expectedAction);
+  });
+
+  it('should add notData = false to empty action with composite filter', () => {
+    const dispatch = jest.fn();
+    const action = {
+      type: 'FOO_FULFILLED',
+      payload: { data: [], meta: { count: 0 } },
+      meta: { filters: { foo: 'bar' } }
+    };
+    const expectedAction = {
+      ...action,
+      payload: {
+        ...action.payload,
+        meta: { count: 0, noData: false }
+      }
+    };
+    middleware(dispatch)(action);
+    expect(dispatch).toHaveBeenCalledWith(expectedAction);
+  });
+
+  it('should add notData = true to empty action with undefined composite filter key', () => {
+    const dispatch = jest.fn();
+    const action = {
+      type: 'FOO_FULFILLED',
+      payload: { data: [], meta: { count: 0 } },
+      meta: { filters: undefined }
+    };
+    const expectedAction = {
+      ...action,
+      payload: {
+        ...action.payload,
+        meta: { count: 0, noData: true }
+      }
+    };
+    middleware(dispatch)(action);
+    expect(dispatch).toHaveBeenCalledWith(expectedAction);
+  });
+
+  it('should add notData = true to empty action with empty simple filter', () => {
+    const dispatch = jest.fn();
+    const action = {
+      type: 'FOO_FULFILLED',
+      payload: { data: [], meta: { count: 0 } },
+      meta: { filter: '' }
+    };
+    const expectedAction = {
+      ...action,
+      payload: {
+        ...action.payload,
+        meta: { count: 0, noData: true }
+      }
+    };
+    middleware(dispatch)(action);
+    expect(dispatch).toHaveBeenCalledWith(expectedAction);
+  });
+
+  it('should add notData = true to empty action with empty composite filter', () => {
+    const dispatch = jest.fn();
+    const action = {
+      type: 'FOO_FULFILLED',
+      payload: { data: [], meta: { count: 0 } },
+      meta: { filters: {} }
+    };
+    const expectedAction = {
+      ...action,
+      payload: {
+        ...action.payload,
+        meta: { count: 0, noData: true }
+      }
+    };
+    middleware(dispatch)(action);
+    expect(dispatch).toHaveBeenCalledWith(expectedAction);
+  });
+});

--- a/src/utilities/empty-data-middleware.js
+++ b/src/utilities/empty-data-middleware.js
@@ -11,10 +11,11 @@ const emptyDataMiddleware = () => (dispatch) => (action) => {
       nextAction.meta,
       'filters'
     )
-      ? Object.values(nextAction.meta.filters).every(
+      ? Object.values(nextAction.meta.filters || {}).every(
           (value) => typeof value === 'undefined' || value.length === 0
         )
-      : nextAction.meta.filter.length === 0;
+      : nextAction.meta?.filter?.length === 0;
+
     nextAction.payload.meta.noData =
       nextAction.payload.meta.count === 0 && noFilter;
     return dispatch(nextAction);


### PR DESCRIPTION
jira: https://projects.engineering.redhat.com/browse/SSP-1743

There was a missing fallback for cases that the `filters` key is not present inside the action metadata