### PR TITLE
update labels colors and icons

### DIFF
--- a/src/smart-components/order/order-detail/order-detail-information.js
+++ b/src/smart-components/order/order-detail/order-detail-information.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { LevelItem, Level, Title, Label } from '@patternfly/react-core';
-import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
-import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 
 import CardIcon from '../../../presentational-components/shared/card-icon';
 import { CATALOG_API_BASE } from '../../../utilities/constants';
@@ -11,6 +9,7 @@ import statesMessages, {
   getTranslatableState
 } from '../../../messages/states.messages';
 import useFormatMessage from '../../../utilities/use-format-message';
+import orderStatusMapper from '../order-status-mapper';
 
 const OrderDetailInformation = ({
   portfolioId,
@@ -41,24 +40,11 @@ const OrderDetailInformation = ({
           </CatalogLink>
         </Title>
       </Level>
-      {state === 'Completed' ||
-        (state === 'Failed' && (
-          <LevelItem>
-            <Label
-              variant="outline"
-              color={state === 'Completed' ? 'green' : 'red'}
-              icon={
-                state === 'Completed' ? (
-                  <CheckCircleIcon />
-                ) : (
-                  <ExclamationCircleIcon />
-                )
-              }
-            >
-              {formatMessage(statesMessages[getTranslatableState(state)])}
-            </Label>
-          </LevelItem>
-        ))}
+      <LevelItem>
+        <Label {...orderStatusMapper[state]} variant="outline">
+          {formatMessage(statesMessages[getTranslatableState(state)])}
+        </Label>
+      </LevelItem>
     </Level>
   );
 };

--- a/src/smart-components/order/order-item.js
+++ b/src/smart-components/order/order-item.js
@@ -1,11 +1,6 @@
 import React, { Fragment } from 'react';
 import { Label, Text, TextVariants } from '@patternfly/react-core';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/cjs/DateFormat';
-import {
-  ExclamationCircleIcon,
-  InfoCircleIcon,
-  CheckCircleIcon
-} from '@patternfly/react-icons';
 
 import CardIcon from '../../presentational-components/shared/card-icon';
 import { getOrderIcon } from '../../helpers/shared/orders';
@@ -16,16 +11,7 @@ import statesMessages, {
 } from '../../messages/states.messages';
 
 import { TableText } from '@patternfly/react-table';
-
-const labelProps = {
-  Completed: { icon: <CheckCircleIcon />, color: 'green' },
-  'Approval Pending': {
-    icon: <InfoCircleIcon />,
-    color: 'blue'
-  },
-  Ordered: { icon: <InfoCircleIcon />, color: 'blue' },
-  Failed: { icon: <ExclamationCircleIcon />, color: 'red' }
-};
+import orderStatusMapper from './order-status-mapper';
 
 /**
  * Create order row definition for react tabular table
@@ -92,7 +78,7 @@ const createOrderItem = (
     {
       title: (
         <TableText>
-          <Label {...labelProps[item.state]} variant="outline">
+          <Label {...orderStatusMapper[item.state]} variant="outline">
             {formatMessage(statesMessages[translatableState])}
           </Label>
         </TableText>

--- a/src/smart-components/order/order-status-mapper.js
+++ b/src/smart-components/order/order-status-mapper.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import {
+  ExclamationCircleIcon,
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  ClockIcon,
+  PlusCircleIcon
+} from '@patternfly/react-icons';
+
+const orderStatusMapper = {
+  Completed: { icon: <CheckCircleIcon />, color: 'green' },
+  'Approval Pending': {
+    icon: <ClockIcon />,
+    color: 'blue'
+  },
+  Ordered: { icon: <PlusCircleIcon />, color: 'grey' },
+  Failed: { icon: <ExclamationCircleIcon />, color: 'red' },
+  Canceled: { icon: <ExclamationTriangleIcon />, color: 'orange' },
+  Created: { icon: <PlusCircleIcon />, color: 'grey' }
+};
+
+export default orderStatusMapper;


### PR DESCRIPTION
### Changes
- Updates order labels icons and colors
- Adds missing labels to order details

![screenshot-ci foo redhat com_1337-2020 08 18-14_03_05](https://user-images.githubusercontent.com/22619452/90510607-8f429380-e15b-11ea-8008-d20fe39cce29.png)
![screenshot-ci foo redhat com_1337-2020 08 18-14_02_50](https://user-images.githubusercontent.com/22619452/90510610-8fdb2a00-e15b-11ea-9155-f53b10fad95f.png)
![screenshot-ci foo redhat com_1337-2020 08 18-14_02_30](https://user-images.githubusercontent.com/22619452/90510615-910c5700-e15b-11ea-8832-4c596d2e9e16.png)
![screenshot-ci foo redhat com_1337-2020 08 18-14_02_18](https://user-images.githubusercontent.com/22619452/90510620-91a4ed80-e15b-11ea-8f6a-a43a271a7b5b.png)
![screenshot-ci foo redhat com_1337-2020 08 18-14_01_55](https://user-images.githubusercontent.com/22619452/90510624-92d61a80-e15b-11ea-99b9-c2283ea14f7f.png)


cc @sbuenafe-rh