### PR TITLE
Enable reset portfolio item icon.

### DIFF
--- a/src/helpers/portfolio/portfolio-helper.ts
+++ b/src/helpers/portfolio/portfolio-helper.ts
@@ -217,6 +217,9 @@ export const copyPortfolioItem = (
 ): AxiosPromise<PortfolioItem> =>
   portfolioItemApi.postCopyPortfolioItem(portfolioItemId, copyObject);
 
+export const resetPortfolioItemIcon = (iconId: string): AxiosPromise<void> =>
+  axiosInstance.delete(`${CATALOG_API_BASE}/icons/${iconId}`);
+
 export const uploadPortfolioItemIcon = (
   portfolioItemId: string,
   file: File,

--- a/src/messages/icon.messages.ts
+++ b/src/messages/icon.messages.ts
@@ -1,0 +1,14 @@
+import { defineMessages } from 'react-intl';
+
+const iconMessages = defineMessages({
+  changeIcon: {
+    id: 'icons.actions.change',
+    defaultMessage: 'Change icon'
+  },
+  resetIcon: {
+    id: 'icons.actions.reset',
+    defaultMessage: 'Reset icon'
+  }
+});
+
+export default iconMessages;

--- a/src/smart-components/portfolio/portfolio-item-detail/edit-portfolio-item.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/edit-portfolio-item.js
@@ -14,6 +14,7 @@ import CardIcon from '../../../presentational-components/shared/card-icon';
 const EditPortfolioItem = ({
   cancelUrl,
   uploadIcon,
+  resetIcon,
   product: { owner, created_at, updated_at, ...product },
   userCapabilities
 }) => {
@@ -22,10 +23,16 @@ const EditPortfolioItem = ({
   const { search } = useLocation();
   return (
     <Stack hasGutter>
-      <StackItem>
-        <IconUpload uploadIcon={uploadIcon}>
+      <StackItem key={product.icon_id || 'default'}>
+        <IconUpload
+          uploadIcon={uploadIcon}
+          resetIcon={resetIcon}
+          enableReset={!!product.icon_id}
+        >
           <CardIcon
-            src={`${CATALOG_API_BASE}/portfolio_items/${product.id}/icon`}
+            src={`${CATALOG_API_BASE}/portfolio_items/${
+              product.id
+            }/icon?cache_id=${product.icon_id || 'default'}`} // we need ho add the query to prevent the browser caching when reseting the image
             sourceId={product.service_offering_source_ref}
             height={64}
           />
@@ -66,7 +73,8 @@ EditPortfolioItem.propTypes = {
   cancelUrl: PropTypes.string.isRequired,
   product: PropTypes.object.isRequired,
   userCapabilities: PropTypes.object.isRequired,
-  uploadIcon: PropTypes.func.isRequired
+  uploadIcon: PropTypes.func.isRequired,
+  resetIcon: PropTypes.func.isRequired
 };
 
 export default EditPortfolioItem;

--- a/src/smart-components/portfolio/portfolio-item-detail/icon-upload.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/icon-upload.js
@@ -1,14 +1,20 @@
 import React, { useState, useRef } from 'react';
 import { PencilAltIcon } from '@patternfly/react-icons';
-import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner/Spinner';
+import {
+  Spinner,
+  Dropdown,
+  DropdownToggle,
+  DropdownItem
+} from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/cjs/actions';
 import styled from 'styled-components';
 import portfolioMessages from '../../../messages/portfolio.messages';
 import useFormatMessage from '../../../utilities/use-format-message';
+import iconMessages from '../../../messages/icon.messages';
 
-const UploadButton = styled.button`
+const UploadButton = styled.span`
   border: none;
   position: absolute;
   top: 0;
@@ -29,7 +35,8 @@ const UploadButton = styled.button`
     background-color: rgba(255, 255, 255, 0.8);
     z-index: 0;
   }
-  svg {
+  svg,
+  .pf-c-spinner {
     z-index: 1;
     position: absolute;
     top: 0;
@@ -48,13 +55,37 @@ const ImagePreview = styled.img`
   object-fit: cover;
 `;
 
-const IconUpload = ({ uploadIcon, children }) => {
+const IconUpload = ({ uploadIcon, resetIcon, enableReset, children }) => {
   const formatMessage = useFormatMessage();
   const inputRef = useRef();
   const [image, setImage] = useState();
   const [isUploading, setIsUploading] = useState(false);
-  const handleClick = () => inputRef.current.click();
+  const [isOpen, setIsOpen] = useState(false);
+  const handleClick = () => {
+    setIsOpen(false);
+    return inputRef.current.click();
+  };
+
+  const handleReset = () => {
+    setImage(undefined);
+    setIsUploading(true);
+    return resetIcon().then(() => setIsUploading(false));
+  };
+
   const dispatch = useDispatch();
+
+  const dropdownItems = [
+    <DropdownItem onClick={handleClick} key="change-icon">
+      {formatMessage(iconMessages.changeIcon)}
+    </DropdownItem>,
+    <DropdownItem
+      isDisabled={!enableReset}
+      onClick={handleReset}
+      key="reset-icon"
+    >
+      {formatMessage(iconMessages.resetIcon)}
+    </DropdownItem>
+  ];
 
   return (
     <UploadIconWrapper>
@@ -85,17 +116,39 @@ const IconUpload = ({ uploadIcon, children }) => {
         id="icon-upload"
         hidden
       />
-      <UploadButton disabled={isUploading} onClick={handleClick}>
-        {isUploading ? <Spinner size="md" /> : <PencilAltIcon size="sm" />}
-      </UploadButton>
-      {!image && children}
-      {image && (
-        <ImagePreview
-          style={{ height: 64 }}
-          src={URL.createObjectURL(image)}
-          id={image.name}
-        />
-      )}
+      <Dropdown
+        onSelect={() => setIsOpen(false)}
+        isOpen={isOpen}
+        isPlain
+        disabled={isUploading}
+        dropdownItems={dropdownItems}
+        toggle={
+          <DropdownToggle
+            disabled={isUploading}
+            toggleIndicator={null}
+            onToggle={(isOpen, event) => {
+              event.stopPropagation();
+              setIsOpen(isOpen);
+            }}
+          >
+            <UploadButton>
+              {isUploading ? (
+                <Spinner size="md" />
+              ) : (
+                <PencilAltIcon size="sm" />
+              )}
+            </UploadButton>
+            {!image && children}
+            {image && (
+              <ImagePreview
+                style={{ height: 64 }}
+                src={URL.createObjectURL(image)}
+                id={image.name}
+              />
+            )}
+          </DropdownToggle>
+        }
+      />
     </UploadIconWrapper>
   );
 };
@@ -105,7 +158,9 @@ IconUpload.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)
-  ])
+  ]),
+  resetIcon: PropTypes.func.isRequired,
+  enableReset: PropTypes.bool
 };
 
 export default IconUpload;

--- a/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/item-detail-description.js
@@ -18,7 +18,8 @@ const ItemDetailDescription = ({
   url,
   search,
   detailPaths,
-  uploadIcon
+  uploadIcon,
+  resetIcon
 }) => {
   const formatMessage = useFormatMessage();
   return (
@@ -101,6 +102,7 @@ const ItemDetailDescription = ({
           product={product}
           userCapabilities={userCapabilities}
           uploadIcon={uploadIcon}
+          resetIcon={resetIcon}
         />
       </CatalogRoute>
     </Switch>
@@ -120,7 +122,8 @@ ItemDetailDescription.propTypes = {
   search: PropTypes.string.isRequired,
   userCapabilities: PropTypes.object.isRequired,
   detailPaths: PropTypes.arrayOf(PropTypes.string),
-  uploadIcon: PropTypes.func.isRequired
+  uploadIcon: PropTypes.func.isRequired,
+  resetIcon: PropTypes.func.isRequired
 };
 
 export default ItemDetailDescription;

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -13,7 +13,10 @@ import {
   ProductLoaderPlaceholder,
   AppPlaceholder
 } from '../../../presentational-components/shared/loader-placeholders';
-import { uploadPortfolioItemIcon } from '../../../helpers/portfolio/portfolio-helper';
+import {
+  uploadPortfolioItemIcon,
+  resetPortfolioItemIcon
+} from '../../../helpers/portfolio/portfolio-helper';
 import useQuery from '../../../utilities/use-query';
 import {
   PORTFOLIO_ITEM_ROUTE,
@@ -58,12 +61,11 @@ const PortfolioItemDetail = () => {
   );
   const fromProducts = queryValues['from-products'] === 'true';
 
-  useEffect(() => {
-    setIsFetching(true);
-    insights.chrome.appNavClick({
-      id: fromProducts ? 'products' : 'portfolios',
-      secondaryNav: true
-    });
+  const fetchData = (skipLoading) => {
+    if (!skipLoading) {
+      setIsFetching(true);
+    }
+
     dispatch(
       getPortfolioItemDetail({
         portfolioItem: queryValues['portfolio-item'],
@@ -72,6 +74,14 @@ const PortfolioItemDetail = () => {
     )
       .then(() => setIsFetching(false))
       .catch(() => setIsFetching(false));
+  };
+
+  useEffect(() => {
+    insights.chrome.appNavClick({
+      id: fromProducts ? 'products' : 'portfolios',
+      secondaryNav: true
+    });
+    fetchData();
   }, [queryValues['portfolio-item']]);
 
   if (isFetching || Object.keys(portfolioItem).length === 0) {
@@ -97,7 +107,10 @@ const PortfolioItemDetail = () => {
         title={formatMessage(portfolioMessages.objectUnavaiable, { object })}
       />
     ));
-  const uploadIcon = (file) => uploadPortfolioItemIcon(portfolioItem.id, file);
+  const uploadIcon = (file) =>
+    uploadPortfolioItemIcon(portfolioItem.id, file).then(() => fetchData(true));
+  const resetIcon = () =>
+    resetPortfolioItemIcon(portfolioItem.icon_id).then(fetchData);
   const detailPaths = [
     PORTFOLIO_ITEM_ROUTE,
     `${url}/order`,
@@ -162,6 +175,7 @@ const PortfolioItemDetail = () => {
                 lg={pathname === PORTFOLIO_ITEM_ROUTE_EDIT ? 12 : 10}
               >
                 <ItemDetailDescription
+                  resetIcon={resetIcon}
                   uploadIcon={uploadIcon}
                   product={portfolioItem}
                   userCapabilities={userCapabilities}


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/SSP-1755

~~blocked by: https://github.com/RedHatInsights/catalog-api/pull/793~~

after clicking on the icon dropdown will appear with change/reset options:

![reset-icon](https://user-images.githubusercontent.com/22619452/93052145-e148dd00-f665-11ea-8762-9f38c62be463.gif)

cc @sbuenafe-rh I have stolen common patterns for multi icon operations actions. Feel free to change it later.