### PR TITLE
Fix sorting on filter chips reset

### DIFF
--- a/src/smart-components/portfolio/portfolios.js
+++ b/src/smart-components/portfolio/portfolios.js
@@ -71,7 +71,11 @@ const portfoliosState = (state, action) => {
         filters: changeFilters(action.payload, state.filterType, state.filters)
       };
     case 'replaceFilterChip':
-      return { ...state, sortDirection: SortByDirection.asc, filters: action.payload };
+      return {
+        ...state,
+        sortDirection: SortByDirection.asc,
+        filters: action.payload
+      };
     case 'setFilteringFlag':
       return { ...state, isFiltering: action.payload };
     case 'setFilterType':

--- a/src/smart-components/portfolio/portfolios.js
+++ b/src/smart-components/portfolio/portfolios.js
@@ -71,7 +71,7 @@ const portfoliosState = (state, action) => {
         filters: changeFilters(action.payload, state.filterType, state.filters)
       };
     case 'replaceFilterChip':
-      return { ...state, filters: action.payload };
+      return { ...state, sortDirection: SortByDirection.asc, filters: action.payload };
     case 'setFilteringFlag':
       return { ...state, isFiltering: action.payload };
     case 'setFilterType':


### PR DESCRIPTION
Reset the sorting direction to the default ( asc ) when filter/sorting chips are cleared.
 Fixes https://projects.engineering.redhat.com/browse/SSP-1727