### PR TITLE
Fix update date for approval request list in the orders detail page

### DIFF
--- a/src/helpers/order/order-helper.ts
+++ b/src/helpers/order/order-helper.ts
@@ -235,6 +235,7 @@ const requestTranscriptQuery = (parent_id: string) => `query {
     number_of_children
     decision
     group_name
+    created_at
     state
     actions {
       id
@@ -247,6 +248,7 @@ const requestTranscriptQuery = (parent_id: string) => `query {
       group_name
       state
       parent_id
+      created_at
       actions {
         id
         created_at
@@ -285,7 +287,8 @@ export const getApprovalRequests = (
       return Promise.all(promises).then((requests) => {
         const data = requests?.[0]?.map(({ actions, ...request }) => ({
           ...request,
-          updated: actions?.length > 0 ? actions.pop()?.created_at : undefined
+          updated:
+            actions?.length > 0 ? actions.pop()?.created_at : request.created_at
         }));
         return { data: data || [] };
       });


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SSP-1808

Updated the graphql query to get the request and subrequests create dates. Use these for Updated column when the actions array is empty.

Before:
![Screenshot from 2020-09-17 13-15-11](https://user-images.githubusercontent.com/12769982/93507495-ca1b2100-f8eb-11ea-96af-aee456ef606c.png)

After:
![Screenshot from 2020-09-17 13-15-51](https://user-images.githubusercontent.com/12769982/93507516-d0110200-f8eb-11ea-9ff9-b8acd22c235c.png)
