### PR TITLE
Display the Set order processes menu item only if the user has permissions

### DIFF
--- a/src/presentational-components/portfolio/porfolio-card.tsx
+++ b/src/presentational-components/portfolio/porfolio-card.tsx
@@ -42,10 +42,12 @@ interface HeaderActionsProps {
   portfolioId: string;
   handleCopyPortfolio: (portfolioId: string) => void;
   userCapabilities: UserCapabilities;
+  canLinkOrderProcesses: boolean;
 }
 const HeaderActions: React.ComponentType<HeaderActionsProps> = ({
   portfolioId,
   handleCopyPortfolio,
+  canLinkOrderProcesses,
   userCapabilities: { share, copy, unshare, update, destroy, set_approval }
 }) => {
   const formatMessage = useFormatMessage();
@@ -99,7 +101,7 @@ const HeaderActions: React.ComponentType<HeaderActionsProps> = ({
     );
   }
 
-  if (window.insights.chrome.isBeta() && update) {
+  if (window.insights.chrome.isBeta() && update && canLinkOrderProcesses) {
     const orderProcessAction = formatMessage(
       orderProcessesMessages.setOrderProcess
     ) as string;
@@ -187,6 +189,7 @@ export interface PortfolioCardProps {
   isDisabled?: boolean;
   metadata: PortfolioMetadata;
   handleCopyPortfolio: (portfolioId: string) => void;
+  canLinkOrderProcesses: boolean;
 }
 const PortfolioCard: React.ComponentType<PortfolioCardProps> = ({
   imageUrl,
@@ -198,6 +201,7 @@ const PortfolioCard: React.ComponentType<PortfolioCardProps> = ({
     user_capabilities,
     statistics: { shared_groups, portfolio_items }
   },
+  canLinkOrderProcesses,
   ...props
 }) => {
   const formatMessage = useFormatMessage();
@@ -219,6 +223,7 @@ const PortfolioCard: React.ComponentType<PortfolioCardProps> = ({
                 portfolioId={id}
                 userCapabilities={user_capabilities}
                 handleCopyPortfolio={handleCopyPortfolio}
+                canLinkOrderProcesses={canLinkOrderProcesses}
               />
             }
           />

--- a/src/presentational-components/portfolio/porfolio-card.tsx
+++ b/src/presentational-components/portfolio/porfolio-card.tsx
@@ -101,6 +101,10 @@ const HeaderActions: React.ComponentType<HeaderActionsProps> = ({
     );
   }
 
+  console.log(
+    'Debug - menu 1 - canLinkOrderProcesses: ',
+    canLinkOrderProcesses
+  );
   if (window.insights.chrome.isBeta() && update && canLinkOrderProcesses) {
     const orderProcessAction = formatMessage(
       orderProcessesMessages.setOrderProcess

--- a/src/presentational-components/portfolio/porfolio-card.tsx
+++ b/src/presentational-components/portfolio/porfolio-card.tsx
@@ -101,10 +101,6 @@ const HeaderActions: React.ComponentType<HeaderActionsProps> = ({
     );
   }
 
-  console.log(
-    'Debug - menu 1 - canLinkOrderProcesses: ',
-    canLinkOrderProcesses
-  );
   if (window.insights.chrome.isBeta() && update && canLinkOrderProcesses) {
     const orderProcessAction = formatMessage(
       orderProcessesMessages.setOrderProcess

--- a/src/smart-components/common/order-modal.tsx
+++ b/src/smart-components/common/order-modal.tsx
@@ -81,6 +81,7 @@ const OrderModal: React.ComponentType<OrderModalProps> = ({ closeUrl }) => {
         delete field.validate;
         delete field.dataType;
       }
+
       return field;
     });
     return { ...schema, fields: updatedFields };

--- a/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
@@ -26,7 +26,8 @@ const DetailToolbarActions = ({
   isFetching,
   availability,
   orderable,
-  userCapabilities: { update, copy, set_approval }
+  userCapabilities: { update, copy, set_approval },
+  canLinkOrderProcesses
 }) => {
   const formatMessage = useFormatMessage();
   const dropdownItems = [];
@@ -79,7 +80,11 @@ const DetailToolbarActions = ({
     );
   }
 
-  if (window.insights.chrome.isBeta() && update) {
+  console.log(
+    'Debug - menu 2 - canLinkOrderProcesses: ',
+    canLinkOrderProcesses
+  );
+  if (window.insights.chrome.isBeta() && update && canLinkOrderProcesses) {
     const orderProcessAction = formatMessage(
       orderProcessesMessages.setOrderProcess
     );
@@ -175,7 +180,8 @@ DetailToolbarActions.propTypes = {
   userCapabilities: PropTypes.shape({
     update: PropTypes.bool,
     copy: PropTypes.bool,
-    set_approval: PropTypes.bool
+    set_approval: PropTypes.bool,
+    canLinkOrderProcesses: PropTypes.bool
   }).isRequired
 };
 

--- a/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.js
@@ -80,10 +80,6 @@ const DetailToolbarActions = ({
     );
   }
 
-  console.log(
-    'Debug - menu 2 - canLinkOrderProcesses: ',
-    canLinkOrderProcesses
-  );
   if (window.insights.chrome.isBeta() && update && canLinkOrderProcesses) {
     const orderProcessAction = formatMessage(
       orderProcessesMessages.setOrderProcess
@@ -180,14 +176,15 @@ DetailToolbarActions.propTypes = {
   userCapabilities: PropTypes.shape({
     update: PropTypes.bool,
     copy: PropTypes.bool,
-    set_approval: PropTypes.bool,
-    canLinkOrderProcesses: PropTypes.bool
-  }).isRequired
+    set_approval: PropTypes.bool
+  }).isRequired,
+  canLinkOrderProcesses: PropTypes.bool
 };
 
 DetailToolbarActions.defaultProps = {
   isFetching: false,
-  orderable: true
+  orderable: true,
+  canLinkOrderProcesses: false
 };
 
 export default DetailToolbarActions;

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
@@ -127,7 +127,8 @@ PortfolioItemDetailToolbar.propTypes = {
   availability: PropTypes.oneOf(['available', 'unavailable']).isRequired,
   userCapabilities: PropTypes.object,
   fromProducts: PropTypes.bool,
-  orderable: PropTypes.bool
+  orderable: PropTypes.bool,
+  canLinkOrderProcesses: PropTypes.bool
 };
 
 PortfolioItemDetailToolbar.defaultProps = {

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail-toolbar.js
@@ -50,7 +50,8 @@ export const PortfolioItemDetailToolbar = ({
   availability,
   userCapabilities,
   orderable,
-  fromProducts
+  fromProducts,
+  canLinkOrderProcesses
 }) => {
   const formatMessage = useFormatMessage();
   const { pathname } = useLocation();
@@ -100,6 +101,7 @@ export const PortfolioItemDetailToolbar = ({
                   availability={availability}
                   orderable={orderable}
                   userCapabilities={userCapabilities}
+                  canLinkOrderProcesses={canLinkOrderProcesses}
                 />
               </Level>
             </LevelItem>
@@ -216,5 +218,6 @@ SurveyEditingToolbar.propTypes = {
   isValid: PropTypes.bool,
   modified: PropTypes.bool,
   handleResetSurvey: PropTypes.func,
-  fromProducts: PropTypes.bool
+  fromProducts: PropTypes.bool,
+  canLinkOrderProcesses: PropTypes.bool
 };

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -1,4 +1,11 @@
-import React, {useEffect, useState, Fragment, lazy, Suspense, useContext} from 'react';
+import React, {
+  useEffect,
+  useState,
+  Fragment,
+  lazy,
+  Suspense,
+  useContext
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch, useRouteMatch, useLocation } from 'react-router-dom';
 import { Grid, GridItem, Alert } from '@patternfly/react-core';
@@ -27,7 +34,7 @@ import CatalogRoute from '../../../routing/catalog-route';
 import portfolioMessages from '../../../messages/portfolio.messages';
 import BackToProducts from '../../../presentational-components/portfolio/back-to-products';
 import useFormatMessage from '../../../utilities/use-format-message';
-import {hasPermission} from '../../../helpers/shared/helpers';
+import { hasPermission } from '../../../helpers/shared/helpers';
 import UserContext from '../../../user-context';
 
 const SurveyEditor = lazy(() =>

--- a/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
+++ b/src/smart-components/portfolio/portfolio-item-detail/portfolio-item-detail.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, Fragment, lazy, Suspense } from 'react';
+import React, {useEffect, useState, Fragment, lazy, Suspense, useContext} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch, useRouteMatch, useLocation } from 'react-router-dom';
 import { Grid, GridItem, Alert } from '@patternfly/react-core';
@@ -27,6 +27,8 @@ import CatalogRoute from '../../../routing/catalog-route';
 import portfolioMessages from '../../../messages/portfolio.messages';
 import BackToProducts from '../../../presentational-components/portfolio/back-to-products';
 import useFormatMessage from '../../../utilities/use-format-message';
+import {hasPermission} from '../../../helpers/shared/helpers';
+import UserContext from '../../../user-context';
 
 const SurveyEditor = lazy(() =>
   import(
@@ -56,6 +58,10 @@ const PortfolioItemDetail = () => {
     ({ portfolioReducer: { selectedPortfolio } }) => selectedPortfolio
   );
   const fromProducts = queryValues['from-products'] === 'true';
+  const { permissions: userPermissions } = useContext(UserContext);
+  const canLinkOrderProcesses = hasPermission(userPermissions, [
+    'catalog:order_processes:link'
+  ]);
 
   const fetchData = (skipLoading) => {
     if (!skipLoading) {
@@ -154,6 +160,7 @@ const PortfolioItemDetail = () => {
                 portfolioItemData?.portfolioItem?.metadata.user_capabilities
               }
               orderable={portfolioItemData?.portfolioItem.metadata?.orderable}
+              canLinkOrderProcesses={canLinkOrderProcesses}
             />
             {unavailable.length > 0 && (
               <div className="pf-u-mr-lg pf-u-ml-lg">{unavailable}</div>

--- a/src/smart-components/portfolio/portfolio-items.js
+++ b/src/smart-components/portfolio/portfolio-items.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useRouteMatch } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
@@ -15,6 +15,8 @@ import useQuery from '../../utilities/use-query';
 import { PORTFOLIO_ROUTE } from '../../constants/routes';
 import filteringMessages from '../../messages/filtering.messages';
 import useFormatMessage from '../../utilities/use-format-message';
+import UserContext from '../../user-context';
+import { hasPermission } from '../../helpers/shared/helpers';
 
 const PortfolioItems = ({
   routes,
@@ -54,6 +56,10 @@ const PortfolioItems = ({
   const { url } = useRouteMatch(PORTFOLIO_ROUTE);
   const [{ portfolio: id }] = useQuery(['portfolio']);
   const dispatch = useDispatch();
+  const { permissions: userPermissions } = useContext(UserContext);
+  const canLinkOrderProcesses = hasPermission(userPermissions, [
+    'catalog:order_processes:link'
+  ]);
 
   const items = data.map((item) => (
     <PortfolioItem
@@ -99,7 +105,8 @@ const PortfolioItems = ({
           fetchPortfolioItemsWithPortfolio: (...args) =>
             dispatch(fetchPortfolioItemsWithPortfolio(...args)),
           portfolioId: id,
-          userCapabilities
+          userCapabilities,
+          canLinkOrderProcesses
         })}
       />
       <ContentGallery

--- a/src/smart-components/portfolio/portfolios.js
+++ b/src/smart-components/portfolio/portfolios.js
@@ -179,8 +179,6 @@ const Portfolios = () => {
       : formatMessage(filteringMessages.noResultsDescription),
     Icon: meta.noData ? WrenchIcon : SearchIcon
   };
-
-  console.log('Debug - canLinkOrderProcesses: ', canLinkOrderProcesses);
   const galleryItems = data.map((item) => (
     <PortfolioCard
       key={item.id}

--- a/src/smart-components/portfolio/portfolios.js
+++ b/src/smart-components/portfolio/portfolios.js
@@ -151,6 +151,10 @@ const Portfolios = () => {
     'catalog:portfolios:create'
   ]);
 
+  const canLinkOrderProcesses = hasPermission(userPermissions, [
+    'catalog:order_processes:link'
+  ]);
+
   const NoDataAction = () => (
     <EmptyStatePrimaryAction
       url={ADD_PORTFOLIO_ROUTE}
@@ -180,6 +184,7 @@ const Portfolios = () => {
     <PortfolioCard
       key={item.id}
       {...item}
+      canLinkOrderProcesses={canLinkOrderProcesses}
       handleCopyPortfolio={handleCopyPortfolio}
     />
   ));

--- a/src/smart-components/portfolio/portfolios.js
+++ b/src/smart-components/portfolio/portfolios.js
@@ -180,6 +180,7 @@ const Portfolios = () => {
     Icon: meta.noData ? WrenchIcon : SearchIcon
   };
 
+  console.log('Debug - canLinkOrderProcesses: ', canLinkOrderProcesses);
   const galleryItems = data.map((item) => (
     <PortfolioCard
       key={item.id}

--- a/src/test/presentational-components/portfolio/portfolio-card.test.js
+++ b/src/test/presentational-components/portfolio/portfolio-card.test.js
@@ -57,7 +57,7 @@ describe('<PortfolioCard />', () => {
   it('should render and create correct card actions', () => {
     const wrapper = mount(
       <MemoryRouter>
-        <PortfolioCard {...initialProps} />
+        <PortfolioCard {...initialProps} canLinkOrderProcesses={true} />
       </MemoryRouter>
     );
     expect(wrapper.find('button')).toHaveLength(1);
@@ -86,6 +86,7 @@ describe('<PortfolioCard />', () => {
         <PortfolioCard
           {...initialProps}
           metadata={prepareTruthyCapability('update')}
+          canLinkOrderProcesses={true}
         />
       </MemoryRouter>
     );

--- a/src/test/presentational-components/portfolio/portfolio-card.test.js
+++ b/src/test/presentational-components/portfolio/portfolio-card.test.js
@@ -71,6 +71,7 @@ describe('<PortfolioCard />', () => {
         <PortfolioCard
           {...initialProps}
           metadata={prepareTruthyCapability('unshare')}
+          canLinkOrderProcesses={true}
         />
       </MemoryRouter>
     );

--- a/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/__snapshots__/detail-toolbar-actions.test.js.snap
@@ -3,6 +3,7 @@
 exports[`<DetailToolbarActions /> should render correctly 1`] = `
 <DetailToolbarActions
   availability="available"
+  canLinkOrderProcesses={true}
   copyUrl="foo/copy"
   editSurveyUrl="foo/edit-survey"
   editUrl="foo/baz"

--- a/src/test/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.test.js
+++ b/src/test/smart-components/portfolio/portfolio-item-detail/detail-toolbar-actions.test.js
@@ -35,7 +35,8 @@ describe('<DetailToolbarActions />', () => {
         copy: true,
         update: true,
         set_approval: true
-      }
+      },
+      canLinkOrderProcesses: true
     };
   });
 

--- a/src/test/utilities/portfolio-toolbar.schema.test.js
+++ b/src/test/utilities/portfolio-toolbar.schema.test.js
@@ -50,7 +50,8 @@ describe('portfolio toolbar schema', () => {
       update: true,
       destroy: true,
       set_approval: true
-    }
+    },
+    canLinkOrderProcesses: true
   };
 
   const mockStore = configureStore();
@@ -111,7 +112,8 @@ describe('portfolio toolbar schema', () => {
         <ToolbarRenderer
           schema={createPortfolioToolbarSchema({
             ...initialProps,
-            userCapabilities: prepareTruthyCapability('update')
+            userCapabilities: prepareTruthyCapability('update'),
+            canLinkOrderProcesses: true
           })}
         />
       </ToolbarWrapper>

--- a/src/toolbar/schemas/portfolio-toolbar.schema.js
+++ b/src/toolbar/schemas/portfolio-toolbar.schema.js
@@ -17,7 +17,7 @@ import orderProcessesMessages from '../../messages/order-processes.messages';
 import { NESTED_EDIT_ORDER_PROCESS_ROUTE } from '../../constants/routes';
 
 /**
- * Cannot be anonymous function. Requires Component.diplayName to work with PF4 refs
+ * Cannot be anonymous function. Requires Component.displayName to work with PF4 refs
  */
 const PortfolioActionsToolbar = ({
   editPortfolioRoute,
@@ -25,11 +25,14 @@ const PortfolioActionsToolbar = ({
   removePortfolioRoute,
   copyInProgress,
   copyPortfolio,
-  userCapabilities: { copy, destroy, update, set_approval }
+  userCapabilities: { copy, destroy, update, set_approval },
+  canLinkOrderProcesses
 }) => {
   const [isOpen, setOpen] = useState(false);
   const formatMessage = useFormatMessage();
   const dropdownItems = [];
+
+  console.log('Debug test 10 - canLinkOrderProceeses -', canLinkOrderProcesses);
 
   if (update) {
     dropdownItems.push(
@@ -81,7 +84,7 @@ const PortfolioActionsToolbar = ({
     );
   }
 
-  if (window.insights.chrome.isBeta() && update) {
+  if (window.insights.chrome.isBeta() && update && canLinkOrderProcesses) {
     const orderProcessAction = formatMessage(
       orderProcessesMessages.setOrderProcess
     );
@@ -150,7 +153,8 @@ PortfolioActionsToolbar.propTypes = {
     update: PropTypes.bool,
     destroy: PropTypes.bool,
     set_approval: PropTypes.bool
-  }).isRequired
+  }).isRequired,
+  canLinkOrderProcesses: PropTypes.bool
 };
 
 const createPortfolioToolbarSchema = ({
@@ -171,7 +175,8 @@ const createPortfolioToolbarSchema = ({
   description,
   fromProducts,
   filterProps: { searchValue, onFilterChange, placeholder },
-  userCapabilities: { share, unshare, ...userCapabilities }
+  userCapabilities: { share, unshare, ...userCapabilities },
+  canLinkOrderProcesses
 }) => ({
   fields: [
     {
@@ -218,6 +223,7 @@ const createPortfolioToolbarSchema = ({
                       copyPortfolio,
                       copyInProgress,
                       userCapabilities,
+                      canLinkOrderProcesses,
                       key: 'portfolio-actions-dropdown'
                     }
                   ]

--- a/src/toolbar/schemas/portfolio-toolbar.schema.js
+++ b/src/toolbar/schemas/portfolio-toolbar.schema.js
@@ -32,8 +32,6 @@ const PortfolioActionsToolbar = ({
   const formatMessage = useFormatMessage();
   const dropdownItems = [];
 
-  console.log('Debug test 10 - canLinkOrderProceeses -', canLinkOrderProcesses);
-
   if (update) {
     dropdownItems.push(
       <DropdownItem


### PR DESCRIPTION
Display the Set order processes menu item only if the user has permissions link order processes permission

Fixes https://issues.redhat.com/browse/SSP-1909

User without order process link permission:

![Screenshot from 2020-10-27 01-51-38](https://user-images.githubusercontent.com/12769982/97262626-a48d0b80-17f7-11eb-9b52-11767d969ffb.png)
![Screenshot from 2020-10-27 01-51-00](https://user-images.githubusercontent.com/12769982/97262628-a48d0b80-17f7-11eb-8961-51fa71d48a7c.png)
![Screenshot from 2020-10-27 01-50-45](https://user-images.githubusercontent.com/12769982/97262629-a525a200-17f7-11eb-8e59-b29639b38751.png)

User with order-processes link permission:
![Screenshot from 2020-10-27 01-55-06](https://user-images.githubusercontent.com/12769982/97262705-ce463280-17f7-11eb-9e4f-caf9fe4570c2.png)
![Screenshot from 2020-10-27 01-53-51](https://user-images.githubusercontent.com/12769982/97262706-cedec900-17f7-11eb-8559-288e6fec5d4b.png)


