### PR TITLE
Add order provision tab

### DIFF
--- a/src/helpers/order/new-order-helper.ts
+++ b/src/helpers/order/new-order-helper.ts
@@ -26,6 +26,11 @@ export type OrderDetailPayload = [
   Portfolio | ObjectNotFound
 ];
 
+export type OrderProvisionPayload = {
+  orderItems: OrderItem[] | [];
+  progressMessages: ProgressMessage[] | [];
+};
+
 export const fetchOrderDetailSequence = async (
   orderId: string
 ): Promise<OrderDetailPayload> => {
@@ -107,4 +112,27 @@ export const fetchOrderDetailSequence = async (
     progressMessages as ProgressMessage | ObjectNotFound,
     portfolio as Portfolio | ObjectNotFound
   ]);
+};
+
+export const fetchOrderProvisionItems = async (
+  orderId: string
+): Promise<OrderProvisionPayload> => {
+  let orderItems: OrderItem[];
+  try {
+    orderItems = await axiosInstance.get(
+      `${CATALOG_API_BASE}/order-items/?order_id=${orderId}`
+    );
+  } catch (error) {
+    orderItems = [];
+    if (error.status === 404 || error.status === 400) {
+      catalogHistory.replace({
+        pathname: '/404',
+        state: { from: catalogHistory.location }
+      });
+    } else {
+      throw error;
+    }
+  }
+  const progressMessages: ProgressMessage[] | [] = [];
+  return { orderItems, progressMessages };
 };

--- a/src/helpers/order/new-order-helper.ts
+++ b/src/helpers/order/new-order-helper.ts
@@ -119,9 +119,11 @@ export const fetchOrderProvisionItems = async (
 ): Promise<OrderProvisionPayload> => {
   let orderItems: OrderItem[];
   try {
-    orderItems = await axiosInstance.get(
-      `${CATALOG_API_BASE}/order-items/?order_id=${orderId}`
+    const items = await axiosInstance.get(
+      `${CATALOG_API_BASE}/order_items/?order_id=${orderId}`
     );
+    orderItems = items.data;
+    console.log('Debug - orderItems: items, orderItems', items, orderItems);
   } catch (error) {
     orderItems = [];
     if (error.status === 404 || error.status === 400) {
@@ -133,6 +135,7 @@ export const fetchOrderProvisionItems = async (
       throw error;
     }
   }
+
   const progressMessages: ProgressMessage[] | [] = [];
   return { orderItems, progressMessages };
 };

--- a/src/helpers/order/order-helper.ts
+++ b/src/helpers/order/order-helper.ts
@@ -15,7 +15,9 @@ import { defaultSettings } from '../shared/pagination';
 import catalogHistory from '../../routing/catalog-history';
 import {
   fetchOrderDetailSequence,
-  OrderDetailPayload
+  fetchOrderProvisionItems,
+  OrderDetailPayload,
+  OrderProvisionPayload
 } from './new-order-helper';
 import {
   ApiCollectionResponse,
@@ -293,3 +295,9 @@ export const getApprovalRequests = (
         return { data: data || [] };
       });
     });
+
+export const getOrderProvisionItems = (
+  orderId: string
+): Promise<OrderProvisionPayload> => {
+  return fetchOrderProvisionItems(orderId);
+};

--- a/src/helpers/portfolio/portfolio-helper.ts
+++ b/src/helpers/portfolio/portfolio-helper.ts
@@ -310,6 +310,5 @@ export const fetchPortfolioItem = async (
   const portfolioItem = await portfolioItemApi.showPortfolioItem(
     portfolioItemId
   );
-  console.log('Debug - get portfolio item', portfolioItem);
   return (portfolioItem as unknown) as PortfolioItem;
 };

--- a/src/helpers/portfolio/portfolio-helper.ts
+++ b/src/helpers/portfolio/portfolio-helper.ts
@@ -303,3 +303,13 @@ export const undeletePortfolio = (
   axiosInstance.post(`${CATALOG_API_BASE}/portfolios/${portfolioId}/undelete`, {
     restore_key: restoreKey
   });
+
+export const fetchPortfolioItem = async (
+  portfolioItemId: string
+): Promise<PortfolioItem> => {
+  const portfolioItem = await portfolioItemApi.showPortfolioItem(
+    portfolioItemId
+  );
+  console.log('Debug - get portfolio item', portfolioItem);
+  return (portfolioItem as unknown) as PortfolioItem;
+};

--- a/src/messages/orders.messages.ts
+++ b/src/messages/orders.messages.ts
@@ -72,6 +72,10 @@ const ordersMessages = defineMessages({
     id: 'orders.menu.approval',
     defaultMessage: 'Approval'
   },
+  menuProvision: {
+    id: 'orders.menu.provision',
+    defaultMessage: 'Provision'
+  },
   menuLifecycle: {
     id: 'orders.menu.lifecycle',
     defaultMessage: 'Lifecycle'
@@ -132,6 +136,14 @@ const ordersMessages = defineMessages({
   artifacts: {
     id: 'orders.artifacts',
     defaultMessage: 'Order artifacts'
+  },
+  noOrderProvision: {
+    id: 'orders.provision.no-items',
+    defaultMessage: 'We were unable to find provisioning data for this order.'
+  },
+  fetchingOrderProvision: {
+    id: 'orders.provision.fetching-provision',
+    defaultMessage: 'Retrieving order provisioning data'
   }
 });
 

--- a/src/redux/action-types.ts
+++ b/src/redux/action-types.ts
@@ -66,7 +66,9 @@ export const SET_OPENAPI_SCHEMA = '@@open-api/set-schema';
  */
 export const SET_ORDER_DETAIL = '@@orders/set-order-detail';
 export const FETCH_APPROVAL_REQUESTS = '@@orders/fetch-order-requests';
-
+export const FETCH_ORDER_PROVISION_ITEMS =
+  '@@orders/FETCH_ORDER_PROVISION_ITEMS';
+export const SET_ORDER_PROVISION_ITEMS = '@@orders/SET_ORDER_PROVISION_ITEMS';
 /*
  * Portfolio actions
  */

--- a/src/redux/actions/order-actions.tsx
+++ b/src/redux/actions/order-actions.tsx
@@ -228,3 +228,31 @@ export const fetchApprovalRequests = (orderItemId: string) => (
       })
     );
 };
+
+export const fetchOrderProvision = (orderId: string) => (
+  dispatch: Dispatch
+): Promise<{
+  type: string;
+  payload: {
+    orderItems: OrderItem[] | [];
+    progressMessages: ProgressMessage[] | [];
+  };
+}> => {
+  dispatch({ type: `${ActionTypes.SET_ORDER_PROVISION_ITEMS}_PENDING` });
+  return OrderHelper.getOrderProvisionItems(orderId)
+    .then(({ orderItems, progressMessages }) =>
+      dispatch({
+        type: `${ActionTypes.SET_ORDER_PROVISION_ITEMS}_FULFILLED`,
+        payload: {
+          orderItems,
+          progressMessages
+        }
+      })
+    )
+    .catch((error) =>
+      dispatch({
+        type: `${ActionTypes.SET_ORDER_PROVISION_ITEMS}_REJECTED`,
+        payload: error
+      })
+    );
+};

--- a/src/redux/reducers/order-reducer.ts
+++ b/src/redux/reducers/order-reducer.ts
@@ -5,7 +5,8 @@ import {
   PortfolioItem,
   Portfolio,
   OrderItem,
-  ApprovalRequest
+  ApprovalRequest,
+  ProgressMessage
 } from '@redhat-cloud-services/catalog-client';
 import { Source } from '@redhat-cloud-services/sources-client';
 import {
@@ -39,6 +40,12 @@ export interface OrderDetail extends AnyObject {
   platform: Full<Source> & Partial<ObjectNotFound>;
   portfolio: Full<Portfolio> & Partial<ObjectNotFound>;
 }
+
+export interface OrderProvisionType extends AnyObject {
+  orderItems: Full<OrderItem>[];
+  progressMessages: Full<ProgressMessage>[];
+}
+
 export interface OrderReducerState extends AnyObject {
   servicePlans: ServicePlan[];
   selectedPlan: ServicePlan;
@@ -46,6 +53,7 @@ export interface OrderReducerState extends AnyObject {
   requests: Request[];
   orderDetail: OrderDetail;
   orders: ApiCollectionResponse<OrderDetail>;
+  orderProvision: OrderProvisionType;
 }
 // Initial State
 export const orderInitialState: OrderReducerState = {
@@ -58,6 +66,10 @@ export const orderInitialState: OrderReducerState = {
     portfolioItem: {} as Full<PortfolioItem>,
     platform: {} as Full<Source>,
     portfolio: {} as Full<Portfolio>
+  },
+  orderProvision: {
+    orderItems: [] as Full<OrderItem>[],
+    progressMessages: [] as Full<ProgressMessage>[]
   },
   orders: {
     data: [],

--- a/src/redux/reducers/order-reducer.ts
+++ b/src/redux/reducers/order-reducer.ts
@@ -21,8 +21,10 @@ import {
   SET_ORDERS,
   FETCH_ORDERS,
   SET_ORDER_DETAIL,
-  FETCH_APPROVAL_REQUESTS
+  FETCH_APPROVAL_REQUESTS,
+  SET_ORDER_PROVISION_ITEMS
 } from '../action-types';
+
 import { defaultSettings } from '../../helpers/shared/pagination';
 import {
   ApiCollectionResponse,
@@ -139,6 +141,13 @@ const updateOrderApprovalRequests: OrderReducerActionHandler = (
     approvalRequest: payload
   }
 });
+const setOrderProvisionItems: OrderReducerActionHandler = (
+  state,
+  { payload }
+) => ({
+  ...state,
+  orderProvision: payload
+});
 
 export default {
   [`${FETCH_SERVICE_PLANS}_PENDING`]: setLoadingState,
@@ -160,5 +169,7 @@ export default {
   [SET_ORDERS]: setOrders,
   [`${SET_ORDER_DETAIL}_FULFILLED`]: setOrderDetail,
   [SET_ORDER_DETAIL]: setOrderDetail,
-  [`${FETCH_APPROVAL_REQUESTS}_FULFILLED`]: updateOrderApprovalRequests
+  [`${FETCH_APPROVAL_REQUESTS}_FULFILLED`]: updateOrderApprovalRequests,
+  [`${SET_ORDER_PROVISION_ITEMS}_FULFILLED`]: setOrderProvisionItems,
+  [SET_ORDER_PROVISION_ITEMS]: setOrderProvisionItems
 };

--- a/src/smart-components/order/order-detail/order-detail-menu.tsx
+++ b/src/smart-components/order/order-detail/order-detail-menu.tsx
@@ -45,6 +45,10 @@ const useNavItems = (
     title: formatMessage(ordersMessages.menuApproval)
   },
   {
+    link: '/provision',
+    title: formatMessage(ordersMessages.menuProvision)
+  },
+  {
     link: '/lifecycle',
     title: formatMessage(ordersMessages.menuLifecycle),
     isDisabled: state !== 'Completed' && state !== 'Ordered'

--- a/src/smart-components/order/order-detail/order-detail.tsx
+++ b/src/smart-components/order/order-detail/order-detail.tsx
@@ -36,6 +36,9 @@ const ApprovalRequests = lazy(() =>
 const OrderLifecycle = lazy(() =>
   import(/* webpackChunkName: "order-lifecycle" */ './order-lifecycle')
 );
+const OrderProvision = lazy(() =>
+  import(/* webpackChunkName: "order-lifecycle" */ './order-provision')
+);
 const OrderDetails = lazy(() =>
   import(/* webpackChunkName: "order-details" */ './order-details')
 );
@@ -167,6 +170,9 @@ const OrderDetail: React.ComponentType = () => {
                     path={`${ORDER_ROUTE}/approval`}
                     component={ApprovalRequests}
                   />
+                  <Route path={`${ORDER_ROUTE}/provision`}>
+                    <OrderProvision />
+                  </Route>
                   <Route path={`${ORDER_ROUTE}/lifecycle`}>
                     <OrderLifecycle />
                   </Route>

--- a/src/smart-components/order/order-detail/order-detail.tsx
+++ b/src/smart-components/order/order-detail/order-detail.tsx
@@ -37,7 +37,7 @@ const OrderLifecycle = lazy(() =>
   import(/* webpackChunkName: "order-lifecycle" */ './order-lifecycle')
 );
 const OrderProvision = lazy(() =>
-  import(/* webpackChunkName: "order-lifecycle" */ './order-provision')
+  import(/* webpackChunkName: "order-provision" */ './order-provision')
 );
 const OrderDetails = lazy(() =>
   import(/* webpackChunkName: "order-details" */ './order-details')

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -39,7 +39,6 @@ import {
 } from '@redhat-cloud-services/catalog-client';
 import { FormatMessage } from '../../../types/common-types';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/cjs/DateFormat';
-import { fetchPortfolioItem } from '../../../helpers/portfolio/portfolio-helper';
 
 /**
  * We are using type conversion of **request as StringObject** because the generated client does not have correct states listed
@@ -100,7 +99,6 @@ const OrderProvision: React.ComponentType = () => {
     orderItemName: string,
     formatMessage: FormatMessage
   ): { title: ReactNode }[] => {
-    console.log('Debug - createRow for item', item);
     const translatableState = getTranslatableState(
       item.state as OrderItemStateEnum
     );
@@ -115,14 +113,14 @@ const OrderProvision: React.ComponentType = () => {
       {
         title: (
           <Text className="pf-u-mb-0" component={TextVariants.small}>
-            <TableText>{capitalize(item.process_scope) as any}</TableText>
+            <TableText>{capitalize(item.process_scope)}</TableText>
           </Text>
         )
       },
       {
         title: (
           <Text className="pf-u-mb-0" component={TextVariants.small}>
-            <TableText>{capitalize(orderItemName) as any}</TableText>
+            <TableText>{orderItemName}</TableText>
           </Text>
         )
       },
@@ -144,15 +142,10 @@ const OrderProvision: React.ComponentType = () => {
     ];
   };
 
-  const rows = orderProvision.orderItems.map(async (item) => {
+  const rows = orderProvision.orderItems.map((item) => {
     //const { orderProgressMessages } = getOrderProgressMessage(item);
-    const portfolioItem = await fetchPortfolioItem(item.portfolio_item_id);
-    const orderItemName = portfolioItem ? portfolioItem.name : '';
-    const testOrder = createOrderItemRow(
-      item,
-      orderItemName || '',
-      formatMessage
-    );
+    const orderItemName = `Order item ${item.id}`;
+    const testOrder = createOrderItemRow(item, orderItemName, formatMessage);
     console.log('Debug - testOrder:', testOrder);
     return testOrder;
   });

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -145,12 +145,9 @@ const OrderProvision: React.ComponentType = () => {
   const rows = orderProvision.orderItems.map((item) => {
     //const { orderProgressMessages } = getOrderProgressMessage(item);
     const orderItemName = `Order item ${item.id}`;
-    const testOrder = createOrderItemRow(item, orderItemName, formatMessage);
-    console.log('Debug - testOrder:', testOrder);
-    return testOrder;
+    return createOrderItemRow(item, orderItemName, formatMessage);
   });
 
-  console.log('Debug - orderProvision.orderItems, rows: ', rows);
   return (
     <TextContent>
       {isFetching ? (

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -1,0 +1,209 @@
+import React, { Fragment, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Bullseye,
+  Card,
+  CardBody,
+  Flex,
+  Spinner,
+  Text,
+  TextContent,
+  TextVariants,
+  Title
+} from '@patternfly/react-core';
+
+import {
+  ISortBy,
+  sortable,
+  SortByDirection,
+  Table,
+  TableBody,
+  TableHeader
+} from '@patternfly/react-table';
+
+import { DateFormat } from '@redhat-cloud-services/frontend-components/components/cjs/DateFormat';
+import InfoIcon from '@patternfly/react-icons/dist/js/icons/info-icon';
+import { fetchOrderProvision } from '../../../redux/actions/order-actions';
+import ordersMessages from '../../../messages/orders.messages';
+import statesMessages from '../../../messages/states.messages';
+import useFormatMessage from '../../../utilities/use-format-message';
+import { AnyObject, ApiCollectionResponse } from '../../../types/common-types';
+import {
+  Order,
+  OrderItem,
+  OrderItemStateEnum
+} from '@redhat-cloud-services/catalog-client';
+import { CatalogRootState } from '../../../types/redux';
+import { CheckCircleIcon } from '@patternfly/react-icons';
+import { OrderProvisionPayload } from '../../../helpers/order/new-order-helper';
+import {OrderDetail, OrderProvisionType} from '../../../redux/reducers/order-reducer';
+
+/**
+ * We are using type conversion of **request as StringObject** because the generated client does not have correct states listed
+ * Probably a discrepancy inside the OpenAPI spec
+ */
+
+const rowOrder = ['updated_at', 'id', 'state'];
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const checkItems = async (
+  fetchItems: () => Promise<ApiCollectionResponse<any>>
+) => {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const result = await fetchItems();
+    if (result?.data.length > 0) {
+      return 'Finished';
+    }
+
+    await delay(3000);
+  }
+};
+
+const isEmpty = (orderProvision?: OrderProvisionType) =>
+  !orderProvision ||
+  !orderProvision.orderItems ||
+  orderProvision.orderItems.length === 0;
+
+const OrderProvision: React.ComponentType = () => {
+  const formatMessage = useFormatMessage();
+  const dispatch = useDispatch();
+  const [sortBy, setSortBy] = useState<ISortBy>({});
+  const { order } = useSelector<CatalogRootState, OrderDetail>(
+    ({ orderReducer: { orderDetail } }) => orderDetail
+  );
+
+  const orderProvision = useSelector<CatalogRootState, OrderProvisionType>(
+    ({ orderReducer: { orderProvision } }) => orderProvision
+  );
+  useEffect(() => {
+    if (order.state !== 'Failed' && order?.id && isEmpty(orderProvision)) {
+      checkItems(() =>
+        dispatch(
+          (fetchOrderProvision(order.id) as unknown) as Promise<
+            ApiCollectionResponse<OrderProvisionPayload>
+          >
+        )
+      );
+    }
+  }, []);
+
+  const handleSort = (
+    _e: React.SyntheticEvent,
+    index: number,
+    direction: SortByDirection
+  ) => setSortBy({ index, direction });
+
+  if (order.state === 'Failed' && isEmpty(orderProvision)) {
+    return (
+      <Bullseye id="no-order-provision">
+        <Flex direction={{ default: 'column' }} grow={{ default: 'grow' }}>
+          <Bullseye>
+            <InfoIcon size="xl" />
+          </Bullseye>
+          <Bullseye>
+            <Title headingLevel="h1" size="2xl">
+              {formatMessage(ordersMessages.noOrderProvision)}
+            </Title>
+          </Bullseye>
+        </Flex>
+      </Bullseye>
+    );
+  }
+
+  const columns = [
+    { title: 'Updated', transforms: [sortable] },
+    { title: 'Name', transforms: [sortable] },
+    'Status'
+  ];
+
+  const rows = orderProvision?.orderItems
+    ? orderProvision?.orderItems
+        .map((item: OrderItem) =>
+          rowOrder.map((key) => {
+            if (key === 'state') {
+              return (
+                <Fragment>
+                  {(item as OrderItem)[key] ===
+                    OrderItemStateEnum.Completed && (
+                    <Fragment>
+                      <CheckCircleIcon color="var(--pf-global--success-color--100)" />
+                      &nbsp;
+                    </Fragment>
+                  )}
+                  {formatMessage(
+                    statesMessages[
+                      ((item as OrderItem)[
+                        key
+                      ] as unknown) as keyof typeof statesMessages
+                    ]
+                  )}
+                </Fragment>
+              );
+            }
+
+            if (key === 'updated_at') {
+              /**
+               * The fragment here is required other wise the super smart PF table will delete the first React element
+               */
+              return (
+                <Fragment>
+                  <DateFormat date={(item as OrderItem)[key]} type="exact" />
+                </Fragment>
+              );
+            }
+
+            return (item as AnyObject)[key];
+          })
+        )
+        .sort((a: AnyObject, b: AnyObject) =>
+          a[sortBy.index!] < b[sortBy.index!]
+            ? -1
+            : a[sortBy.index!] < b[sortBy.index!]
+            ? 1
+            : 0
+        ) || []
+    : [];
+
+  return (
+    <TextContent>
+      {isEmpty(orderProvision) ? (
+        <Bullseye>
+          <Flex direction={{ default: 'column' }} grow={{ default: 'grow' }}>
+            <Bullseye id="fetching-order-provision">
+              <Title headingLevel="h1" size="xl">
+                {formatMessage(ordersMessages.fetchingOrderProvision)}
+              </Title>
+            </Bullseye>
+            <Bullseye>
+              <Spinner size="xl" />
+            </Bullseye>
+          </Flex>
+        </Bullseye>
+      ) : (
+        <Card>
+          <CardBody>
+            <Text className="pf-u-mb-md" component={TextVariants.h2}>
+              {formatMessage(ordersMessages.activity)}
+            </Text>
+            <Table
+              aria-label="Order provisioning activity"
+              onSort={handleSort}
+              sortBy={sortBy}
+              cells={columns}
+              rows={
+                sortBy.direction === SortByDirection.asc ? rows : rows.reverse()
+              }
+            >
+              <TableHeader />
+              <TableBody />
+            </Table>
+          </CardBody>
+        </Card>
+      )}
+    </TextContent>
+  );
+};
+
+export default OrderProvision;

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -143,7 +143,6 @@ const OrderProvision: React.ComponentType = () => {
   };
 
   const rows = orderProvision.orderItems.map((item) => {
-    //const { orderProgressMessages } = getOrderProgressMessage(item);
     const orderItemName = `Order item ${item.id}`;
     return createOrderItemRow(item, orderItemName, formatMessage);
   });

--- a/src/test/smart-components/order/__snapshots__/order-provision.test.js.snap
+++ b/src/test/smart-components/order/__snapshots__/order-provision.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Orders /> should render correctly 1`] = `
+<Stack>
+  <ToolbarRenderer
+    schema={
+      Object {
+        "fields": Array [
+          Object {
+            "className": "orders pf-u-p-lg",
+            "component": "TopToolbar",
+            "fields": Array [
+              Object {
+                "className": "",
+                "component": "TopToolbarTitle",
+                "key": "orders-toolbar-title",
+                "title": "Orders",
+              },
+            ],
+            "key": "orders-toolbar",
+          },
+        ],
+      }
+    }
+  />
+  <OrdersList />
+</Stack>
+`;
+
+exports[`<Orders /> should render correctly in loading state 1`] = `
+<Stack>
+  <ToolbarRenderer
+    schema={
+      Object {
+        "fields": Array [
+          Object {
+            "className": "orders pf-u-p-lg",
+            "component": "TopToolbar",
+            "fields": Array [
+              Object {
+                "className": "",
+                "component": "TopToolbarTitle",
+                "key": "orders-toolbar-title",
+                "title": "Orders",
+              },
+            ],
+            "key": "orders-toolbar",
+          },
+        ],
+      }
+    }
+  />
+  <OrdersList />
+</Stack>
+`;

--- a/src/test/smart-components/order/order-provision.test.js
+++ b/src/test/smart-components/order/order-provision.test.js
@@ -1,0 +1,248 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+import { shallow, mount } from 'enzyme';
+import configureStore from 'redux-mock-store';
+import { shallowToJson } from 'enzyme-to-json';
+import { MemoryRouter, Route } from 'react-router-dom';
+import promiseMiddleware from 'redux-promise-middleware';
+
+import Orders from '../../../smart-components/order/orders';
+import { orderInitialState } from '../../../redux/reducers/order-reducer';
+import { portfoliosInitialState } from '../../../redux/reducers/portfolio-reducer';
+import {
+  CATALOG_API_BASE,
+  SOURCES_API_BASE
+} from '../../../utilities/constants';
+import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications/';
+import { SET_PORTFOLIO_ITEMS, FETCH_ORDERS } from '../../../redux/action-types';
+import OrderProvision from '../../../smart-components/order/order-detail/order-provision';
+import {
+  mockApi,
+  mockGraphql
+} from '../../../helpers/shared/__mocks__/user-login';
+import { IntlProvider } from 'react-intl';
+import { OrderItemStateEnum } from '@redhat-cloud-services/catalog-client';
+
+describe('<Orders />', () => {
+  let initialProps;
+  const middlewares = [thunk, promiseMiddleware, notificationsMiddleware()];
+  let mockStore;
+  let initialState;
+
+  const createDate = new Date(Date.UTC(2019, 5, 1, 0));
+
+  const orderReducer = {
+    orderProvision: {
+      orderItems: [
+        {
+          updated_at: createDate.toString(),
+          state: OrderItemStateEnum.Completed,
+          service_parameters: {}
+        }
+      ]
+    },
+    portfolioItem: {
+      name: 'Portfolio item name',
+      id: 'portfolio-item-id',
+      updated_at: createDate.toString()
+    },
+    order: {
+      id: '123',
+      state: 'Completed',
+      created_at: createDate.toString(),
+      owner: 'hula hup'
+    },
+    platform: {
+      id: '123',
+      source_type_id: '3',
+      name: 'Super platform'
+    },
+    portfolio: {
+      name: 'Portfolio name'
+    },
+    orderItem: {
+      updated_at: createDate.toString(),
+      service_parameters: {}
+    },
+    progressMessages: {
+      data: []
+    }
+  };
+
+  const ComponentWrapper = ({ store, children, ...props }) => (
+    <IntlProvider locale="en">
+      <Provider store={store}>
+        <MemoryRouter {...props}>{children}</MemoryRouter>
+      </Provider>
+    </IntlProvider>
+  );
+
+  beforeEach(() => {
+    initialProps = {};
+    mockStore = configureStore(middlewares);
+    initialState = {
+      i18nReducer: {
+        formatMessage: ({ defaultMessage }) => defaultMessage
+      },
+      breadcrumbsReducer: { fragments: [] },
+      orderReducer: { ...orderInitialState, isLoading: false },
+      portfolioReducer: { ...portfoliosInitialState, isLoading: false },
+      platformReducer: { platformIconMapping: {} }
+    };
+  });
+
+  it('should render correctly', () => {
+    const store = mockStore(initialState);
+    const wrapper = shallow(<Orders store={store} {...initialProps} />);
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render correctly in loading state', () => {
+    const store = mockStore(initialState);
+    const wrapper = shallow(
+      <Orders store={store} {...initialProps} isLoading />
+    );
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should mount and render orders list component and paginate correctly', async () => {
+    jest.useFakeTimers();
+    const orderItemsPagination = { ...orderReducer };
+    orderItemsPagination.orders = {
+      meta: {
+        limit: 50,
+        offset: 0,
+        count: 120
+      },
+      data: [...Array(10)].map((item, index) => ({
+        id: `order-${index}`,
+        state: 'undecided',
+        orderItems: [
+          {
+            id: `order-item-${index}`
+          }
+        ]
+      }))
+    };
+    const store = mockStore({
+      ...initialState,
+      orderReducer: { ...orderInitialState, ...orderItemsPagination }
+    });
+
+    mockApi
+      .onGet(
+        `${CATALOG_API_BASE}/orders?&sort_by=id:descfilter[state][contains_i]=&limit=50&offset=0`
+      )
+      .replyOnce(200, { data: [] });
+    mockApi
+      .onGet(`${CATALOG_API_BASE}/portfolio_items?`)
+      .replyOnce(200, { data: [] });
+    mockApi
+      .onGet(`${CATALOG_API_BASE}/order_items?`)
+      .replyOnce(200, { data: [] });
+    mockGraphql.onPost(`${SOURCES_API_BASE}/graphql`).replyOnce(200, {
+      data: {
+        application_types: [
+          {
+            sources: [
+              {
+                id: '1',
+                name: 'Source 1'
+              }
+            ]
+          }
+        ]
+      }
+    });
+    /**
+     * Pagination requests
+     */
+    mockApi
+      .onGet(`${CATALOG_API_BASE}/orders?&sort_by=id:desc&limit=50&offset=100`)
+      .replyOnce(200, { data: [] });
+    let wrapper;
+    await act(async () => {
+      wrapper = mount(
+        <ComponentWrapper store={store} initialEntries={['/orders']}>
+          <Route path="/orders">
+            <Orders />
+          </Route>
+        </ComponentWrapper>
+      );
+    });
+    await act(async () => {
+      wrapper.update();
+    });
+
+    store.clearActions();
+    await act(async () => {
+      wrapper
+        .find('button[data-action="last"]')
+        .first()
+        .simulate('click');
+    });
+    /**
+     * wait for the debounce to run
+     */
+    await act(async () => {
+      jest.runAllTimers();
+      wrapper.update();
+    });
+    expect(store.getActions()).toEqual([
+      { type: `${FETCH_ORDERS}_PENDING` },
+      { type: SET_PORTFOLIO_ITEMS, payload: { data: [] } },
+      {
+        type: `${FETCH_ORDERS}_FULFILLED`,
+        meta: {
+          filter: '&sort_by=id:desc',
+          filters: {
+            owner: '',
+            state: []
+          },
+          limit: 50,
+          offset: 100,
+          sortBy: 'id',
+          sortDirection: 'desc',
+          sortIndex: 0,
+          stateKey: 'orders',
+          storeState: true
+        },
+        payload: { data: [] }
+      }
+    ]);
+  });
+
+  it('should mount and render order provision component', async (done) => {
+    const store = mockStore({
+      ...initialState,
+      orderReducer: { ...orderInitialState, ...orderReducer }
+    });
+
+    mockApi
+      .onGet(`${CATALOG_API_BASE}/orders/123`)
+      .replyOnce(200, { data: [{ id: 123 }] });
+    let wrapper;
+    await act(async () => {
+      wrapper = mount(
+        <ComponentWrapper
+          store={store}
+          initialEntries={[
+            '/order?order=123&order-item=order-item-id&portfolio-item=portfolio-item-id&platform=platform-id&portfolio=portfolio-id'
+          ]}
+        >
+          <Route path="/order">
+            <OrderProvision />
+          </Route>
+        </ComponentWrapper>
+      );
+    });
+    await act(async () => {
+      wrapper.update();
+    });
+
+    expect(wrapper.find(OrderProvision)).toHaveLength(1);
+    done();
+  });
+});


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/SSP-1918
 - part 1 - show before/after/( if any) and product  order items in the provisioning tab
( part 2 - add progress messages for each - in the next PR)

![Screenshot from 2020-11-04 15-17-41](https://user-images.githubusercontent.com/12769982/98165329-b172c480-1eb3-11eb-9751-5fd5c7eea4b5.png)
