### PR TITLE
Add progress messages to provision tab

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -141,7 +141,7 @@
       "error",
       "never"
     ],
-    "react/prop-types": 2,
+    "react/prop-types": 1,
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-use-before-define": [1]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2308,9 +2308,9 @@
       }
     },
     "@redhat-cloud-services/catalog-client": {
-      "version": "1.0.84",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/catalog-client/-/catalog-client-1.0.84.tgz",
-      "integrity": "sha512-2frSArpV/GCOtWdwqEai827bjVjKOpslRATvF/LIcFeMd2Ptzap1emxm0CsAupaboAIuzHtVrzEe1Gb6sQHPyg==",
+      "version": "1.0.85",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/catalog-client/-/catalog-client-1.0.85.tgz",
+      "integrity": "sha512-c4F/CykouQiFpIiRQ5mHQD1SFdqtI1QLY6YM/hmiNx8TxwOwcoYh6TTmTNPdJ/SEWCcRlr1m/fma82vJtfKbUQ==",
       "requires": {
         "axios": "^0.19.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2255,26 +2255,26 @@
       "integrity": "sha512-+IfOc0E440Q61IYQZbux7pwcLf7JWQd1rOs2DDWnoVaw82zr/BZMtGh9T2kcklcH7TUHavSyF6tlCgU40IQ/4g=="
     },
     "@patternfly/react-table": {
-      "version": "4.19.5",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.19.5.tgz",
-      "integrity": "sha512-Fccvn6RicC1fxvZQ/kbZfysdnbGf37B+1AOAeSVSaKcYTnLI7lVTfsWqUqAz2vg0c7+q+IBD8wLsl/djWBs8IA==",
+      "version": "4.19.13",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.19.13.tgz",
+      "integrity": "sha512-quDj69aP+9dZ6K0JNQsTLTp/yww2dD1uoSJKrtUuIkeUp+/nF2ANNEJMQj0NTBCeQozhEnyD4myDQr/L9Jo5ZA==",
       "requires": {
         "@patternfly/patternfly": "4.59.1",
-        "@patternfly/react-core": "^4.75.2",
+        "@patternfly/react-core": "^4.75.9",
         "@patternfly/react-icons": "^4.7.16",
-        "@patternfly/react-styles": "^4.7.12",
+        "@patternfly/react-styles": "^4.7.13",
         "@patternfly/react-tokens": "^4.9.16",
         "lodash": "^4.17.19",
         "tslib": "1.13.0"
       },
       "dependencies": {
         "@patternfly/react-core": {
-          "version": "4.75.2",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.75.2.tgz",
-          "integrity": "sha512-hoCeTahVgl5I0jA74/so2bZL1eabSD2Uwt8uYgz+W+ShYAC4rJreLOVn43I15J5VPpwIvxrbubccpBqCGL2+wA==",
+          "version": "4.75.9",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.75.9.tgz",
+          "integrity": "sha512-x4O9wE/XnVyhJAL6k5vkBb8qvwXccMEqM/mtOkQimLjNQ5CoUOi/Omdtfi3RBv2RH+hFxgSDTPp+pPkGqqENTQ==",
           "requires": {
             "@patternfly/react-icons": "^4.7.16",
-            "@patternfly/react-styles": "^4.7.12",
+            "@patternfly/react-styles": "^4.7.13",
             "@patternfly/react-tokens": "^4.9.16",
             "focus-trap": "4.0.2",
             "react-dropzone": "9.0.0",
@@ -2282,15 +2282,10 @@
             "tslib": "1.13.0"
           }
         },
-        "@patternfly/react-icons": {
-          "version": "4.7.16",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.7.16.tgz",
-          "integrity": "sha512-g1RsaGy/FRsHINdHpHR9RNhC72qs5W/0wIUQVB0HPtCrXdr1UfJCh03RRIhixfGPQDYgw9Ou3j3rARljhwUPUw=="
-        },
         "@patternfly/react-styles": {
-          "version": "4.7.12",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.7.12.tgz",
-          "integrity": "sha512-+IfOc0E440Q61IYQZbux7pwcLf7JWQd1rOs2DDWnoVaw82zr/BZMtGh9T2kcklcH7TUHavSyF6tlCgU40IQ/4g=="
+          "version": "4.7.13",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.7.13.tgz",
+          "integrity": "sha512-vtvHyzbSlWySEafAonbZjzxqpP+7K/hlC8hyZuXaCdwmBPLr0ho7hCpkIepdEGYND+XSeEjnNT/nlP07gnij7w=="
         },
         "@patternfly/react-tokens": {
           "version": "4.9.16",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-styles": "^4.7.12",
     "@patternfly/react-table": "^4.19.13",
     "@redhat-cloud-services/approval-client": "^1.0.74",
-    "@redhat-cloud-services/catalog-client": "^1.0.84",
+    "@redhat-cloud-services/catalog-client": "^1.0.85",
     "@redhat-cloud-services/frontend-components": "^2.4.19",
     "@redhat-cloud-services/frontend-components-notifications": "^2.2.3",
     "@redhat-cloud-services/frontend-components-utilities": "^2.2.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@patternfly/react-core": "^4.63.3",
     "@patternfly/react-icons": "^4.7.16",
     "@patternfly/react-styles": "^4.7.12",
-    "@patternfly/react-table": "^4.19.5",
+    "@patternfly/react-table": "^4.19.13",
     "@redhat-cloud-services/approval-client": "^1.0.74",
     "@redhat-cloud-services/catalog-client": "^1.0.84",
     "@redhat-cloud-services/frontend-components": "^2.4.19",

--- a/src/helpers/order/new-order-helper.ts
+++ b/src/helpers/order/new-order-helper.ts
@@ -136,6 +136,22 @@ export const fetchOrderProvisionItems = async (
     }
   }
 
-  const progressMessages: ProgressMessage[] | [] = [];
-  return { orderItems, progressMessages };
+  const promises = orderItems.map((orderItem) =>
+    axiosInstance.get(
+      `${CATALOG_API_BASE}/order_items/${orderItem.id}/progress_messages`
+    )
+  );
+
+  return Promise.all(promises).then((itemMessages) => {
+    console.log('Debug - itemMessages, orderItems', itemMessages, orderItems);
+    const progressMessages = itemMessages.reduce(
+      (acc, curr) => ({
+        ...acc,
+        ...curr.data
+      }),
+      {}
+    );
+    console.log('Debug - progressMessages', progressMessages);
+    return { orderItems, progressMessages };
+  });
 };

--- a/src/helpers/order/new-order-helper.ts
+++ b/src/helpers/order/new-order-helper.ts
@@ -123,7 +123,6 @@ export const fetchOrderProvisionItems = async (
       `${CATALOG_API_BASE}/order_items/?order_id=${orderId}`
     );
     orderItems = items.data;
-    console.log('Debug - orderItems: items, orderItems', items, orderItems);
   } catch (error) {
     orderItems = [];
     if (error.status === 404 || error.status === 400) {
@@ -143,7 +142,6 @@ export const fetchOrderProvisionItems = async (
   );
 
   return Promise.all(promises).then((itemMessages) => {
-    console.log('Debug - itemMessages, orderItems', itemMessages, orderItems);
     const progressMessages = itemMessages.reduce(
       (acc, curr) => ({
         ...acc,
@@ -151,7 +149,6 @@ export const fetchOrderProvisionItems = async (
       }),
       {}
     );
-    console.log('Debug - progressMessages', progressMessages);
     return { orderItems, progressMessages };
   });
 };

--- a/src/helpers/order/order-helper.ts
+++ b/src/helpers/order/order-helper.ts
@@ -301,7 +301,6 @@ export const getOrderProvisionItems = async (
   orderId: string
 ): Promise<OrderProvisionPayload> => {
   const items = await fetchOrderProvisionItems(orderId);
-  console.log('debug - fetchOPItems returns: ', items);
   return items;
 };
 

--- a/src/helpers/order/order-helper.ts
+++ b/src/helpers/order/order-helper.ts
@@ -30,9 +30,10 @@ import {
   Order,
   OrderItem,
   PortfolioItem,
-  ApprovalRequest
+  ApprovalRequest,
+  ProgressMessage
 } from '@redhat-cloud-services/catalog-client';
-import { AxiosPromise } from 'axios';
+import { AxiosPromise, AxiosResponse } from 'axios';
 import { AnyObject } from '@data-driven-forms/react-form-renderer';
 import { Request, Action } from '@redhat-cloud-services/approval-client';
 
@@ -296,8 +297,21 @@ export const getApprovalRequests = (
       });
     });
 
-export const getOrderProvisionItems = (
+export const getOrderProvisionItems = async (
   orderId: string
 ): Promise<OrderProvisionPayload> => {
-  return fetchOrderProvisionItems(orderId);
+  const items = await fetchOrderProvisionItems(orderId);
+  console.log('debug - fetchOPItems returns: ', items);
+  return items;
 };
+
+export const getProgressMessages = (
+  orderItemId: string
+): Promise<{
+  data: ProgressMessage[];
+}> =>
+  axiosInstance
+    .get(`${CATALOG_API_BASE}/order_items/${orderItemId}/progress_messages`)
+    .then(({ data }: { data: Full<ProgressMessage>[] }) => {
+      return { data: data || [] };
+    });

--- a/src/helpers/order/order-helper.ts
+++ b/src/helpers/order/order-helper.ts
@@ -33,7 +33,7 @@ import {
   ApprovalRequest,
   ProgressMessage
 } from '@redhat-cloud-services/catalog-client';
-import { AxiosPromise, AxiosResponse } from 'axios';
+import { AxiosPromise } from 'axios';
 import { AnyObject } from '@data-driven-forms/react-form-renderer';
 import { Request, Action } from '@redhat-cloud-services/approval-client';
 

--- a/src/messages/orders.messages.ts
+++ b/src/messages/orders.messages.ts
@@ -101,12 +101,16 @@ const ordersMessages = defineMessages({
     id: 'orders.order.provision.parameters',
     defaultMessage: 'Parameters'
   },
+  defaultOrderItemType: {
+    id: 'orders.order.default_type',
+    defaultMessage: 'Product'
+  },
   orderProgressMessages: {
     id: 'orders.order.detail.messages',
     defaultMessage: 'Progress messages'
   },
   lifecycleLink: {
-    id: 'orders.order.lifecicle.link',
+    id: 'orders.order.lifecycle.link',
     defaultMessage: 'Manage product'
   },
   cancelOrder: {

--- a/src/messages/orders.messages.ts
+++ b/src/messages/orders.messages.ts
@@ -97,6 +97,10 @@ const ordersMessages = defineMessages({
     id: 'orders.order.detail.parameters',
     defaultMessage: 'Order parameters'
   },
+  orderItemParameters: {
+    id: 'orders.order.provision.parameters',
+    defaultMessage: 'Parameters'
+  },
   orderProgressMessages: {
     id: 'orders.order.detail.messages',
     defaultMessage: 'Progress messages'

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -124,7 +124,6 @@ const OrderProvision: React.ComponentType = () => {
           </Text>
         )
       },
-
       {
         title: (
           <TableText>

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -81,7 +81,7 @@ const OrderProvision: React.ComponentType = () => {
     'catalog:order_processes:link'
   ]);
 
-  if (order.state === 'Failed' && isEmpty(orderProvision)) {
+  if (!isFetching && isEmpty(orderProvision)) {
     return (
       <Bullseye id="no-order-provision">
         <Flex direction={{ default: 'column' }} grow={{ default: 'grow' }}>
@@ -101,7 +101,10 @@ const OrderProvision: React.ComponentType = () => {
   const capitalize = (str: any) => str?.charAt(0).toUpperCase() + str?.slice(1);
 
   const columns: Array<ICell> = [
-    { title: 'Updated', cellFormatters: [expandable] },
+    {
+      title: 'Updated',
+      cellFormatters: showProgressMessages ? [expandable] : []
+    },
     { title: 'Type' },
     { title: 'Activity' },
     { title: 'State' }
@@ -280,7 +283,7 @@ const OrderProvision: React.ComponentType = () => {
               aria-label="Order provisioning activity"
               cells={columns}
               rows={rows}
-              onCollapse={onCollapse}
+              onCollapse={showProgressMessages ? onCollapse : undefined}
             >
               <TableHeader />
               <TableBody />

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -94,56 +94,138 @@ const OrderProvision: React.ComponentType = () => {
     { title: 'State' }
   ];
 
-  const createOrderItemRow = (
+  const createOrderItemMainRow = (
     item: OrderItem,
     orderItemName: string,
     formatMessage: FormatMessage
-  ): { title: ReactNode }[] => {
+  ): {
+    isOpen: boolean;
+    cells: (
+      | { title: any }
+      | { title: any }
+      | { title: any }
+      | { title: any }
+    )[];
+  } => {
     const translatableState = getTranslatableState(
       item.state as OrderItemStateEnum
     );
+    return {
+      isOpen: false,
+      cells: [
+        {
+          title: (
+            <Text className="pf-u-mb-0" component={TextVariants.small}>
+              <DateFormat date={item.updated_at} type="exact" />
+            </Text>
+          )
+        },
+        {
+          title: (
+            <Text className="pf-u-mb-0" component={TextVariants.small}>
+              <TableText>{capitalize(item.process_scope)}</TableText>
+            </Text>
+          )
+        },
+        {
+          title: (
+            <Text className="pf-u-mb-0" component={TextVariants.small}>
+              <TableText>{orderItemName}</TableText>
+            </Text>
+          )
+        },
+        {
+          title: (
+            <TableText>
+              <Label
+                {...orderStatusMapper[
+                  item.state as keyof typeof orderStatusMapper
+                ]}
+                variant="outline"
+              >
+                {formatMessage(statesMessages[translatableState])}
+              </Label>
+            </TableText>
+          )
+        }
+      ]
+    };
+  };
+
+  const createOrderItemExpandedRow = (
+    item: OrderItem,
+    key: number,
+    orderItemName: string,
+    formatMessage: FormatMessage
+  ): {
+    isOpen: boolean;
+    cells: (
+      | { title: any }
+      | { title: any }
+      | { title: any }
+      | { title: any }
+    )[];
+  } => {
+    const translatableState = getTranslatableState(
+      item.state as OrderItemStateEnum
+    );
+    return {
+      isOpen: false,
+      cells: [
+        {
+          title: (
+            <Text className="pf-u-mb-0" component={TextVariants.small}>
+              <DateFormat date={item.updated_at} type="exact" />
+            </Text>
+          )
+        },
+        {
+          title: (
+            <Text className="pf-u-mb-0" component={TextVariants.small}>
+              <TableText>{capitalize(item.process_scope)}</TableText>
+            </Text>
+          )
+        },
+        {
+          title: (
+            <Text className="pf-u-mb-0" component={TextVariants.small}>
+              <TableText>{orderItemName}</TableText>
+            </Text>
+          )
+        },
+        {
+          title: (
+            <TableText>
+              <Label
+                {...orderStatusMapper[
+                  item.state as keyof typeof orderStatusMapper
+                ]}
+                variant="outline"
+              >
+                {formatMessage(statesMessages[translatableState])}
+              </Label>
+            </TableText>
+          )
+        }
+      ]
+    };
+  };
+
+  const createOrderItemRow = (
+    item: OrderItem,
+    key: number,
+    orderItemName: string,
+    formatMessage: FormatMessage
+  ): { isOpen: boolean; cells: { title: any }[] }[] => {
     return [
-      {
-        title: (
-          <Text className="pf-u-mb-0" component={TextVariants.small}>
-            <DateFormat date={item.updated_at} type="exact" />
-          </Text>
-        )
-      },
-      {
-        title: (
-          <Text className="pf-u-mb-0" component={TextVariants.small}>
-            <TableText>{capitalize(item.process_scope)}</TableText>
-          </Text>
-        )
-      },
-      {
-        title: (
-          <Text className="pf-u-mb-0" component={TextVariants.small}>
-            <TableText>{orderItemName}</TableText>
-          </Text>
-        )
-      },
-      {
-        title: (
-          <TableText>
-            <Label
-              {...orderStatusMapper[
-                item.state as keyof typeof orderStatusMapper
-              ]}
-              variant="outline"
-            >
-              {formatMessage(statesMessages[translatableState])}
-            </Label>
-          </TableText>
-        )
-      }
+      createOrderItemMainRow(item, orderItemName, formatMessage),
+      createOrderItemExpandedRow(item, key, orderItemName, formatMessage)
     ];
   };
 
-  const rows = orderProvision.orderItems.map((item) => {
+  const rows = orderProvision.orderItems.map((item, key) => {
     const orderItemName = `Order item ${item.id}`;
-    return createOrderItemRow(item, orderItemName, formatMessage);
+    return createOrderItemRow(item, key, orderItemName, formatMessage);
   });
 
   return (

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -131,7 +131,12 @@ const OrderProvision: React.ComponentType = () => {
         {
           title: (
             <Text className="pf-u-mb-0" component={TextVariants.small}>
-              <TableText>{capitalize(item.process_scope)}</TableText>
+              <TableText>
+                {capitalize(
+                  item.process_scope ||
+                    formatMessage(ordersMessages.defaultOrderItemType)
+                )}
+              </TableText>
             </Text>
           )
         },

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -174,11 +174,20 @@ const OrderProvision: React.ComponentType = () => {
     };
   };
 
-  const createRows = (): RowType[] =>
-    orderProvision.orderItems.reduce((acc: RowType[], item: OrderItem, key) => {
-      return [
-        ...acc,
-        createOrderItemMainRow(item, `Order item ${item.id}`, formatMessage),
+  const createOrderRow = (
+    item: OrderItem,
+    orderItemName: string,
+    formatMessage: FormatMessage,
+    key: number
+  ): RowType[] => {
+    const orderRow = [
+      createOrderItemMainRow(item, orderItemName, formatMessage)
+    ];
+    if (
+      orderProvision.progressMessages &&
+      orderProvision.progressMessages.length > 0
+    ) {
+      orderRow.push(
         createOrderItemExpandedRow(
           item,
           Object.values(orderProvision.progressMessages).filter(
@@ -187,6 +196,17 @@ const OrderProvision: React.ComponentType = () => {
           formatMessage,
           key
         )
+      );
+    }
+
+    return orderRow;
+  };
+
+  const createRows = (): RowType[] =>
+    orderProvision.orderItems.reduce((acc: RowType[], item: OrderItem, key) => {
+      return [
+        ...acc,
+        ...createOrderRow(item, `Order item ${item.id}`, formatMessage, key)
       ];
     }, []);
 

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -16,7 +16,6 @@ import {
 import {
   expandable,
   ICell,
-  IExtraData,
   IRowData,
   Table,
   TableBody,
@@ -75,12 +74,6 @@ const OrderProvision: React.ComponentType = () => {
   const orderProvision = useSelector<CatalogRootState, OrderProvisionType>(
     ({ orderReducer: { orderProvision } }) => orderProvision
   );
-  useEffect(() => {
-    setIsFetching(true);
-    Promise.all([dispatch(fetchOrderProvision(order.id))]).then(() =>
-      setIsFetching(false)
-    );
-  }, []);
 
   if (order.state === 'Failed' && isEmpty(orderProvision)) {
     return (
@@ -199,10 +192,16 @@ const OrderProvision: React.ComponentType = () => {
 
   const [rows, setRows] = useState<RowType[]>(createRows());
 
+  useEffect(() => {
+    setIsFetching(true);
+    Promise.all([dispatch(fetchOrderProvision(order.id))]).then(() =>
+      setIsFetching(false)
+    );
+  }, []);
+
   useEffect((): void => {
-    console.log('Debug - setRows: rows', rows);
     setRows(createRows());
-  }, [orderProvision.orderItems]);
+  }, [orderProvision?.orderItems]);
 
   const setOpen = (data: RowType[], rowId: any) =>
     data.map((row) =>
@@ -221,18 +220,9 @@ const OrderProvision: React.ComponentType = () => {
     rowIndex: number,
     isOpen: boolean,
     rowData: IRowData,
-    extraData: IExtraData
   ): void => {
-    console.log(
-      'Debug - rowData, extraData, isOpen, rows',
-      rowData,
-      extraData,
-      isOpen,
-      rows
-    );
     const u_rows = setOpen(rows, rowData.id);
     setRows(u_rows);
-    console.log('Debug - new rows', rows);
   };
 
   return (

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -112,7 +112,6 @@ const OrderProvision: React.ComponentType = () => {
 
   const createOrderItemMainRow = (
     item: OrderItem,
-    orderItemName: string,
     formatMessage: FormatMessage
   ): RowType => {
     const translatableState = getTranslatableState(
@@ -139,7 +138,7 @@ const OrderProvision: React.ComponentType = () => {
         {
           title: (
             <Text className="pf-u-mb-0" component={TextVariants.small}>
-              <TableText>{orderItemName}</TableText>
+              <TableText>{item.name}</TableText>
             </Text>
           )
         },
@@ -185,13 +184,10 @@ const OrderProvision: React.ComponentType = () => {
 
   const createOrderRow = (
     item: OrderItem,
-    orderItemName: string,
     formatMessage: FormatMessage,
     key: number
   ): RowType[] => {
-    const orderRow = [
-      createOrderItemMainRow(item, orderItemName, formatMessage)
-    ];
+    const orderRow = [createOrderItemMainRow(item, formatMessage)];
     if (
       showProgressMessages &&
       orderProvision.progressMessages &&
@@ -214,12 +210,7 @@ const OrderProvision: React.ComponentType = () => {
 
   const createRows = (): RowType[] =>
     orderProvision.orderItems.reduce((acc: RowType[], item: OrderItem, key) => {
-      const row = createOrderRow(
-        item,
-        `Order item ${item.id}`,
-        formatMessage,
-        key
-      );
+      const row = createOrderRow(item, formatMessage, key);
       return [...acc, ...row];
     }, []);
 

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -219,7 +219,7 @@ const OrderProvision: React.ComponentType = () => {
     event: React.MouseEvent,
     rowIndex: number,
     isOpen: boolean,
-    rowData: IRowData,
+    rowData: IRowData
   ): void => {
     const u_rows = setOpen(rows, rowData.id);
     setRows(u_rows);

--- a/src/smart-components/order/order-detail/progress-messages.tsx
+++ b/src/smart-components/order/order-detail/progress-messages.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import PropTypes from 'Prop'
+import PropTypes from 'prop-types';
+
 import {
   TextContent,
   Text,
@@ -19,7 +20,6 @@ import {
   OrderItem,
   ProgressMessage
 } from '@redhat-cloud-services/catalog-client';
-import PropTypes from 'prop-types';
 
 export interface ProgressMessagesParams {
   orderItem: OrderItem;

--- a/src/smart-components/order/order-detail/progress-messages.tsx
+++ b/src/smart-components/order/order-detail/progress-messages.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
+import PropTypes from 'Prop'
 import {
   TextContent,
   Text,
@@ -18,6 +19,7 @@ import {
   OrderItem,
   ProgressMessage
 } from '@redhat-cloud-services/catalog-client';
+import PropTypes from 'prop-types';
 
 export interface ProgressMessagesParams {
   orderItem: OrderItem;
@@ -64,6 +66,12 @@ const ProgressMessages: React.ComponentType<ProgressMessagesParams> = ({
       </GridItem>
     </Grid>
   );
+};
+
+ProgressMessages.propTypes = {
+  orderItem: PropTypes.object,
+  progressMessages: PropTypes.object,
+  formatMessage: PropTypes.object
 };
 
 export default ProgressMessages;

--- a/src/smart-components/order/order-detail/progress-messages.tsx
+++ b/src/smart-components/order/order-detail/progress-messages.tsx
@@ -1,0 +1,64 @@
+import React, { ReactNode } from 'react';
+import {
+  TextContent,
+  Text,
+  TextVariants,
+  Grid,
+  Card,
+  CardBody,
+  GridItem,
+  Stack,
+  StackItem
+} from '@patternfly/react-core';
+
+import ReactJsonView from 'react-json-view';
+import ordersMessages from '../../../messages/orders.messages';
+import { FormatMessage } from '../../../types/common-types';
+import {
+  OrderItem,
+  ProgressMessage
+} from '@redhat-cloud-services/catalog-client';
+
+export interface ProgressMessagesParams {
+  orderItem: OrderItem;
+  progressMessages: ProgressMessage[];
+  formatMessage: FormatMessage;
+}
+
+const ProgressMessages: React.ComponentType<ProgressMessagesParams> = ({
+  orderItem,
+  progressMessages,
+  formatMessage
+}) => {
+  return (
+    <Grid hasGutter>
+      <GridItem md={12} lg={6} xl={4}>
+        <Stack hasGutter>
+          <StackItem>
+            <Card>
+              <CardBody>
+                {orderItem?.service_parameters && (
+                  <ReactJsonView src={orderItem.service_parameters} />
+                )}
+              </CardBody>
+            </Card>
+          </StackItem>
+        </Stack>
+      </GridItem>
+      <GridItem md={12} lg={6} xl={8}>
+        <Card>
+          <CardBody>
+            <TextContent>
+              <Text className="pf-u-mb-md" component={TextVariants.h2}>
+                {formatMessage(ordersMessages.orderProgressMessages)}
+              </Text>
+            </TextContent>
+            {<ReactJsonView src={progressMessages} />}
+          </CardBody>
+        </Card>
+      </GridItem>
+    </Grid>
+  );
+};
+
+export default ProgressMessages;

--- a/src/smart-components/order/order-detail/progress-messages.tsx
+++ b/src/smart-components/order/order-detail/progress-messages.tsx
@@ -37,6 +37,11 @@ const ProgressMessages: React.ComponentType<ProgressMessagesParams> = ({
           <StackItem>
             <Card>
               <CardBody>
+                <TextContent>
+                  <Text className="pf-u-mb-md" component={TextVariants.h2}>
+                    {formatMessage(ordersMessages.orderItemParameters)}
+                  </Text>
+                </TextContent>
                 {orderItem?.service_parameters && (
                   <ReactJsonView src={orderItem.service_parameters} />
                 )}

--- a/src/smart-components/order/order-detail/progress-messages.tsx
+++ b/src/smart-components/order/order-detail/progress-messages.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {
   TextContent,
@@ -66,12 +65,6 @@ const ProgressMessages: React.ComponentType<ProgressMessagesParams> = ({
       </GridItem>
     </Grid>
   );
-};
-
-ProgressMessages.propTypes = {
-  orderItem: PropTypes.object,
-  progressMessages: PropTypes.object,
-  formatMessage: PropTypes.object
 };
 
 export default ProgressMessages;


### PR DESCRIPTION
 Implements the expanded details for the Provision tab: https://issues.redhat.com/browse/SSP-1918

![Screenshot from 2020-11-09 10-01-14](https://user-images.githubusercontent.com/12769982/98558112-0b3c0b80-2273-11eb-8717-0090b14ba3d9.png)

![Screenshot from 2020-11-09 10-01-26](https://user-images.githubusercontent.com/12769982/98558130-0f682900-2273-11eb-8c38-d8bfeda37cb1.png)

Non - admin user - no expandable content with progress messages
![Screenshot from 2020-11-09 16-57-26](https://user-images.githubusercontent.com/12769982/98601449-11e77480-22ad-11eb-8faf-fcbaf8d05251.png)
