### PR TITLE
Separate progress messages for order items on fetch 

### DIFF
--- a/src/redux/actions/order-actions.tsx
+++ b/src/redux/actions/order-actions.tsx
@@ -25,7 +25,10 @@ import {
 } from '../../types/common-types';
 import { AsyncMiddlewareAction, GetReduxState } from '../../types/redux';
 import { Source } from '@redhat-cloud-services/sources-client';
-import { ObjectNotFound } from '../../helpers/order/new-order-helper';
+import {
+  ObjectNotFound,
+  ProgressMessageItem
+} from '../../helpers/order/new-order-helper';
 
 export const fetchServicePlans = (
   portfolioItemId: string
@@ -235,17 +238,17 @@ export const fetchOrderProvision = (orderId: string) => (
   type: string;
   payload: {
     orderItems: OrderItem[] | [];
-    progressMessages: ProgressMessage[] | [];
+    progressMessageItems: ProgressMessageItem[] | [];
   };
 }> => {
   dispatch({ type: `${ActionTypes.SET_ORDER_PROVISION_ITEMS}_PENDING` });
   return OrderHelper.getOrderProvisionItems(orderId)
-    .then(({ orderItems, progressMessages }) =>
+    .then(({ orderItems, progressMessageItems }) =>
       dispatch({
         type: `${ActionTypes.SET_ORDER_PROVISION_ITEMS}_FULFILLED`,
         payload: {
           orderItems,
-          progressMessages
+          progressMessageItems
         }
       })
     )

--- a/src/redux/reducers/order-reducer.ts
+++ b/src/redux/reducers/order-reducer.ts
@@ -5,8 +5,7 @@ import {
   PortfolioItem,
   Portfolio,
   OrderItem,
-  ApprovalRequest,
-  ProgressMessage
+  ApprovalRequest
 } from '@redhat-cloud-services/catalog-client';
 import { Source } from '@redhat-cloud-services/sources-client';
 import {
@@ -32,7 +31,10 @@ import {
   ReduxActionHandler,
   Full
 } from '../../types/common-types';
-import { ObjectNotFound } from '../../helpers/order/new-order-helper';
+import {
+  ObjectNotFound,
+  ProgressMessageItem
+} from '../../helpers/order/new-order-helper';
 
 export interface OrderDetail extends AnyObject {
   approvalRequest?: ApiCollectionResponse<ApprovalRequest>;
@@ -45,7 +47,7 @@ export interface OrderDetail extends AnyObject {
 
 export interface OrderProvisionType extends AnyObject {
   orderItems: Full<OrderItem>[];
-  progressMessages: Full<ProgressMessage>[];
+  progressMessageItems: Full<ProgressMessageItem>[];
 }
 
 export interface OrderReducerState extends AnyObject {
@@ -71,7 +73,7 @@ export const orderInitialState: OrderReducerState = {
   },
   orderProvision: {
     orderItems: [] as Full<OrderItem>[],
-    progressMessages: [] as Full<ProgressMessage>[]
+    progressMessageItems: [] as Full<ProgressMessageItem>[]
   },
   orders: {
     data: [],

--- a/src/smart-components/order/order-detail/order-provision.tsx
+++ b/src/smart-components/order/order-detail/order-provision.tsx
@@ -202,19 +202,22 @@ const OrderProvision: React.ComponentType = () => {
     const orderRow = [createOrderItemMainRow(item, formatMessage)];
     if (
       showProgressMessages &&
-      orderProvision.progressMessages &&
-      Object.values(orderProvision.progressMessages).length > 0
+      orderProvision.progressMessageItems &&
+      orderProvision.progressMessageItems.length > 0
     ) {
-      orderRow.push(
-        createOrderItemExpandedRow(
-          item,
-          Object.values(orderProvision.progressMessages).filter(
-            (message) => message.order_item_id === item.id
-          ),
-          formatMessage,
-          key
-        )
+      const progressMessageItem = orderProvision.progressMessageItems.find(
+        (msgItem) => msgItem.orderItemId === item.id
       );
+      if (progressMessageItem) {
+        orderRow.push(
+          createOrderItemExpandedRow(
+            item,
+            progressMessageItem.progressMessages,
+            formatMessage,
+            key
+          )
+        );
+      }
     }
 
     return orderRow;


### PR DESCRIPTION
The progress message data no longer contains the order id.
This PR separates the progress messages per order item on fetch.

Fixes https://issues.redhat.com/browse/SSP-1956

Before:
![Screenshot from 2020-11-16 16-42-35](https://user-images.githubusercontent.com/12769982/99311733-08b95300-282b-11eb-9a36-ce1f1cedb7a8.png)


After:
![Screenshot from 2020-11-16 16-42-21](https://user-images.githubusercontent.com/12769982/99311757-0e169d80-282b-11eb-937e-936d713759e9.png)
