### PR TITLE
Add 'Approval process set' label to catalog objects cards

### DIFF
--- a/src/messages/labels.messages.ts
+++ b/src/messages/labels.messages.ts
@@ -5,6 +5,10 @@ const labelMessages = defineMessages({
     id: 'common.labels.shared',
     defaultMessage: 'Shared'
   },
+  approvalProcessSet: {
+    id: 'common.labels.approval_process_set',
+    defaultMessage: 'Approval process set'
+  },
   portfolio: {
     id: 'common.labels.portfolio',
     defaultMessage: 'Portfolio'

--- a/src/presentational-components/portfolio/porfolio-card.tsx
+++ b/src/presentational-components/portfolio/porfolio-card.tsx
@@ -250,8 +250,9 @@ const PortfolioCard: React.ComponentType<PortfolioCardProps> = ({
               {formatMessage(labelMessages.approvalProcessSet)}
             </Label>
           )}
+          &nbsp;
           {shared_groups && shared_groups > 0 && (
-            <Label variant="filled" color="grey">
+            <Label variant="filled" color="green">
               {formatMessage(labelMessages.shared)}
             </Label>
           )}

--- a/src/presentational-components/portfolio/porfolio-card.tsx
+++ b/src/presentational-components/portfolio/porfolio-card.tsx
@@ -199,7 +199,7 @@ const PortfolioCard: React.ComponentType<PortfolioCardProps> = ({
   handleCopyPortfolio,
   metadata: {
     user_capabilities,
-    statistics: { shared_groups, portfolio_items }
+    statistics: { shared_groups, approval_processes, portfolio_items }
   },
   canLinkOrderProcesses,
   ...props
@@ -245,6 +245,11 @@ const PortfolioCard: React.ComponentType<PortfolioCardProps> = ({
           />
         </StyledCardBody>
         <CardFooter>
+          {approval_processes && approval_processes > 0 && (
+            <Label variant="filled" color="blue">
+              {formatMessage(labelMessages.approvalProcessSet)}
+            </Label>
+          )}
           {shared_groups && shared_groups > 0 && (
             <Label variant="filled" color="grey">
               {formatMessage(labelMessages.shared)}

--- a/src/presentational-components/portfolio/porfolio-card.tsx
+++ b/src/presentational-components/portfolio/porfolio-card.tsx
@@ -246,13 +246,13 @@ const PortfolioCard: React.ComponentType<PortfolioCardProps> = ({
         </StyledCardBody>
         <CardFooter>
           {approval_processes && approval_processes > 0 && (
-            <Label variant="filled" color="blue">
+            <Label variant="filled" color="grey">
               {formatMessage(labelMessages.approvalProcessSet)}
             </Label>
           )}
           &nbsp;
           {shared_groups && shared_groups > 0 && (
-            <Label variant="filled" color="green">
+            <Label variant="filled" color="grey">
               {formatMessage(labelMessages.shared)}
             </Label>
           )}

--- a/src/smart-components/portfolio/portfolio-item.js
+++ b/src/smart-components/portfolio/portfolio-item.js
@@ -42,8 +42,8 @@ const PortfolioItem = (props) => {
         <CardFooter>
           {props.metadata &&
           props.metadata.statistics &&
-          props.metadata.statistics.approval_processes > 0 ? (
-            <Label variant="filled" color="blue">
+          props.metadata.statistics.approval_processes >= 0 ? (
+            <Label variant="filled" color="grey">
               {formatMessage(labelMessages.approvalProcessSet)}
             </Label>
           ) : (

--- a/src/smart-components/portfolio/portfolio-item.js
+++ b/src/smart-components/portfolio/portfolio-item.js
@@ -40,9 +40,7 @@ const PortfolioItem = (props) => {
         </CardHeader>
         <ServiceOfferingCardBody {...props} />
         <CardFooter>
-          {props.metadata &&
-          props.metadata.statistics &&
-          props.metadata.statistics.approval_processes >= 0 ? (
+          {props.metadata?.statistics?.approval_processes > 0 ? (
             <Label variant="filled" color="grey">
               {formatMessage(labelMessages.approvalProcessSet)}
             </Label>

--- a/src/smart-components/portfolio/portfolio-item.js
+++ b/src/smart-components/portfolio/portfolio-item.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CardHeader, CardFooter, Level } from '@patternfly/react-core';
+import { CardHeader, CardFooter, Level, Label } from '@patternfly/react-core';
 
 import { CATALOG_API_BASE } from '../../utilities/constants';
 import CardIcon from '../../presentational-components/shared/card-icon';
@@ -11,34 +11,49 @@ import {
   StyledGalleryItem
 } from '../../presentational-components/styled-components/styled-gallery';
 import styled from 'styled-components';
+import useFormatMessage from '../../utilities/use-format-message';
+import labelMessages from '../../messages/labels.messages';
 
 const StyledLevel = styled(Level)`
   flex: 1;
 `;
 
-const PortfolioItem = (props) => (
-  <StyledGalleryItem isDisabled={props.removeInProgress && props.isSelected}>
-    <StyledCard>
-      <CardHeader>
-        <StyledLevel>
-          <CardIcon
-            src={`${CATALOG_API_BASE}/portfolio_items/${props.id}/icon`}
-            sourceId={props.service_offering_source_ref}
-          />
-          {props.isSelectable && (
-            <CardCheckbox
-              handleCheck={() => props.onSelect(props.id)}
-              isChecked={props.isSelected}
-              id={props.id}
+const PortfolioItem = (props) => {
+  const formatMessage = useFormatMessage();
+  return (
+    <StyledGalleryItem isDisabled={props.removeInProgress && props.isSelected}>
+      <StyledCard>
+        <CardHeader>
+          <StyledLevel>
+            <CardIcon
+              src={`${CATALOG_API_BASE}/portfolio_items/${props.id}/icon`}
+              sourceId={props.service_offering_source_ref}
             />
+            {props.isSelectable && (
+              <CardCheckbox
+                handleCheck={() => props.onSelect(props.id)}
+                isChecked={props.isSelected}
+                id={props.id}
+              />
+            )}
+          </StyledLevel>
+        </CardHeader>
+        <ServiceOfferingCardBody {...props} />
+        <CardFooter>
+          {props.metadata &&
+          props.metadata.statistics &&
+          props.metadata.statistics.approval_processes > 0 ? (
+            <Label variant="filled" color="blue">
+              {formatMessage(labelMessages.approvalProcessSet)}
+            </Label>
+          ) : (
+            ''
           )}
-        </StyledLevel>
-      </CardHeader>
-      <ServiceOfferingCardBody {...props} />
-      <CardFooter></CardFooter>
-    </StyledCard>
-  </StyledGalleryItem>
-);
+        </CardFooter>
+      </StyledCard>
+    </StyledGalleryItem>
+  );
+};
 
 PortfolioItem.propTypes = {
   id: PropTypes.string,

--- a/src/test/presentational-components/portfolio/__snapshots__/portfolio-card.test.js.snap
+++ b/src/test/presentational-components/portfolio/__snapshots__/portfolio-card.test.js.snap
@@ -67,7 +67,9 @@ exports[`<PortfolioCard /> should render correctly 1`] = `
         }
       />
     </Styled(CardBody)>
-    <CardFooter />
+    <CardFooter>
+       
+    </CardFooter>
   </Styled(Card)>
 </Styled(Component)>
 `;

--- a/src/test/presentational-components/portfolio/portfolio-card.test.js
+++ b/src/test/presentational-components/portfolio/portfolio-card.test.js
@@ -165,4 +165,20 @@ describe('<PortfolioCard />', () => {
     expect(wrapper.find(Label)).toHaveLength(1);
     expect(wrapper.find(Label).text()).toEqual('Shared');
   });
+
+  it('should render with approval processes set label', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <PortfolioCard
+          {...initialProps}
+          metadata={{
+            ...initialProps.metadata,
+            statistics: { approval_processes: 1 }
+          }}
+        />
+      </MemoryRouter>
+    );
+    expect(wrapper.find(Label)).toHaveLength(1);
+    expect(wrapper.find(Label).text()).toEqual('Approval process set');
+  });
 });

--- a/src/types/common-types.d.ts
+++ b/src/types/common-types.d.ts
@@ -91,6 +91,7 @@ export interface UserCapabilities {
 
 export interface PortfolioStatistics {
   shared_groups?: number;
+  approval_processes?: number;
   portfolio_items?: number;
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-1809

Mocks: https://marvelapp.com/prototype/625jh26/screen/58833387

Adds a label to indicate whether approval processes are set for the portfolio or product. 

![Screenshot from 2020-12-02 14-20-41](https://user-images.githubusercontent.com/12769982/100921886-28977a80-34ab-11eb-8d45-b2dbd6c2b503.png)
![Screenshot from 2020-12-02 14-21-31](https://user-images.githubusercontent.com/12769982/100921900-2d5c2e80-34ab-11eb-9afb-0f5f75b3c8f4.png)
![Screenshot from 2020-12-02 14-22-04](https://user-images.githubusercontent.com/12769982/100921910-30efb580-34ab-11eb-8442-9c396b36e0d4.png)


 