### PR TITLE
Update api path, separate order progress messages

### DIFF
--- a/src/helpers/order/order-helper.ts
+++ b/src/helpers/order/order-helper.ts
@@ -199,9 +199,7 @@ export const getOrderDetail = (
         throw error;
       }),
     axiosInstance
-      .get(
-        `${CATALOG_API_BASE}/order_items/${params['order-item']}/progress_messages`
-      )
+      .get(`${CATALOG_API_BASE}/orders/${params.order}/progress_messages`)
       .catch((error) => {
         if (error.status === 404 || error.status === 400) {
           return {};

--- a/src/smart-components/order/order-status-mapper.tsx
+++ b/src/smart-components/order/order-status-mapper.tsx
@@ -15,6 +15,7 @@ const orderStatusMapper: {
   Created: { icon: ReactNode; color: 'grey' };
   'Approval Pending': { icon: ReactNode; color: 'blue' };
   Approved: { icon: ReactNode; color: 'green' };
+  Denied: { icon: ReactNode; color: 'red' };
 } = {
   Completed: { icon: <CheckCircleIcon />, color: 'green' },
   'Approval Pending': {
@@ -25,7 +26,8 @@ const orderStatusMapper: {
   Failed: { icon: <ExclamationCircleIcon />, color: 'red' },
   Canceled: { icon: <ExclamationTriangleIcon />, color: 'orange' },
   Created: { icon: <PlusCircleIcon />, color: 'grey' },
-  Approved: { icon: <CheckCircleIcon />, color: 'green' }
+  Approved: { icon: <CheckCircleIcon />, color: 'green' },
+  Denied: { icon: <ExclamationCircleIcon />, color: 'red' }
 };
 
 export default orderStatusMapper;

--- a/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
+++ b/src/test/smart-components/portfolio/__snapshots__/portfolio-item.test.js.snap
@@ -51,7 +51,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                           className="pf-l-level sc-fznZeY dhizEt"
                         >
                           <CardIcon
-                            src="/api/catalog/v1.2/portfolio_items/1/icon"
+                            src="/api/catalog/v1.3/portfolio_items/1/icon"
                           >
                             <styled.div
                               height={40}
@@ -81,7 +81,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                   hidden={true}
                                   onError={[Function]}
                                   onLoad={[Function]}
-                                  src="/api/catalog/v1.2/portfolio_items/1/icon"
+                                  src="/api/catalog/v1.3/portfolio_items/1/icon"
                                   threshold={2000}
                                 >
                                   <t
@@ -96,7 +96,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                     onError={[Function]}
                                     onLoad={[Function]}
                                     placeholderSrc={null}
-                                    src="/api/catalog/v1.2/portfolio_items/1/icon"
+                                    src="/api/catalog/v1.3/portfolio_items/1/icon"
                                     threshold={2000}
                                     useIntersectionObserver={true}
                                     visibleByDefault={false}
@@ -119,7 +119,7 @@ exports[`<PortfolioItem /> should render correctly 1`] = `
                                         hidden={true}
                                         onError={[Function]}
                                         onLoad={[Function]}
-                                        src="/api/catalog/v1.2/portfolio_items/1/icon"
+                                        src="/api/catalog/v1.3/portfolio_items/1/icon"
                                       />
                                     </t>
                                   </t>

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -1,4 +1,4 @@
-export const CATALOG_API_BASE = `${process.env.BASE_PATH}/catalog/v1.2`;
+export const CATALOG_API_BASE = `${process.env.BASE_PATH}/catalog/v1.3`;
 export const SOURCES_API_BASE = `${process.env.BASE_PATH}/sources/v1.0`;
 export const APPROVAL_API_BASE = `${process.env.BASE_PATH}/approval/v1.2`;
 export const TOPOLOGICAL_INVENTORY_API_BASE = `${process.env.BASE_PATH}/topological-inventory/v1.0`;


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2014

Update api path
Separate order progress messages
Add icon and color map entry for order 'Denied' status

Before:
![Screenshot from 2020-12-14 13-55-10](https://user-images.githubusercontent.com/12769982/102124678-954d3600-3e16-11eb-80cb-f9eee6d97b04.png)

After:
![Screenshot from 2020-12-14 13-54-44](https://user-images.githubusercontent.com/12769982/102124697-9b431700-3e16-11eb-9945-1dd1b21699a0.png)

