### PR TITLE
Update approval request fetching refresh

### DIFF
--- a/src/smart-components/order/order-detail/approval-request.tsx
+++ b/src/smart-components/order/order-detail/approval-request.tsx
@@ -65,9 +65,10 @@ const checkRequest = async (
   fetchRequests: () => Promise<ApiCollectionResponse<any>>
 ) => {
   // eslint-disable-next-line no-constant-condition
-  while (true) {
+  let retries = 0;
+  while (retries <= 5) {
     const result = await fetchRequests();
-    if (result?.data.length > 0) {
+    if (result?.data.length > 0 || retries++ === 5) {
       return 'Finished';
     }
 

--- a/src/smart-components/order/order-detail/approval-request.tsx
+++ b/src/smart-components/order/order-detail/approval-request.tsx
@@ -51,6 +51,7 @@ import {
 import { CatalogRootState } from '../../../types/redux';
 import { OrderDetail } from '../../../redux/reducers/order-reducer';
 import orderStatusMapper from '../order-status-mapper';
+import { MAX_RETRY_LIMIT } from '../../../utilities/constants';
 
 /**
  * We are using type conversion of **request as StringObject** because the generated client does not have correct states listed
@@ -66,9 +67,9 @@ const checkRequest = async (
 ) => {
   // eslint-disable-next-line no-constant-condition
   let retries = 0;
-  while (retries <= 3) {
+  while (retries <= MAX_RETRY_LIMIT) {
     const result = await fetchRequests();
-    if (result?.data.length > 0 || retries++ >= 3) {
+    if (result?.data.length > 0 || retries++ >= MAX_RETRY_LIMIT) {
       return 'Finished';
     }
 

--- a/src/smart-components/order/order-detail/approval-request.tsx
+++ b/src/smart-components/order/order-detail/approval-request.tsx
@@ -53,8 +53,8 @@ import { OrderDetail } from '../../../redux/reducers/order-reducer';
 import orderStatusMapper from '../order-status-mapper';
 
 /**
- * We are using type conversion of **request as StringObject** becuase the generated client does not have correct states listed
- * Probably a discrepency inside the OpenAPI spec
+ * We are using type conversion of **request as StringObject** because the generated client does not have correct states listed
+ * Probably a discrepancy inside the OpenAPI spec
  */
 
 const rowOrder = ['updated', 'group_name', 'decision'];
@@ -66,9 +66,9 @@ const checkRequest = async (
 ) => {
   // eslint-disable-next-line no-constant-condition
   let retries = 0;
-  while (retries <= 5) {
+  while (retries <= 3) {
     const result = await fetchRequests();
-    if (result?.data.length > 0 || retries++ === 5) {
+    if (result?.data.length > 0 || retries++ >= 3) {
       return 'Finished';
     }
 
@@ -95,16 +95,18 @@ const ApprovalRequests: React.ComponentType = () => {
   } = useSelector<CatalogRootState, OrderDetail>(
     ({ orderReducer: { orderDetail } }) => orderDetail
   );
+  const [isFetching, setFetching] = useState(true);
 
   useEffect(() => {
     if (orderItem?.id && isEmpty(approvalRequest)) {
+      setFetching(true);
       checkRequest(() =>
         dispatch(
           (fetchApprovalRequests(orderItem.id!) as unknown) as Promise<
             ApiCollectionResponse<ApprovalRequest>
           >
         )
-      );
+      ).then(() => setFetching(false));
     }
   }, []);
 
@@ -114,7 +116,7 @@ const ApprovalRequests: React.ComponentType = () => {
     direction: SortByDirection
   ) => setSortBy({ index, direction });
 
-  if (order.state === 'Failed' && isEmpty(approvalRequest)) {
+  if (isEmpty(approvalRequest) && !isFetching) {
     return (
       <Bullseye id="no-approval-requests">
         <Flex direction={{ default: 'column' }} grow={{ default: 'grow' }}>

--- a/src/test/smart-components/order/orders.test.js
+++ b/src/test/smart-components/order/orders.test.js
@@ -320,6 +320,63 @@ describe('<Orders />', () => {
     done();
   });
 
+  it('should mount and render order approval detail component for order in created state', async (done) => {
+    const createdOrder = {
+      ...orderReducer,
+      orderDetail: {
+        ...orderReducer.orderDetail,
+        order: {
+          id: '123',
+          state: 'Created',
+          created_at: createDate.toString(),
+          owner: 'hula hup'
+        }
+      }
+    };
+    const store = mockStore({
+      ...initialState,
+      orderReducer: { ...orderInitialState, ...orderReducer, ...createdOrder }
+    });
+
+    mockApi
+      .onGet(`${CATALOG_API_BASE}/orders/123`)
+      .replyOnce(200, { data: [{ id: 123 }] });
+    mockApi
+      .onGet(`${CATALOG_API_BASE}/portfolio_items/portfolio-item-id`)
+      .replyOnce(200, {});
+    mockApi
+      .onGet(`${CATALOG_API_BASE}/portfolios/portfolio-id`)
+      .replyOnce(200, {});
+    mockApi
+      .onGet(`${CATALOG_API_BASE}/order_items/order-item-id`)
+      .replyOnce(200, {});
+    mockApi
+      .onGet(`${CATALOG_API_BASE}/order_items/order-item-id/progress_messages`)
+      .replyOnce(200, {});
+    mockApi
+      .onGet(`${CATALOG_API_BASE}/order_items/order-item-id/approval_requests`)
+      .replyOnce(200, {});
+    mockApi.onGet(`${SOURCES_API_BASE}/sources/platform-id`).replyOnce(200, {});
+    let wrapper;
+    await act(async () => {
+      wrapper = mount(
+        <ComponentWrapper
+          store={store}
+          initialEntries={[
+            '/orders/order/approval?order=123&order-item=order-item-id&portfolio-item=portfolio-item-id&platform=platform-id&portfolio=portfolio-id'
+          ]} // eslint-disable-line max-len
+        >
+          <Route path="/orders/order/approval">
+            <OrderDetail />
+          </Route>
+        </ComponentWrapper>
+      );
+    });
+    wrapper.update();
+    expect(wrapper.find(OrderDetail)).toHaveLength(1);
+    done();
+  });
+
   it('should mount and render order detail component and open/close cancel order modal', async (done) => {
     const enabledCancel = { ...orderReducer };
     enabledCancel.orderDetail.order.state = 'Approval Pending';

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -29,3 +29,5 @@ export const APP_NAME = {
 
 export const BEFORE_TYPE = 'before';
 export const AFTER_TYPE = 'after';
+
+export const MAX_RETRY_LIMIT = 3;


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-1859

Will discuss with UX about adding a refresh button to the 'No records' page 

Before - infinite loop for orders stuck on the 'Created' state:

![Screenshot from 2021-01-26 14-29-44](https://user-images.githubusercontent.com/12769982/105911299-0a0bb680-5ff8-11eb-9797-8f269b1920c4.png)

After - number of retries limited. 
![Screenshot from 2021-01-26 16-22-19](https://user-images.githubusercontent.com/12769982/105911407-27408500-5ff8-11eb-8a48-7f4b0a7b922f.png)

