### PR TITLE
More platform refresh changes

### DIFF
--- a/src/helpers/shared/helpers.tsx
+++ b/src/helpers/shared/helpers.tsx
@@ -97,3 +97,6 @@ export const hasPermission = (
 
 export const stateToDisplay = (state?: string): boolean =>
   state !== 'Completed' && state !== 'Ordered' && state !== 'Failed';
+
+export const delay = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/helpers/shared/user-login.ts
+++ b/src/helpers/shared/user-login.ts
@@ -31,7 +31,7 @@ export interface ErrorResponse {
 
 export interface ServerError {
   response?: ErrorResponse;
-  status?: 403 | 404 | 401 | 400 | 500 | 200; // not a complete list, replace by library with complete interface
+  status?: 403 | 404 | 401 | 400 | 429 | 500 | 200; // not a complete list, replace by library with complete interface
   config?: AxiosRequestConfig;
 }
 

--- a/src/presentational-components/platform/platform-card.tsx
+++ b/src/presentational-components/platform/platform-card.tsx
@@ -30,6 +30,7 @@ import { SyncAltIcon } from '@patternfly/react-icons';
 import { refreshPlatform } from '../../redux/actions/platform-actions';
 import platformsMessages from '../../messages/platforms.messages';
 import { useDispatch } from 'react-redux';
+import { delay } from '../../helpers/shared/helpers';
 
 const TO_DISPLAY = ['description', 'modified'];
 
@@ -66,8 +67,11 @@ const PlatformCard: React.ComponentType<PlatformCardProps> = ({
 
   const handleRefreshPlatform = (platformId: string) => {
     dispatch({ type: 'setFetching', payload: true });
-    dispatch(refreshPlatform(platformId));
-    dispatch({ type: 'setFetching', payload: false });
+    Promise.all([dispatch(refreshPlatform(platformId))]).then(async () => {
+      await delay(10000);
+      return;
+      dispatch({ type: 'setFetching', payload: false });
+    });
   };
 
   return (

--- a/src/redux/actions/platform-actions.ts
+++ b/src/redux/actions/platform-actions.ts
@@ -112,7 +112,7 @@ export const refreshPlatform = (platformId: string) => (
         )
       )
       .catch((error) => {
-        if (error.status === '429') {
+        if (error.status === 429) {
           dispatch(
             addNotification({
               variant: 'info',

--- a/src/smart-components/order/order-detail/approval-request.tsx
+++ b/src/smart-components/order/order-detail/approval-request.tsx
@@ -52,6 +52,7 @@ import { CatalogRootState } from '../../../types/redux';
 import { OrderDetail } from '../../../redux/reducers/order-reducer';
 import orderStatusMapper from '../order-status-mapper';
 import { MAX_RETRY_LIMIT } from '../../../utilities/constants';
+import { delay } from '../../../helpers/shared/helpers';
 
 /**
  * We are using type conversion of **request as StringObject** because the generated client does not have correct states listed
@@ -59,8 +60,6 @@ import { MAX_RETRY_LIMIT } from '../../../utilities/constants';
  */
 
 const rowOrder = ['updated', 'group_name', 'decision'];
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const checkRequest = async (
   fetchRequests: () => Promise<ApiCollectionResponse<any>>

--- a/src/smart-components/platform/platforms.js
+++ b/src/smart-components/platform/platforms.js
@@ -45,7 +45,12 @@ const Platforms = () => {
         name.toLowerCase().includes(filterValue.toLowerCase())
       )
       .map((item) => (
-        <PlatformCard ouiaId={`platform-${item.id}`} key={item.id} {...item} />
+        <PlatformCard
+          ouiaId={`platform-${item.id}`}
+          key={item.id}
+          {...item}
+          updateData={() => dispatch(fetchPlatforms())}
+        />
       )),
     isLoading: isLoading && platforms.length === 0
   };


### PR DESCRIPTION
 - Add delay in re-enabling the platform refresh button after the refresh started
 - Handle 429 as refresh in progress
 - Add platform version and tower version to the platform card
 

429 error:
![Screenshot from 2021-02-15 17-53-22](https://user-images.githubusercontent.com/12769982/107999960-d39dd780-6fb6-11eb-90a9-ddfd1f3ce885.png)

While refresh is runnig:
![Screenshot from 2021-02-15 21-22-21](https://user-images.githubusercontent.com/12769982/108010915-06a29400-6fd4-11eb-8dbf-11562259ba4d.png)
