### PR TITLE
Remove the Enabled label from the platform card and the platform summary page

### DIFF
--- a/src/presentational-components/platform/platform-card.tsx
+++ b/src/presentational-components/platform/platform-card.tsx
@@ -168,12 +168,6 @@ const PlatformCard: React.ComponentType<PlatformCardProps> = ({
           <ItemDetails {...{ name, ...props }} toDisplay={TO_DISPLAY} />
         </StyledCardBody>
         <CardFooter>
-          <Label variant="filled" color={props.enabled ? 'green' : 'red'}>
-            {props.enabled
-              ? formatMessage(labelMessages.enabled)
-              : formatMessage(labelMessages.disabled)}
-          </Label>
-          &nbsp;
           <Label
             variant="filled"
             color={props.availability_status === 'available' ? 'green' : 'red'}

--- a/src/smart-components/platform/platform.js
+++ b/src/smart-components/platform/platform.js
@@ -86,14 +86,6 @@ const Platform = () => {
     };
   }, [platform]);
 
-  const platformEnabled = (platform) => ({
-    color: platform.enabled ? 'green' : 'red',
-    icon: <InfoCircleIcon />,
-    title: platform.enabled
-      ? formatMessage(labelMessages.enabled)
-      : formatMessage(labelMessages.disabled)
-  });
-
   const platformAvailable = (platform) => ({
     color: platform.availability_status === 'available' ? 'green' : 'red',
     icon: <InfoCircleIcon />,
@@ -121,7 +113,6 @@ const Platform = () => {
               title: selectedPlatform.name,
               paddingBottom: false,
               tabItems,
-              platformEnabled: () => platformEnabled(selectedPlatform),
               platformAvailable: () => platformAvailable(selectedPlatform)
             })}
           />

--- a/src/test/presentational-components/platform/__snapshots__/platform-card.test.js.snap
+++ b/src/test/presentational-components/platform/__snapshots__/platform-card.test.js.snap
@@ -590,21 +590,6 @@ exports[`<PlatformCard /> should render correctly 1`] = `
                     <span
                       className="pf-c-label__content"
                     >
-                      Disabled
-                    </span>
-                  </span>
-                </Label>
-                 
-                <Label
-                  color="red"
-                  variant="filled"
-                >
-                  <span
-                    className="pf-c-label pf-m-red"
-                  >
-                    <span
-                      className="pf-c-label__content"
-                    >
                       Not available
                     </span>
                   </span>

--- a/src/toolbar/schemas/platforms-toolbar.schema.js
+++ b/src/toolbar/schemas/platforms-toolbar.schema.js
@@ -50,7 +50,6 @@ export const createPlatformsTopToolbarSchema = ({
   title,
   paddingBottom,
   tabItems,
-  platformEnabled,
   platformAvailable
 }) => ({
   fields: [
@@ -89,11 +88,6 @@ export const createPlatformsTopToolbarSchema = ({
                   key: 'platform-label',
                   alignment: 'alignRight',
                   fields: [
-                    {
-                      component: toolbarComponentTypes.LABEL,
-                      key: 'platform-enabled-label',
-                      ...platformEnabled()
-                    },
                     {
                       component: toolbarComponentTypes.LABEL,
                       key: 'platform-available-label',


### PR DESCRIPTION
Remove the Enabled label from the platform card and teh platform summary page. ( Disabled platforms are hidden)

![Screenshot from 2021-02-18 15-25-00](https://user-images.githubusercontent.com/12769982/108417066-8495b380-71fd-11eb-89f0-01503913381c.png)
![Screenshot from 2021-02-18 15-24-48](https://user-images.githubusercontent.com/12769982/108417068-852e4a00-71fd-11eb-9389-8b7bda32874c.png)
