### PR TITLE
Extract l10n messages for typescript files, but excluding .d.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   "scripts": {
     "analyze": "NODE_ENV=production webpack --config config/prod.webpack.config.js --env.prod=true --env.analyze=true --mode production",
     "build": "NODE_ENV=production webpack --config config/prod.webpack.config.js --mode production",
-    "extract:messages": "npx @formatjs/cli extract 'src/**/*.{js,jsx}' --out-file ./translations/messages.json",
+    "extract:messages": "npx @formatjs/cli extract 'src/**/!(*.d).{js,jsx,ts,tsx}' --out-file ./translations/messages.json",
     "lint": "yarn lint:js && yarn lint:ts",
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
     "lint:js": "yarn eslint ./src --ext .js",


### PR DESCRIPTION
Previously, only javascript files were being checked for strings by the `npm run extract:messages` command, which resulted in 2 or 3 dummy strings in `./translations/messages.json`.  This change does the following:
* checks typescript files in addition
* excludes `*.d.ts` files as they cause formatjs to fail

Example of previous error:

```
[chadams@chadams-work catalog-ui]$ npx @formatjs/cli extract 'src/**/*.{js,jsx,ts,tsx}' --out-file ./translations/messages.json
npx: installed 68 in 10.857s
[@formatjs/cli] [WARN] Error: Error processing file src/index.d.ts 
Debug Failure. Output generation failed
```


Now all of the strings are extracted as expected.  The strings end up here:

```
$ tree ./catalog-ui/translations/
translations/
└── messages.json
```

```
$ cat translations/messages.json | wc -l
740
```
