### PR TITLE
Fix dev release

### DIFF
--- a/.github/workflows/dist-release.yml
+++ b/.github/workflows/dist-release.yml
@@ -5,47 +5,46 @@ name: "Dist release"
 on:
   workflow_dispatch: # allow running manually
   push:
-    branches: [ 'main' ]
+    branches: ["main"]
 
 jobs:
   dev:
     runs-on: ubuntu-latest
     env:
-      BRANCH: 'master' # for webpack
+      BRANCH: "master" # for webpack
       NODE_OPTIONS: "--max-old-space-size=4096 --max_old_space_size=4096"
 
     steps:
+      - name: "Checkout catalog-ui (${{ github.ref }})"
+        uses: actions/checkout@v2
 
-    - name: "Checkout catalog-ui (${{ github.ref }})"
-      uses: actions/checkout@v2
+      - name: "Install node 14"
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
 
-    - name: "Install node 14"
-      uses: actions/setup-node@v2
-      with:
-        node-version: '14'
+      - name: "Cache ~/.npm"
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ env.GITHUB_REF }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.GITHUB_REF }}-
+            ${{ runner.os }}-node-
 
-    - name: "Cache ~/.npm"
-      uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ env.GITHUB_REF }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-${{ env.GITHUB_REF }}-
-          ${{ runner.os }}-node-
+      - name: "Build a tar"
+        run: |
+          npm ci || npm install
+          npm run build:standalone
+          tar -C dist/ -czvf catalog-ui.tar.gz .
 
-    - name: "Build a tar"
-      run: |
-        npm ci || npm install
-        npm run build:standalone
-        tar -C dist/ -czvf catalog-ui.tar.gz .
-
-    - name: "Release"
-      run: |
-        gh release create -p "$RELEASE_TAG" --title "$RELEASE_NAME" --notes "$RELEASE_BODY" || true # may already exist
-        gh release upload "$RELEASE_TAG" "$RELEASE_FILE" --clobber
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_NAME: "UI Dev Release"
-        RELEASE_BODY: "This is a special release that provides an up to date build off of the latest changes in the `main` branch. The `catalog-ui.tar.gz` artifact provided here corresponds to the latest version of `main`."
-        RELEASE_FILE: 'catalog-ui.tar.gz'
-        RELEASE_TAG: 'latest'
+      - name: "Release"
+        run: |
+          gh release create -p "$RELEASE_TAG" --title "$RELEASE_NAME" --notes "$RELEASE_BODY" || true # may already exist
+          gh release upload "$RELEASE_TAG" "$RELEASE_FILE" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NAME: "UI Dev Release"
+          RELEASE_BODY: "This is a special release that provides an up to date build off of the latest changes in the `main` branch. The `catalog-ui.tar.gz` artifact provided here corresponds to the latest version of `main`."
+          RELEASE_FILE: "catalog-ui.tar.gz"
+          RELEASE_TAG: "latest"

--- a/.github/workflows/dist-release.yml
+++ b/.github/workflows/dist-release.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: "Release"
         run: |
+          gh release delete $RELEASE_TAG -y
           gh release create -p "$RELEASE_TAG" --title "$RELEASE_NAME" --notes "$RELEASE_BODY" || true # may already exist
           gh release upload "$RELEASE_TAG" "$RELEASE_FILE" --clobber
         env:


### PR DESCRIPTION
https://issues.redhat.com/browse/SSP-2710

Right now the latest dev release workflow is not working because [the latest release already exists](https://github.com/RedHatInsights/catalog-ui/runs/5054260855?check_suite_focus=true#step:6:14). 

There are two commits:

- apply the right format
- delete the release before publish